### PR TITLE
Disable React warnings when building static files for prod

### DIFF
--- a/docs/webpack.config.static.js
+++ b/docs/webpack.config.static.js
@@ -4,6 +4,7 @@ var CleanPlugin = require("clean-webpack-plugin");
 var path = require("path");
 var StaticSiteGeneratorPlugin = require("static-site-generator-webpack-plugin");
 var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
+var DefinePlugin = require("webpack").DefinePlugin;
 
 var base = require("./webpack.config.dev.js");
 
@@ -28,6 +29,12 @@ module.exports = {
   module: base.module,
   plugins: [
     new CleanPlugin([ path.join(__dirname, OUTPUT_DIR) ]),
+    new DefinePlugin({
+      "process.env": {
+        // Disable warnings for static build
+        NODE_ENV: JSON.stringify("production")
+      }
+    }),
     new StatsWriterPlugin({
       filename: "stats.json"
     }),


### PR DESCRIPTION
I noticed that development warnings were showing up in the JS console at http://projects.formidablelabs.com/victory/:

<img width="567" alt="screen shot 2015-12-01 at 5 50 24 pm" src="https://cloud.githubusercontent.com/assets/794843/11520017/13832fd4-9854-11e5-80ee-b354c90a20fb.png">

Setting the `NODE_ENV` to production when building the static site takes care of this issue.