### PR TITLE
Add `npm start` script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ npm start
 # Open the demo app
 $ open http://localhost:3000
 
-# Run tests
+# Run checks (lint and tests)
 $ npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ You can also join the Gitter chat room at https://gitter.im/FormidableLabs/victo
 ## Get started
 
 1. Add Victory to your project:
-  ```
-  npm install victory --save
+
+  ```sh
+  $ npm install victory --save
   ```
 
 2. Add your first Victory component:
@@ -41,6 +42,7 @@ You can also join the Gitter chat room at https://gitter.im/FormidableLabs/victo
   ```
 
 3. `VictoryPie` component will be rendered, and you should see:
+
 ![VictoryPie](https://cloud.githubusercontent.com/assets/3802023/12114963/369a6538-b3a6-11e5-898c-db410a335a7b.png)
 
 
@@ -77,15 +79,29 @@ You can read about these Victory components via interactive docs!
 
 
 ## Animation
-Wrap any Victory component with [VictoryAnimation](https://github.com/FormidableLabs/victory-animation) and it will transition smoothly between states whenever data changes. VictoryAnimation relies on d3's interpolator, so it knows how to transitions between colors, dates, numbers, strings etc.
 
-## Development
-
-Please see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md)
+Wrap any Victory component with [VictoryAnimation][] and it will transition smoothly between states whenever data changes. VictoryAnimation relies on d3's interpolator, so it knows how to transitions between colors, dates, numbers, strings etc.
 
 ## Contributing
 
-Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md)
+Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md) in the project builder archetype.
+
+```sh
+# Clone the Victory repo
+$ git clone git@github.com:FormidableLabs/victory.git
+$ cd victory
+
+# Run the demo app server
+$ npm start
+
+# Open the demo app
+$ open http://localhost:3000
+
+# Run tests
+$ npm test
+```
+
+For more on the development environment, see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md) in the project builder archetype.
 
 ## Roadmap
 
@@ -93,3 +109,4 @@ Please see [ROADMAP](ROADMAP.md)
 
 [trav_img]: https://api.travis-ci.org/FormidableLabs/victory.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/victory
+[VictoryAnimation]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-animation/victory-animation.jsx

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -1,12 +1,33 @@
 import React from "react";
-import {VictoryLine, VictoryChart, VictoryAxis, VictoryBar} from "../src/index";
+import {
+  VictoryAxis,
+  VictoryBar,
+  VictoryChart,
+  VictoryLine,
+  VictoryPie,
+  VictoryScatter
+} from "../src/index";
 
 export default class App extends React.Component {
   render() {
     return (
       <div className="demo">
-        <VictoryLine/>
-        <VictoryChart/>
+        <h1>Victory Demo</h1>
+
+        <h2>Composites</h2>
+
+        <h3>VictoryPie</h3>
+        <p>Default props</p>
+        <VictoryPie/>
+
+        <h3>VictoryChart</h3>
+        <p>Line chart of function <code>y = x^2</code></p>
+        <VictoryChart>
+          <VictoryLine y={(data) => data.x * data.x}/>
+        </VictoryChart>
+
+        <h3>VictoryChart</h3>
+        <p>Custom axes and tickformats; Bar + line chart</p>
         <VictoryChart domainPadding={{x: 30, y: 30}}>
           <VictoryAxis
             tickValues={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]}
@@ -47,6 +68,25 @@ export default class App extends React.Component {
             label="LINE"
           />
         </VictoryChart>
+
+        <h2>Primitives</h2>
+
+        <h3>VictoryAxis</h3>
+        <p>Default props</p>
+        <VictoryAxis/>
+
+        <h3>VictoryBar</h3>
+        <p>Default props</p>
+        <VictoryBar/>
+
+        <h3>VictoryLine</h3>
+        <p>Default props</p>
+        <VictoryLine/>
+
+        <h3>VictoryScatter</h3>
+        <p>Default props</p>
+        <VictoryScatter/>
+
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
   },
   "homepage": "https://github.com/formidablelabs/victory",
   "scripts": {
+    "copy-cname": "cp docs/CNAME docs/build/CNAME",
+    "copy-static-assets": "cp -r docs/static/ docs/build/static",
+    "docs-build-static": "webpack --config docs/webpack.config.static.js --progress && npm run copy-static-assets && npm run copy-cname",
+    "docs-dev": "webpack-dev-server --port 3000 --config docs/webpack.config.dev.js --content-base docs",
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
-    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\"",
+    "server-docs": "http-server docs/build",
     "test": "builder run npm:test",
-    "docs-dev": "webpack-dev-server --port 3000 --config docs/webpack.config.dev.js --content-base docs",
-    "copy-static-assets": "cp -r docs/static/ docs/build/static",
-    "copy-cname": "cp docs/CNAME docs/build/CNAME",
-    "docs-build-static": "webpack --config docs/webpack.config.static.js --progress && npm run copy-static-assets && npm run copy-cname",
-    "server-docs": "http-server docs/build"
+    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {
-    "builder": "~2.4.0",
     "builder-victory-component": "~0.2.1",
+    "builder": "~2.4.0",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-animation": "0.1.0",
@@ -47,12 +47,12 @@
     "lodash": "^3.10.1",
     "mocha": "^2.3.3",
     "radium": "^0.16.2",
-    "react": "0.14.x",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "0.14.x",
     "react-ga": "^1.2.0",
     "react-router": "1.0.0",
-    "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "react": "0.14.x",
+    "sinon-chai": "^2.8.0",
+    "sinon": "^1.17.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preversion": "builder run npm:preversion",
     "server-docs": "http-server docs/build",
     "start": "builder run hot",
-    "test": "builder run npm:test",
+    "test": "builder run check",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
     "server-docs": "http-server docs/build",
+    "start": "builder run hot",
     "test": "builder run npm:test",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },


### PR DESCRIPTION
I've added standard npm scripts and updated the README to have the minimum needed to get started on development.

- `npm start` runs `builder run hot`
- `npm test` runs `builder run check`

I've also added primitives and composite components to demo app.

/cc @tptee @boygirl 