### PR TITLE
Prevent installation using npm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/formidablelabs/victory.git"
   },
+  "engineStrict" : true,
+  "engines": {
+    "npm": ">=3.0.0"
+  },
   "author": "Formidable",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This makes victory's dependency on npm3 explicit:

```
npm ERR! notsup Unsupported
npm ERR! notsup Not compatible with your version of node/npm: victory@0.6.1
npm ERR! notsup Required: {"npm":">=3.0.0"}
npm ERR! notsup Actual:   {"npm":"2.14.16","node":"4.2.6"}
```

Rather than npm2 users having to find it out the long, large, slow way :smile: 

```
$ npm install victory
npm WARN optional dep failed, continuing fsevents@1.0.11
/ (for 276 MB of node_modules)
```