### PR TITLE
Docs: Fix a few style bugs

### DIFF
--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -65,7 +65,6 @@ class App extends React.Component {
               overview={require("!!raw!../ecology.md")}
               scope={{React, ReactDOM, VictoryChart, VictoryLine}}
               playgroundtheme="elegant" />
-            <Style rules={theme}/>
           </div>
 
           <div className="Row">

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -39,7 +39,7 @@ class Docs extends React.Component {
   getMainStyles() {
     return {
       display: "flex",
-      flex: "1 0 100%",
+      flex: "1 0 auto",
       flexDirection: "column",
       margin: "0 auto",
       padding: "1rem",

--- a/docs/components/theme.js
+++ b/docs/components/theme.js
@@ -138,7 +138,7 @@ export default {
     boxShadow: 'none',
     color: settings.darkestSand,
     fontFamily: settings.sansSerif,
-    fontWeight: 'bold',
+    fontWeight: 'normal',
     padding: '0.75em 1.25em',
     textAlign: 'center',
     transition: 'color 0.2s ease, border-color 0.7s ease'
@@ -254,12 +254,12 @@ export default {
   '.Ecology p': {
     maxWidth: '640px' // Ideal 60–70 characters per line
   },
+  '.Overview pre': {
+    overflow: 'hidden' // Hide horizontal scrollbars for playgrounds.
+  },
   /*
    * Interactive/Component Playground
    */
-  '.Interactive': {
-    overflowX: 'hidden' // playground & preview have horizontal scrollbars.
-  },
   '.Interactive .playground': {
     display: 'flex',
     flexWrap: 'wrap',


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/formidable-landers/issues/27 

- Fix sticky footer in Safari
- Remove duplicated `<Style>` tag 
- Find source of the horizontal scrollbars: the triple ticks notation wraps everything in `<pre>` tag, as per github flavored markdown rules, but this tag is the cause. For instance, if this tag was changed to `<div>` there would be no horizontal scrollbars, but I did not find a conventional way to add a class name to a `<div>` in markdown notation. 

/cc @david-davidson @boygirl 