### PR TITLE
Docs: Use default copy in header and set maxWidth to props table

### DIFF
--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -29,7 +29,7 @@ class App extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor="#ebe3db">
+        <Header backgroundColor={VictorySettings.palestSand}>
           Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
         </Header>
         <main className="Container" style={this.getMainStyles()}>

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -29,9 +29,7 @@ class App extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header
-          text={"Interested in using Victory on your next project? Let’s talk."}
-        />
+        <Header backgroundColor="#ebe3db" />
         <main className="Container" style={this.getMainStyles()}>
 
           <header className="Header">
@@ -117,7 +115,7 @@ class App extends React.Component {
           </div>
 
         </main>
-        <Footer/>
+        <Footer backgroundColor="#ebe3db"/>
         <Style rules={VictoryTheme}/>
       </div>
     );

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -29,7 +29,9 @@ class App extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor="#ebe3db" />
+        <Header backgroundColor="#ebe3db">
+          Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
+        </Header>
         <main className="Container" style={this.getMainStyles()}>
 
           <header className="Header">

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -5,7 +5,7 @@ import React from "react";
 import Ecology from "ecology";
 import ReactDOM from "react-dom";
 import { VictoryChart, VictoryLine, VictoryPie } from "../../src/index";
-import { VictoryTheme, Header, Footer} from "formidable-landers";
+import { VictorySettings, VictoryTheme, Header, Footer} from "formidable-landers";
 // Analytics
 import ga from "react-ga";
 
@@ -42,7 +42,14 @@ class App extends React.Component {
           </header>
 
           <div className="Row">
-            <p className="Headline Headline--major u-textCenter">Victory</p>
+            <p className="Headline Headline--major u-textCenter">
+              Victory
+              <span style={{
+                  fontFamily: VictorySettings.sansSerif,
+                  fontSize: "0.35em",
+                  verticalAlign: "1em"
+                }}>&#8482;</span>
+            </p>
             <div className="u-textCenter">
               <code className="Installer">npm install victory</code>
             </div>
@@ -115,7 +122,11 @@ class App extends React.Component {
           </div>
 
         </main>
-        <Footer backgroundColor="#ebe3db"/>
+        <Footer backgroundColor="#ebe3db">
+          <div style={{margin: "2em 0", fontSize: "0.8rem"}}>
+            Victory is a trademark of Formidable Labs, Inc.
+          </div>
+        </Footer>
         <Style rules={VictoryTheme}/>
       </div>
     );

--- a/docs/components/component-docs.jsx
+++ b/docs/components/component-docs.jsx
@@ -19,16 +19,14 @@ class ComponentDocs extends BaseDocs {
     const Docs = _.findWhere(components, { slug: this.props.params.component }).docs;
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header
-          text={"Interested in using Victory on your next project? Let’s talk."}
-        />
+        <Header backgroundColor="#ebe3db" />
         <main style={this.getMainStyles()}>
           <Sidebar active={`${this.props.params.component}`} />
           <section style={this.getDocsStyles()}>
             <Docs />
           </section>
         </main>
-        <Footer/>
+        <Footer backgroundColor="#ebe3db"/>
         <Style rules={VictoryTheme} />
       </div>
     );

--- a/docs/components/component-docs.jsx
+++ b/docs/components/component-docs.jsx
@@ -2,7 +2,7 @@ import _ from "underscore";
 import ga from "react-ga";
 import Radium, { Style } from "radium";
 import React from "react";
-import { VictoryTheme, Header, Footer } from "formidable-landers";
+import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
 
 import BaseDocs from "./docs";
 import { components, routing as routingConfig } from "../config";
@@ -19,7 +19,7 @@ class ComponentDocs extends BaseDocs {
     const Docs = _.findWhere(components, { slug: this.props.params.component }).docs;
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor="#ebe3db">
+        <Header backgroundColor={VictorySettings.palestSand}>
           Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
         </Header>
         <main style={this.getMainStyles()}>

--- a/docs/components/component-docs.jsx
+++ b/docs/components/component-docs.jsx
@@ -26,7 +26,11 @@ class ComponentDocs extends BaseDocs {
             <Docs />
           </section>
         </main>
-        <Footer backgroundColor="#ebe3db"/>
+        <Footer backgroundColor="#ebe3db">
+          <div style={{margin: "2em 0", fontSize: "0.8rem"}}>
+            Victory is a trademark of Formidable Labs, Inc.
+          </div>
+        </Footer>
         <Style rules={VictoryTheme} />
       </div>
     );

--- a/docs/components/component-docs.jsx
+++ b/docs/components/component-docs.jsx
@@ -19,7 +19,9 @@ class ComponentDocs extends BaseDocs {
     const Docs = _.findWhere(components, { slug: this.props.params.component }).docs;
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor="#ebe3db" />
+        <Header backgroundColor="#ebe3db">
+          Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
+        </Header>
         <main style={this.getMainStyles()}>
           <Sidebar active={`${this.props.params.component}`} />
           <section style={this.getDocsStyles()}>

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -6,7 +6,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { components, routing as routingConfig } from "../config";
-import { VictoryTheme, Header, Footer } from "formidable-landers";
+import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
 import * as Victory from "../../src/index";
 const { VictoryChart, VictoryLine, VictoryPie } = Victory;
 const V = Victory;
@@ -61,7 +61,7 @@ class Docs extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor="#ebe3db">
+        <Header backgroundColor={VictorySettings.palestSand}>
           Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
         </Header>
         <main style={this.getMainStyles()}>

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -61,7 +61,9 @@ class Docs extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor="#ebe3db" />
+        <Header backgroundColor="#ebe3db">
+          Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
+        </Header>
         <main style={this.getMainStyles()}>
           <Sidebar active={""} />
           <section style={this.getDocsStyles()}>

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -61,9 +61,7 @@ class Docs extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header
-          text={"Interested in using Victory on your next project? Let’s talk."}
-        />
+        <Header backgroundColor="#ebe3db" />
         <main style={this.getMainStyles()}>
           <Sidebar active={""} />
           <section style={this.getDocsStyles()}>
@@ -75,7 +73,7 @@ class Docs extends React.Component {
             {this._renderDocsList()}
           </section>
         </main>
-        <Footer/>
+        <Footer backgroundColor="#ebe3db"/>
         <Style rules={VictoryTheme}/>
         {/* We need padding: 5px on `.Ecology code`; putting it here for now */}
         <Style

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -73,7 +73,11 @@ class Docs extends React.Component {
             {this._renderDocsList()}
           </section>
         </main>
-        <Footer backgroundColor="#ebe3db"/>
+        <Footer backgroundColor="#ebe3db">
+          <div style={{margin: "2em 0", fontSize: "0.8rem"}}>
+            Victory is a trademark of Formidable Labs, Inc.
+          </div>
+        </Footer>
         <Style rules={VictoryTheme}/>
         {/* We need padding: 5px on `.Ecology code`; putting it here for now */}
         <Style


### PR DESCRIPTION
Based on https://github.com/FormidableLabs/formidable-landers/pull/45

- Use default copy for header
- Set an explicit `backgroundColor` prop for the header and footer
- Set `maxWidth` for the props type column: 
<img width="1199" alt="screen shot 2016-01-04 at 9 47 43 am" src="https://cloud.githubusercontent.com/assets/768965/12096544/e0100064-b2ca-11e5-86ff-39d5078b31c9.png">

/cc @coopy @david-davidson 