### PR TITLE
Content tweaks

### DIFF
--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -3,7 +3,7 @@ import Radium, { Style } from "radium";
 import React from "react";
 import Ecology from "ecology";
 import ReactDOM from "react-dom";
-import {VictoryChart, VictoryLine} from "../../src/index";
+import { VictoryChart, VictoryLine, VictoryPie } from "../../src/index";
 import { VictoryTheme, Header, Footer} from "formidable-landers";
 // Analytics
 import ga from "react-ga";
@@ -56,7 +56,7 @@ class App extends React.Component {
           <div>
             <Ecology
               overview={require("!!raw!../ecology.md")}
-              scope={{React, ReactDOM, VictoryChart, VictoryLine}}
+              scope={{React, ReactDOM, VictoryChart, VictoryLine, VictoryPie}}
               playgroundtheme="elegant" />
           </div>
 

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -1,3 +1,4 @@
+import { components } from "../config";
 import { Link } from "react-router";
 import Radium, { Style } from "radium";
 import React from "react";
@@ -85,6 +86,32 @@ class App extends React.Component {
             <div className="Copy u-textCenter">
               <Link className="Button Button--spotlight" to="docs">Get Started</Link>
             </div>
+          </div>
+
+          <div className="Row">
+            <h3 className="u-textCenter">Quick links:</h3>
+            <p className="Copy">
+              GitHub: <a href="https://github.com/FormidableLabs/victory">
+                https://github.com/FormidableLabs/victory
+              </a>
+            </p>
+            <p className="Copy">
+              Gitter chatroom: <a href="https://gitter.im/FormidableLabs/victory">
+                https://gitter.im/FormidableLabs/victory
+              </a>
+            </p>
+            <p className="Copy">Component docs:</p>
+            <ul className="Copy">
+              {components.map((component) => {
+                return (
+                  <li key={component.slug}>
+                    <Link to={`docs/${component.slug}`}>
+                      {component.text}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
 
         </main>

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -49,7 +49,7 @@ class App extends React.Component {
 
           <div className="Row">
             <p className="Headline Headline--minor u-textCenter">
-              An ecosystem of modular data visualization components for React
+              An ecosystem of modular data visualization components for React.
             </p>
           </div>
 
@@ -61,21 +61,21 @@ class App extends React.Component {
           </div>
 
           <div className="Row">
-            <h2 className="u-textCenter">Powerful</h2>
+            <h2 className="u-textCenter">Friendly</h2>
             <p className="Copy">
               The modular, componentized nature of React has allowed us to write fully-contained, reusable data visualization elements that are responsible for their own styles and behaviors.
             </p>
           </div>
 
           <div className="Row">
-            <h2 className="u-textCenter">Effortless</h2>
+            <h2 className="u-textCenter">Flexible</h2>
             <p className="Copy">
               The use of sensible default props makes getting started very easy, without sacrificing flexiblity. Victory also leverages React lifecycle methods and DOM diffing to create a lightweight animation wrapper.
             </p>
           </div>
 
           <div className="Row">
-            <h2 className="u-textCenter">Victorious</h2>
+            <h2 className="u-textCenter">Composable</h2>
             <p className="Copy">
               When combined, these features result in a set of components that are easy to use, and compose into more complicated visualizations.
             </p>

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -29,7 +29,9 @@ class App extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header/>
+        <Header
+          text={"Interested in using Victory on your next project? Let’s talk."}
+        />
         <main className="Container" style={this.getMainStyles()}>
 
           <header className="Header">

--- a/docs/components/component-docs.jsx
+++ b/docs/components/component-docs.jsx
@@ -27,7 +27,9 @@ class ComponentDocs extends BaseDocs {
     const Docs = docs[this.props.params.component];
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header />
+        <Header
+          text={"Interested in using Victory on your next project? Let’s talk."}
+        />
         <main style={this.getMainStyles()}>
           <Sidebar active={`${this.props.params.component}`} />
           <section style={this.getDocsStyles()}>

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -69,12 +69,21 @@ class Docs extends React.Component {
               overview={require("!!raw!../ecology-getting-started.md")}
               scope={{React, ReactDOM, V, VictoryChart, VictoryLine, VictoryPie}}
               playgroundtheme="elegant" />
-            <h3>Explore the interactive docs!</h3>
+            <h3>Explore the interactive docs:</h3>
             {this._renderDocsList()}
           </section>
         </main>
         <Footer/>
         <Style rules={VictoryTheme}/>
+        {/* We need padding: 5px on `.Ecology code`; putting it here for now */}
+        <Style
+          scopeSelector={".Ecology"}
+          rules={{
+            code: {
+              padding: "5px"
+            }
+          }}
+        />
       </div>
     );
   }

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -61,7 +61,9 @@ class Docs extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header/>
+        <Header
+          text={"Interested in using Victory on your next project? Let’s talk."}
+        />
         <main style={this.getMainStyles()}>
           <Sidebar active={""} />
           <section style={this.getDocsStyles()}>

--- a/docs/ecology-getting-started.md
+++ b/docs/ecology-getting-started.md
@@ -4,20 +4,38 @@ Victory is an opinionated, but fully overridable, ecosystem of composable React 
 
 ### Including components
 
-Components can be included individually:
-
-```playground
-// import { VictoryPie } from "victory"
-<VictoryPie/>
+First, grab Victory:
+```js
+npm install victory
 ```
 
-Or imported as a set:
-```playground
-// import * as V from "victory"
-<V.VictoryPie/>
+Then include components individually...
+```js
+import { VictoryPie } from "victory";
+// <VictoryPie />
 ```
-### Animation
-Wrap any Victory component with [VictoryAnimation](https://github.com/FormidableLabs/victory-animation) and it will transition smoothly between states whenever data changes. `VictoryAnimation` relies on d3's interpolator, so it knows how to transition between colors, dates, numbers, strings etc.
 
-### Contributing
-Interested in helping out? Great! You can [get started here](https://github.com/FormidableLabs/victory/blob/master/CONTRIBUTING.md).
+... Or import them as a set.
+```js
+import * as V from "victory";
+// <V.VictoryPie />
+```
+
+(The interactive docs throughout this site have already included this `import` step.)
+
+Now you're ready to render:
+```
+import React from "React";
+import { VictoryPie } from "victory";
+
+class HelloWorld extends React.Component {
+  render () {
+    return (
+      <VictoryPie />
+    );
+  }
+};
+```
+
+### Contributing and source
+Interested in helping out or seeing what's happening under the hood? Victory is maintained at [https://github.com/FormidableLabs/victory](https://github.com/FormidableLabs/victory), and you can [start contributing here](https://github.com/FormidableLabs/victory/blob/master/CONTRIBUTING.md).

--- a/docs/ecology.md
+++ b/docs/ecology.md
@@ -7,3 +7,19 @@
     y={(x) => Math.cos(2 * Math.PI * x)} />
 </VictoryChart>
 ```
+```playground
+<VictoryPie
+  startAngle={0}
+  endAngle={180}
+  padAngle={5}
+  innerRadius={100}
+  data={[
+    {x: "<5", y: 6279},
+    {x: "5-13", y: 9182},
+    {x: "14-17", y: 5511},
+    {x: "18-24", y: 7164},
+    {x: "25-44", y: 6716},
+    {x: "45-64", y: 4263},
+    {x: "≥65", y: 7502}
+  ]} />
+```

--- a/docs/ecology.md
+++ b/docs/ecology.md
@@ -1,11 +1,9 @@
 ```playground
 <VictoryChart>
   <VictoryLine
-    y={(x) => Math.sin(1.5 * Math.PI * x)}
-  />
+    y={(x) => Math.sin(1.5 * Math.PI * x)} />
   <VictoryLine
     style={{data: {stroke: "#c33b33"}}}
-    y={(x) => Math.cos(2 * Math.PI * x)}
-  />
+    y={(x) => Math.cos(2 * Math.PI * x)} />
 </VictoryChart>
 ```


### PR DESCRIPTION
Here are a bunch of content tweaks:
* Adds a second `component-playground` on the homepage
* Adds "quick links" on the homepage: Gitter, GitHub, component-specific docs
* Swaps in new homepage subheads: "Friendly," "Flexible," "Composable"
* Adds  custom, Victory-specific header text
* Updates /docs entry point with normal code blocks instead of playgrounds, plus better getting-started explanation
* Implements a most-use-cases fix for the playground bug on the homepage: putting the closing JSX tags on the same line as the last props fixes it for every line except for the very last one (which is itself a closing tag: not something people will want to edit)

I'll add @exogen's  animation docs soon.

/cc @eastridge @boygirl 

![victory1](https://cloud.githubusercontent.com/assets/6352327/11858806/a1f6845c-a419-11e5-8e82-74af756a049f.png)

![victory2](https://cloud.githubusercontent.com/assets/6352327/11858793/79c01930-a419-11e5-9af0-09c36bfb623f.png)

