### PR TITLE
Update header; Add Roadmap link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,22 +4,22 @@ The Victory documentation site (currently `projects.formidablelabs.com/victory`;
 
 ### Development
 
-Run `npm run dev-docs` to start `webpack-dev-server` at port 3000. Run `npm run check` for the usual linting, which covers the `docs` source.
+Run `builder run docs-dev` to start `webpack-dev-server` at port 3000. Run `builder run check` for the usual linting, which covers the `docs` source.
 
 ### Deployment
 
-On `master`, run `npm run build-static-docs` to build the static site in `docs/build`, and commit your changes. (As with Heroku, Git needs to know what's changed before it can push, so we're stuck committing built artifacts.) Then run `npm run push-gh-pages` to perform a subtree push from `/docs/build` (local) to root in the `gh-pages` branch (remote), updating the live site. Finally, run `git push origin master` to get the static build into shared history--see Gotchas.
+On `master`, run `builder run docs-build-static` to build the static site in `docs/build`, and commit your changes. (As with Heroku, Git needs to know what's changed before it can push, so we're stuck committing built artifacts.) Then run `builder run push-gh-pages` to perform a subtree push from `/docs/build` (local) to root in the `gh-pages` branch (remote), updating the live site. Finally, run `git push origin master` to get the static build into shared history--see Gotchas.
 
 ### Gotchas
 
-* We use pushState routing for clean URLs (`myurl.com/path`, not `myurl.com/#/path`), but we don't have any Node app rendering content on the server side. This is fine in production because the static build step generates content for every route, but it can be a headache in development. If you've run `npm run dev-docs` and navigated to a nested route like `localhost:3000/docs/my-component`, you can't just refresh the page to see changes--for now, you have to refresh `localhost:3000` and then navigate back to the page you're interested in.
+* We use pushState routing for clean URLs (`myurl.com/path`, not `myurl.com/#/path`), but we don't have any Node app rendering content on the server side. This is fine in production because the static build step generates content for every route, but it can be a headache in development. If you've run `builder run docs-dev` and navigated to a nested route like `localhost:3000/docs/my-component`, you can't just refresh the page to see changes--for now, you have to refresh `localhost:3000` and then navigate back to the page you're interested in.
 
 * Since the live site lives in a nested route (`/victory/`), we have to do a few things differently:
   * In `docs/router.jsx`, we instantiate `history` with the `basename` `/victory`.
   * In both `docs/components/static-index.jsx` (prod base page) and `docs/index.html` (local dev base page), we specific a `base href`: the path relative to which relative content in served. In `static-index`, that path is `/victory` (since that's where the prod site lives); in `index.html`, it's `/` (since we're serving at `localhost:3000`). Then, elsewhere, we serve all assets with relative paths.
 This works great in production and pretty well in development (previous Gotcha aside), but it doesn't work when previewing built assets. That is, if you `cd` into `docs/build` and start a server with something like `python -m SimpleHTTPServer`, the app won't be able to find its assets: the `build-static-docs` step builds into `static-index`, which specifies the `/victory` base href for prod, which doesn't exist locally. Point is, if you see this happen, no worries--nothing's wrong!
 
-* Having trouble with `npm run push-gh-pages`? The remote history is probably ahead of your local history, which means someone else ran `push-gh-pages` and it's not in your history tree; maybe they forgot to push to master after building and deploying. You need the equivalent of `--force`, but that's not an option with subtree pushes. Luckily, you can chain commands together like this:
+* Having trouble with `builder run push-gh-pages`? The remote history is probably ahead of your local history, which means someone else ran `push-gh-pages` and it's not in your history tree; maybe they forgot to push to master after building and deploying. You need the equivalent of `--force`, but that's not an option with subtree pushes. Luckily, you can chain commands together like this:
 ```
 git push origin `git subtree split --prefix docs/build master`:gh-pages --force
 ```

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -29,7 +29,7 @@ class App extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: 'block'}}>
+        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: "block"}}>
           {headerText}
         </Header>
         <main className="Container" style={this.getMainStyles()}>

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -109,6 +109,11 @@ class App extends React.Component {
                 https://gitter.im/FormidableLabs/victory
               </a>
             </p>
+            <p className="Copy">
+              Roadmap: <a href="https://github.com/FormidableLabs/victory/blob/master/ROADMAP.md">
+                ROADMAP.md
+              </a>
+            </p>
             <p className="Copy">Component docs:</p>
             <ul className="Copy">
               {components.map((component) => {

--- a/docs/components/app.jsx
+++ b/docs/components/app.jsx
@@ -1,4 +1,4 @@
-import { components } from "../config";
+import { components, headerText } from "../config";
 import { Link } from "react-router";
 import Radium, { Style } from "radium";
 import React from "react";
@@ -29,8 +29,8 @@ class App extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor={VictorySettings.palestSand}>
-          Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
+        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: 'block'}}>
+          {headerText}
         </Header>
         <main className="Container" style={this.getMainStyles()}>
 

--- a/docs/components/component-docs.jsx
+++ b/docs/components/component-docs.jsx
@@ -19,7 +19,7 @@ class ComponentDocs extends BaseDocs {
     const Docs = _.findWhere(components, { slug: this.props.params.component }).docs;
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: 'block'}}>
+        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: "block"}}>
           {headerText}
         </Header>
         <main style={this.getMainStyles()}>

--- a/docs/components/component-docs.jsx
+++ b/docs/components/component-docs.jsx
@@ -5,7 +5,7 @@ import React from "react";
 import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
 
 import BaseDocs from "./docs";
-import { components, routing as routingConfig } from "../config";
+import { components, headerText, routing as routingConfig } from "../config";
 import Sidebar from "./sidebar";
 
 @Radium
@@ -19,8 +19,8 @@ class ComponentDocs extends BaseDocs {
     const Docs = _.findWhere(components, { slug: this.props.params.component }).docs;
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor={VictorySettings.palestSand}>
-          Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
+        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: 'block'}}>
+          {headerText}
         </Header>
         <main style={this.getMainStyles()}>
           <Sidebar active={`${this.props.params.component}`} />

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -5,7 +5,7 @@ import Radium, { Style } from "radium";
 import React from "react";
 import ReactDOM from "react-dom";
 
-import { components, routing as routingConfig } from "../config";
+import { components, headerText, routing as routingConfig } from "../config";
 import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
 import * as Victory from "../../src/index";
 const { VictoryChart, VictoryLine, VictoryPie } = Victory;
@@ -61,8 +61,8 @@ class Docs extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor={VictorySettings.palestSand}>
-          Looking for custom dashboards or data visualization consulting? Let&rsquo;s talk.
+        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: 'block'}}>
+          {headerText}
         </Header>
         <main style={this.getMainStyles()}>
           <Sidebar active={""} />

--- a/docs/components/docs.jsx
+++ b/docs/components/docs.jsx
@@ -61,7 +61,7 @@ class Docs extends React.Component {
   render() {
     return (
       <div style={{display: "flex", minHeight: "100vh", flexDirection: "column"}}>
-        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: 'block'}}>
+        <Header backgroundColor={VictorySettings.palestSand} styleOverrides={{display: "block"}}>
           {headerText}
         </Header>
         <main style={this.getMainStyles()}>

--- a/docs/config.js
+++ b/docs/config.js
@@ -2,6 +2,7 @@ export default {
   routing: {
     base: "/"
   },
+  headerText: "Looking for a custom dashboard? Need help leveling up your data visualizations? Let’s talk!",
   components: [
     {
       text: "VictoryAnimation",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "version": "builder run npm:version",
     "test": "builder run npm:test",
     "docs-dev": "webpack-dev-server --port 3000 --config docs/webpack.config.dev.js --content-base docs",
-    "docs-hot": "webpack-dev-server --port 3000 --config docs/webpack.config.hot.js --hot --content-base docs",
     "copy-static-assets": "cp -r docs/static/ docs/build/static",
     "copy-cname": "cp docs/CNAME docs/build/CNAME",
     "docs-build-static": "webpack --config docs/webpack.config.static.js --progress && npm run copy-static-assets && npm run copy-cname"


### PR DESCRIPTION
- Update header text in three places
  - Override `display:flex` since that messes up the underline.
  - Now the string lives in docs/config, for easier updates in the future.
- Add Roadmap link
- Update dev documentation for docs

