### PR TITLE
update deps and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Victory Changelog
 
+## 0.24.0 (2017-10-19)
+
+**Breaking Changes**
+
+- [victory-chart/527](https://github.com/FormidableLabs/victory-chart/pull/527)
+  - adds an `invertAxis` prop for `VictoryAxis` that will flip the domain of a given axis when true. Changing the `orientation` prop of a given axis will no longer flip the domain on that axis _unless_ the `invertAxis` prop is also set.
+  - `tickFormat` as an array will set the number of ticks if `tickValues` are not given.
+  - `tickValues` will be forced to a unique array. `tickFormat` may still have non-unique values.
+  - `tickCount` will now always have an effect when set. Previously, this prop would do nothing when `tickValues` were provided. Now `tickCount` will downsample any array provided to either `tickValues` or `tickFormat`.
+
+Other Changes
+
+VictoryChart
+- [529](https://github.com/FormidableLabs/victory-chart/pull/529) `VictoryChart` no longer calculates `tickValues` or `tickFormat` for axis children. `stringMap` and `categories` are passed to axis components instead.
+- [528](https://github.com/FormidableLabs/victory-chart/pull/528) and [530](https://github.com/FormidableLabs/victory-chart/pull/530) Remove numeric keys from styles
+- [526](https://github.com/FormidableLabs/victory-chart/pull/526) Always set animation state
+
+VictoryCore
+- [310](https://github.com/FormidableLabs/victory-core/pull/310) Add `getPath` prop for `Point` to support custom path calculation
+- [311](https://github.com/FormidableLabs/victory-core/pull/311) Fix bug in `TextSize`
+- [313](https://github.com/FormidableLabs/victory-core/pull/313) Use `tickFormat` for calculating a stringMap when appropriate
+- [314](https://github.com/FormidableLabs/victory-core/pull/314) Theme changes: Change `pointerEvents` to "visible" for grids
+
 ## 0.23.1 (2017-10-04)
 
 - [victory-core/307](https://github.com/FormidableLabs/victory-core/pull/307) Adds a default className for containers

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "dependencies": {
     "builder": "^3.2.1",
     "builder-victory-component": "^5.0.1",
-    "victory-chart": "^23.0.1",
-    "victory-core": "^19.0.3",
-    "victory-pie": "^13.0.0"
+    "victory-chart": "^24.0.0",
+    "victory-core": "^20.0.0",
+    "victory-pie": "^13.0.1"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^5.0.1",


### PR DESCRIPTION
## 0.24.0 (2017-10-19)

**Breaking Changes**

- [victory-chart/527](https://github.com/FormidableLabs/victory-chart/pull/527)
  - adds an `invertAxis` prop for `VictoryAxis` that will flip the domain of a given axis when true. Changing the `orientation` prop of a given axis will no longer flip the domain on that axis _unless_ the `invertAxis` prop is also set.
  - `tickFormat` as an array will set the number of ticks if `tickValues` are not given.
  - `tickValues` will be forced to a unique array. `tickFormat` may still have non-unique values.
  - `tickCount` will now always have an effect when set. Previously, this prop would do nothing when `tickValues` were provided. Now `tickCount` will downsample any array provided to either `tickValues` or `tickFormat`.

Other Changes

VictoryChart
- [529](https://github.com/FormidableLabs/victory-chart/pull/529) `VictoryChart` no longer calculates `tickValues` or `tickFormat` for axis children. `stringMap` and `categories` are passed to axis components instead.
- [528](https://github.com/FormidableLabs/victory-chart/pull/528) and [530](https://github.com/FormidableLabs/victory-chart/pull/530) Remove numeric keys from styles
- [526](https://github.com/FormidableLabs/victory-chart/pull/526) Always set animation state

VictoryCore
- [310](https://github.com/FormidableLabs/victory-core/pull/310) Add `getPath` prop for `Point` to support custom path calculation
- [311](https://github.com/FormidableLabs/victory-core/pull/311) Fix bug in `TextSize`
- [313](https://github.com/FormidableLabs/victory-core/pull/313) Use `tickFormat` for calculating a stringMap when appropriate
- [314](https://github.com/FormidableLabs/victory-core/pull/314) Theme changes: Change `pointerEvents` to "visible" for grids