### PR TITLE
Move static docs tasks to project; Upgrade archetype.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,2 @@
+---
+  extends: ./node_modules/builder-victory-component/config/eslint/.eslintrc-source

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,8 +24,6 @@
   <div id="content">
     <p style="text-align: center;">Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
-  <script src="https://fb.me/react-0.13.3.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>
   <script async defer type="text/javascript" src="main.js"></script>

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "scripts": {
     "copy-cname": "cp docs/CNAME docs/build/CNAME",
     "copy-static-assets": "cp -r docs/static/ docs/build/static",
-    "docs-build-static": "webpack --config docs/webpack.config.static.js --progress && npm run copy-static-assets && npm run copy-cname",
+    "docs-build-static": "webpack --bail --config docs/webpack.config.static.js --progress && npm run copy-static-assets && npm run copy-cname",
     "docs-dev": "webpack-dev-server --port 3000 --config docs/webpack.config.dev.js --content-base docs",
+    "server-docs": "http-server docs/build",
+    "push-gh-pages": "git subtree push --prefix docs/build origin gh-pages",
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
     "server-docs": "http-server docs/build",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   },
   "dependencies": {
     "builder": "2.9.1",
-    "builder-victory-component": "^1.0.7",
+    "builder-victory-component": "^2.0.0",
     "victory-chart": "6.0.1",
     "victory-core": "1.2.2",
     "victory-pie": "2.0.1"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^1.0.7",
+    "builder-victory-component-dev": "^2.0.0",
     "chai": "^3.2.0",
     "ecology": "^1.2.0",
     "file-loader": "^0.8.5",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,2 @@
+---
+  extends: ../node_modules/builder-victory-component/config/eslint/.eslintrc-test


### PR DESCRIPTION
- We're removing the static-docs tasks from the archetype... https://github.com/FormidableLabs/builder-victory-component/pull/51
- ...so now those tasks live here.
- Also add `.eslintrc` files.
- ...and remove silly static `<script/>` includes from `docs/index.html`