### PR TITLE
Update to React 15.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "chai": "^3.2.0",
     "lodash": "^4.12.0",
     "mocha": "^2.3.3",
-    "react": "^15.1.0",
-    "react-addons-test-utils": "^15.1.0",
-    "react-dom": "^15.1.0",
+    "react": "^15.5.4",
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },


### PR DESCRIPTION
Since React 16 is right around the corner, Facebook released v.15.5 to
make the migration easier. This also moved the `PropTypes` into their
own npm module `prop-types`.
More info:
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

This pull request updates the necessary `react` packages. 

**Corresponding pull requests for other victory repositories:**  
`victory-core`: https://github.com/FormidableLabs/victory-core/pull/232  
`victory-chart`: https://github.com/FormidableLabs/victory-chart/pull/460  
`victory-pie`: https://github.com/FormidableLabs/victory-pie/pull/139