### PR TITLE
Adds a Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+## HEAD
+
+## 0.1.3 (2015-12-30)
+
+## 0.1.2 (2015-12-30)
+
+## 0.1.1 (2015-12-29)
+
+## 0.1.0 (2015-12-18)
+
+The following components documented and ready to use; API subject to change:
+
+- victory-animation
+-victory-axis
+- victory-bar
+- victory-chart
+- victory-label
+- victory-line
+- victory-pie
+- victory-scatter
+
+Functional styles and functional props (where appropriate) are implemented for all the data primitives (VictoryBar, VictoryLine etc.) and VictoryAxis
+
+Components use d3-modules
+
+Basic code coverage across all Victory components.
+
+We make no promises about any code prior to this release. From this point on, you can expect a regular release schedule (~every two weeks) with detailed release notes. Check out our roadmap for upcoming features


### PR DESCRIPTION
I saw you guys were communicating changes in the GitHub releases. This is all well and good, but I would recommend maintaining a regular changelog in addition.

This way the changes to master can be cataloged under the "HEAD" section as of the changelog as they are made. When a release is made, your release notes are pretty much already compiled for you.

In addition: this repo is a composition of a bunch of your other modules. This changelog is a centralized place to summarize ecosystem-wide changes that might affect one's usage.

It also allows people other than project maintainers to help contribute to the changelog. I have a huge vested interest in keeping close tabs on the changes made here. I can help you guys keep this up to date. I am watching this repo's changes so I mind as well report my findings somewhere.