### PR TITLE
remove duplicate VictoryAnimation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,6 @@ import { VictoryPie } from "victory-pie";
 export {
   Area, Bar, Candle, ClipPath, Curve, ErrorBar, Line, Point, Slice, Voronoi, Flyout,
   VictoryAnimation,
-  VictoryAnimation,
   VictoryArea,
   VictoryAxis,
   VictoryBar,


### PR DESCRIPTION
Looks like there was a messy merge.  Victory won't build with a duplicate export.