### PR TITLE
Webpack3 + ES6 Exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "extends": "builder-victory-component/config/babel/.babelrc"
+  "extends": "builder-victory-component/config/babel/.babelrc-react"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Desktop.ini
 $RECYCLE.BIN/
 
 # App specific
+.vscode
 bower_components
 coverage
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bower_components
 coverage
 dist
 lib
+es
 node_modules
 npm-debug.log*
 yarn.lock

--- a/.npmignore.publishr
+++ b/.npmignore.publishr
@@ -1,6 +1,7 @@
 /*
 !/dist
 dist/*.map
+!/es
 !/lib
 !/src
 !LICENSE.txt

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   },
   "dependencies": {
     "builder": "^3.2.1",
-    "builder-victory-component": "^5.0.0",
+    "builder-victory-component": "^5.0.1",
     "victory-chart": "^21.2.0",
     "victory-core": "^16.1.0",
     "victory-pie": "^11.1.2"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^5.0.0",
+    "builder-victory-component-dev": "^5.0.1",
     "chai": "^3.5.0",
     "lodash": "^4.17.4",
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/formidablelabs/victory",
   "scripts": {
-    "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
+    "postinstall": "builder run npm:postinstall",
     "preversion": "builder run npm:preversion",
     "postversion": "builder run npm:postversion",
     "postpublish": "builder run npm:postpublish",

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   },
   "dependencies": {
     "builder": "^3.2.1",
-    "builder-victory-component": "^4.0.4",
+    "builder-victory-component": "^5.0.0",
     "victory-chart": "^21.2.0",
     "victory-core": "^16.1.0",
     "victory-pie": "^11.1.2"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^4.0.4",
+    "builder-victory-component-dev": "^5.0.0",
     "chai": "^3.5.0",
     "lodash": "^4.17.4",
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "charting"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/formidablelabs/victory.git"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "dependencies": {
     "builder": "^3.2.1",
     "builder-victory-component": "^5.0.1",
-    "victory-chart": "^21.2.0",
-    "victory-core": "^16.1.0",
-    "victory-pie": "^11.1.2"
+    "victory-chart": "^21.3.0",
+    "victory-core": "^16.3.0",
+    "victory-pie": "^11.3.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^5.0.1",


### PR DESCRIPTION
This PR modernizes the Victory build and offerings. Generally:

- Provide an `es/` directory alongside `lib/` that has ES module export / imports (but everything else babel built) per the `redux` model. This model allows webpack2+ to use ESM resolution and enable tree-shaking, while is still backwards compatible with webpack1 which will use `lib/`
- Remove all references to `.jsx` since we don't use those anymore.
- Clean up and hone down a lot of stuff.

/cc @boygirl @chrisbolin

### Cross-reference PRs

First, infrastructure:

* https://github.com/FormidableLabs/builder-victory-component-dev/pull/7
* https://github.com/FormidableLabs/builder-victory-component/pull/92

Second, core:

* https://github.com/FormidableLabs/victory-core/pull/266

Third, dependers:

* https://github.com/FormidableLabs/victory-pie/pull/149
* https://github.com/FormidableLabs/victory-chart/pull/495

Finally, parent:

* https://github.com/FormidableLabs/victory/pull/651

### Tickets

Implemented / fixed:

- Provide es6 build to use with Webpack. Fixes https://github.com/FormidableLabs/victory/issues/256
- Provide efficient webpack helpers for tree-shaking + DCE. Fixes https://github.com/FormidableLabs/victory/issues/548

Opened / still open:

- Webpack tree shaking does not completely remove unused re-exports. https://github.com/FormidableLabs/victory/issues/549

### Bundles

The main goal here is not the victory _bundle_, but enabling webpack2+ users to get more efficient builds going off the `es/` directory. And with the dedupe plugin being removed in webpack2+, our dev bundle is definitely bigger. But, fortunately, the prod minified bundles aren't that different:

*Before / webpack1*

```
$ find ../victory*/dist -type f -exec wc -c {} \;
  993198 ../victory-chart/dist/victory-chart.js
 1323555 ../victory-chart/dist/victory-chart.js.map
  438868 ../victory-chart/dist/victory-chart.min.js
 2634923 ../victory-chart/dist/victory-chart.min.js.map
  659513 ../victory-core/dist/victory-core.js
  915723 ../victory-core/dist/victory-core.js.map
  276427 ../victory-core/dist/victory-core.min.js
 1734458 ../victory-core/dist/victory-core.min.js.map
  674687 ../victory-pie/dist/victory-pie.js
  836742 ../victory-pie/dist/victory-pie.js.map
  284790 ../victory-pie/dist/victory-pie.min.js
 1814890 ../victory-pie/dist/victory-pie.min.js.map
 1013340 ../victory/dist/victory.js
 1235399 ../victory/dist/victory.js.map
  450323 ../victory/dist/victory.min.js
 2747731 ../victory/dist/victory.min.js.map
```

*After / webpack3*

```
$ find ../victory*/dist -type f -exec wc -c {} \;
 1663000 ../victory-chart/dist/victory-chart.js
 1602704 ../victory-chart/dist/victory-chart.js.map
  434851 ../victory-chart/dist/victory-chart.min.js
 3349108 ../victory-chart/dist/victory-chart.min.js.map
  975040 ../victory-core/dist/victory-core.js
  941706 ../victory-core/dist/victory-core.js.map
  265075 ../victory-core/dist/victory-core.min.js
 1930341 ../victory-core/dist/victory-core.min.js.map
 1219152 ../victory-pie/dist/victory-pie.js
 1092945 ../victory-pie/dist/victory-pie.js.map
  304427 ../victory-pie/dist/victory-pie.min.js
 2396990 ../victory-pie/dist/victory-pie.min.js.map
 1869374 ../victory/dist/victory.js
 1680468 ../victory/dist/victory.js.map
  487115 ../victory/dist/victory.min.js
 3846520 ../victory/dist/victory.min.js.map
```