### PR TITLE
use npm 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,8 @@
     "type": "git",
     "url": "https://github.com/formidablelabs/victory.git"
   },
-  "engineStrict": true,
   "engines": {
-    "npm": ">=3.0.0"
+    "npm": ">=2.0.0"
   },
   "author": "Formidable",
   "license": "MIT",


### PR DESCRIPTION
- removed `engineStrict`, looks like it's deprecated in npm 3 (https://docs.npmjs.com/files/package.json#enginestrict)
- use npm version >=2.0.0

We (at airbnb) are hoping to use victory in production but need victory to work with npm 2 to do so. I'm hoping we can keep this branch open so we can reference it in our package.json. in the short term, if we want any fixes to master we will have to rebase them to this branch to stay up-to-date.

I'm open to other approaches here, but would love to get to a working solution ASAP! 

In our package.json we would include the victory dependency like so:

```js
"dependencies": {
    "victory": "FormidableLabs/victory#cb7cc954efd4781bb235acfe079eb4699b200175"
}
```

testing:
i ran `npm i` and `npm start` and got the test page up and running without issue.

cc @williaster @ljharb