### PR TITLE
Remove playgrounds from /docs index, and add link to Victory GitHub

### DIFF
--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -6,12 +6,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { components } from "../config";
-import { VictoryTheme, Header, Footer } from "formidable-landers";
-import * as Victory from "../../src/index";
-const { VictoryChart, VictoryLine, VictoryPie } = Victory;
-const V = Victory;
-
 import Sidebar from "./sidebar";
+import { VictoryTheme, Header, Footer } from "formidable-landers";
 
 @Radium
 class Docs extends React.Component {
@@ -67,7 +63,6 @@ class Docs extends React.Component {
           <section style={this.getDocsStyles()}>
             <Ecology
               overview={require("!!raw!../ecology-getting-started.md")}
-              scope={{React, ReactDOM, V, VictoryChart, VictoryLine, VictoryPie}}
               playgroundtheme="elegant" />
             <h3>Explore the interactive docs!</h3>
             {this._renderDocsList()}

--- a/docs/ecology-getting-started.md
+++ b/docs/ecology-getting-started.md
@@ -2,22 +2,6 @@
 
 Victory is an opinionated, but fully overridable, ecosystem of composable React components for building interactive data visualizations.
 
-### Including components
+It's maintained on GitHub at https://github.com/FormidableLabs/victory.
 
-Components can be included individually:
-
-```playground
-// import { VictoryPie } from "victory"
-<VictoryPie/>
-```
-
-Or imported as a set:
-```playground
-// import * as V from "victory"
-<V.VictoryPie/>
-```
-### Animation
-Wrap any Victory component with [VictoryAnimation](https://github.com/FormidableLabs/victory-animation) and it will transition smoothly between states whenever data changes. `VictoryAnimation` relies on d3's interpolator, so it knows how to transition between colors, dates, numbers, strings etc.
-
-### Contributing
 Interested in helping out? Great! You can [get started here](https://github.com/FormidableLabs/victory/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
The playgrounds currently up at http://victory.formidable.com/docs/ are kind of boring. They're left over from when the awesome, non-boring component-specific docs weren't actually part of the site. Also, @alexlande wisely points out that we lack a direct link back to the GitHub repo.

So: this removes the old playgrounds and "Getting started" steps, in favor of a few quick links. I figure people would rather get straight to the component docs anyway.

/cc @coopy @boygirl @alexlande @eastridge 

It looks like this:
![victory-docs](https://cloud.githubusercontent.com/assets/6352327/11853132/0233d0d2-a3f1-11e5-90d2-2d1cc6be87fb.png)
