### PR TITLE
Docs google analytics

### DIFF
--- a/components/app.jsx
+++ b/components/app.jsx
@@ -4,6 +4,9 @@ import Ecology from 'ecology';
 import Radium, { Style } from 'radium';
 import { Link } from 'react-router';
 
+// Analytics
+import ga from 'react-ga';
+
 import theme from './theme';
 
 // TODO: Extract these global Header/Footers into formidable-landers
@@ -13,6 +16,10 @@ import Footer from "./footer";
 
 @Radium
 class App extends React.Component {
+  componentWillMount() {
+    ga.pageview('/victory');
+  }
+
   render() {
     return (
       <div style={{display: 'flex', minHeight: '100vh', flexDirection: 'column'}}>

--- a/components/docs.jsx
+++ b/components/docs.jsx
@@ -1,18 +1,24 @@
-import React from 'react';
+import ga from 'react-ga';
 import Radium, { Style } from 'radium';
+import React from 'react';
 
 import theme from './theme';
 
+// Child components
+
 // TODO: Extract these global Header/Footers into formidable-landers
 // https://github.com/FormidableLabs/formidable-landers/issues/12
-import Header from "./header";
 import Footer from "./footer";
+import Header from "./header";
 
-// Child components
 import Sidebar from "./sidebar";
 
 @Radium
 class Docs extends React.Component {
+
+  componentWillMount() {
+    ga.pageview('/victory/docs');
+  }
 
   getDocsStyles() {
     return {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "history": "^1.13.1",
     "lodash": "^3.9.3",
     "radium": "^0.14.1",
+    "react-ga": "^1.2.0",
     "rimraf": "^2.4.0",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",

--- a/router.jsx
+++ b/router.jsx
@@ -7,6 +7,9 @@ import App from './components/app';
 import Docs from './components/docs';
 import Root from './components/root';
 
+// Analytics
+import ga from 'react-ga';
+
 const routes = (
   <Route path="/" component={Root}>
     <IndexRoute component={App} />
@@ -24,6 +27,7 @@ export default {
         {routes}
       </Router>
     );
+    ga.initialize("UA-43290258-1", { debug: true });
     render(router, el);
   }
 


### PR DESCRIPTION
Adds google analytics route tagging to victory.

The manual `ga.pageview` calls are not ideal , but we can figure out a better way to do them in `react-router 1.0` later.

@david-davidson @paulathevalley 