### PR TITLE
Restrict `history` dep to 1.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "builder": "~2.1.3",
     "builder-react-component": "~0.1.1",
-    "history": "^1.13.1",
+    "history": "~1.13.1",
     "lodash": "^3.9.3",
     "radium": "^0.14.1",
     "style-loader": "~0.8.0",


### PR DESCRIPTION
[react-router 1.0.2](https://github.com/rackt/react-router/releases/tag/v1.0.2) requires `history` 1.13.x, but fresh installs are now getting 1.15.x, hence this `npm install` failure:

<img width="1107" alt="screen shot 2015-12-10 at 1 54 37 pm" src="https://cloud.githubusercontent.com/assets/6352327/11729731/a3b27dba-9f45-11e5-8320-fc6caa1a6530.png">

This just restricts us to 1.13.x. :+1: 

/cc @exogen @boygirl 