### PR TITLE
update for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Victory Changelog
 
+## 0.19.1 (2017-05-12)
+
+- [victory-chart/469](https://github.com/FormidableLabs/victory-chart/pull/469) Adds `VictoryCursorContainer`
+- [victory-core/241](https://github.com/FormidableLabs/victory-core/pull/241) Adds optional `title` an `desc` props to `VictoryLabel`
+- [victory-core/243](https://github.com/FormidableLabs/victory-core/pull/243) Impovements to `VictoryContainer`
+  - Automatic `overflow: "visible"` for elements rendered in `VictoryPortal` (tooltips)
+  - `VictoryContainer` no longer renders `g` tags (this was causing confusion with evented containers)
+  - Default responsive styles are now `width: "100%"` `height: "100%"` (fixes a bug in safari)
+  - Changes the merge order for responsive styles so that `width` and `height` attrs may be overridden
+- [victory-core/244](https://github.com/FormidableLabs/victory-core/pull/244) adds missing `index` and `datum` props to `Flyout`
+- [victory-core/245](https://github.com/FormidableLabs/victory-core/pull/245) fixes `dy` calculation in `VictoryLabel`
+
+
 ## 0.19.0 (2017-05-02)
 
 **BREAKING CHANGE**

--- a/package.json
+++ b/package.json
@@ -34,15 +34,16 @@
   "dependencies": {
     "builder": "^3.2.1",
     "builder-victory-component": "^4.0.0",
-    "victory-chart": "^19.0.0",
-    "victory-core": "^15.0.0",
-    "victory-pie": "^11.0.0"
+    "victory-chart": "^19.1.1",
+    "victory-core": "^15.1.0",
+    "victory-pie": "^11.1.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^4.0.0",
     "chai": "^3.5.0",
     "lodash": "^4.17.4",
     "mocha": "^3.0.2",
+    "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import {
   VictorySelectionContainer, SelectionHelpers, selectionContainerMixin,
   VictoryBrushContainer, BrushHelpers, brushContainerMixin,
   VictoryVoronoiContainer, VoronoiHelpers, voronoiContainerMixin,
+  VictoryCursorContainer, CursorHelpers, cursorContainerMixin,
   combineContainerMixins, createContainer
 } from "victory-chart";
 
@@ -63,6 +64,7 @@ export {
   VictoryZoomContainer, ZoomHelpers, zoomContainerMixin,
   VictorySelectionContainer, SelectionHelpers, selectionContainerMixin,
   VictoryBrushContainer, BrushHelpers, brushContainerMixin,
+  VictoryCursorContainer, CursorHelpers, cursorContainerMixin,
   VictoryVoronoiContainer, VoronoiHelpers, voronoiContainerMixin,
   combineContainerMixins, createContainer,
   addEvents, Collection, Data, DefaultTransitions, Domain, Events, Helpers, Log,

--- a/test/client/spec/components/victory.spec.js
+++ b/test/client/spec/components/victory.spec.js
@@ -62,7 +62,7 @@ describe("victory", () => {
     expect(Victory.SelectionHelpers).not.to.equal(undefined);
     expect(Victory.ZoomHelpers).not.to.equal(undefined);
     expect(Victory.VoronoiHelpers).not.to.equal(undefined);
-    expect(Victory.CursoriHelpers).not.to.equal(undefined);
+    expect(Victory.CursorHelpers).not.to.equal(undefined);
     expect(Victory.voronoiContainerMixin).not.to.equal(undefined);
     expect(Victory.zoomContainerMixin).not.to.equal(undefined);
     expect(Victory.brushContainerMixin).not.to.equal(undefined);

--- a/test/client/spec/components/victory.spec.js
+++ b/test/client/spec/components/victory.spec.js
@@ -57,14 +57,17 @@ describe("victory", () => {
     expect(Victory.VictorySelectionContainer).not.to.equal(undefined);
     expect(Victory.VictoryBrushContainer).not.to.equal(undefined);
     expect(Victory.VictoryVoronoiContainer).not.to.equal(undefined);
+    expect(Victory.VictoryCursorContainer).not.to.equal(undefined);
     expect(Victory.BrushHelpers).not.to.equal(undefined);
     expect(Victory.SelectionHelpers).not.to.equal(undefined);
     expect(Victory.ZoomHelpers).not.to.equal(undefined);
     expect(Victory.VoronoiHelpers).not.to.equal(undefined);
+    expect(Victory.CursoriHelpers).not.to.equal(undefined);
     expect(Victory.voronoiContainerMixin).not.to.equal(undefined);
     expect(Victory.zoomContainerMixin).not.to.equal(undefined);
     expect(Victory.brushContainerMixin).not.to.equal(undefined);
     expect(Victory.selectionContainerMixin).not.to.equal(undefined);
+    expect(Victory.cursorContainerMixin).not.to.equal(undefined);
     expect(Victory.combineContainerMixins).not.to.equal(undefined);
     expect(Victory.createContainer).not.to.equal(undefined);
   });


### PR DESCRIPTION
- [victory-chart/469](https://github.com/FormidableLabs/victory-chart/pull/469) Adds `VictoryCursorContainer`
- [victory-core/241](https://github.com/FormidableLabs/victory-core/pull/241) Adds optional `title` an `desc` props to `VictoryLabel`
- [victory-core/243](https://github.com/FormidableLabs/victory-core/pull/243) Impovements to `VictoryContainer`
  - Automatic `overflow: "visible"` for elements rendered in `VictoryPortal` (tooltips)
  - `VictoryContainer` no longer renders `g` tags (this was causing confusion with evented containers)
  - Default responsive styles are now `width: "100%"` `height: "100%"` (fixes a bug in safari)
  - Changes the merge order for responsive styles so that `width` and `height` attrs may be overridden
- [victory-core/244](https://github.com/FormidableLabs/victory-core/pull/244) adds missing `index` and `datum` props to `Flyout`
- [victory-core/245](https://github.com/FormidableLabs/victory-core/pull/245) fixes `dy` calculation in `VictoryLabel`