### PR TITLE
Hide horizontal scrollbars on component playgrounds

### DIFF
--- a/docs/components/theme.js
+++ b/docs/components/theme.js
@@ -257,6 +257,9 @@ export default {
   /*
    * Interactive/Component Playground
    */
+  '.Interactive': {
+    overflowX: 'hidden' // playground & preview have horizontal scrollbars.
+  },
   '.Interactive .playground': {
     display: 'flex',
     flexWrap: 'wrap',


### PR DESCRIPTION
This is a quick fix as I am not sure where the scrollbars are coming from just yet...

/cc @david-davidson 