### PR TITLE
Docs: Exclude the formidable-landers symlink for local testing

### DIFF
--- a/docs/webpack.config.dev.js
+++ b/docs/webpack.config.dev.js
@@ -36,7 +36,8 @@ module.exports = {
         // from all `node_modules` packages that *aren't* Victory:
         exclude: function (absPath) {
           return absPath.indexOf("node_modules") > -1 &&
-            absPath.indexOf("node_modules/victory") === -1;
+            absPath.indexOf("node_modules/victory") === -1 ||
+            absPath.indexOf("formidable-landers") > -1;
         },
         loaders: ["babel-loader?stage=0"]
       }, {


### PR DESCRIPTION
This will allow `npm link formidable-landers` to work for local testing without webpack choking on the symlink path. 

/cc @per @boygirl 