### PR TITLE
add issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -10,14 +10,15 @@
 
 * [ ] I've searched open issues to make sure I'm not opening a duplicate issue
 
-
 ### The Problem
 
 Describe the issue you're seeing, and what you expect the behavior to be.
 
 ### Reproduction
 
-Please try to reproduce the issue you're seeing in a sandbox. You can [fork this sandbox](https://codesandbox.io/s/m3xo745x2x) to get started. If you can't reproduce your issue in a sandbox, please list steps to reproduce your issue, and include exact version numbers for `victory` and `react`.
+Please try to reproduce the issue you're seeing in a sandbox. You can [fork this sandbox](https://codesandbox.io/s/m3xo745x2x) to get started.
+
+If you can't reproduce your issue in a sandbox, please create a minimal git repo that demonstrates the problem you're seeing. Include instructions for installing and reproducing your error.
 
 # Feature Requests
 
@@ -30,6 +31,3 @@ Please try to reproduce the issue you're seeing in a sandbox. You can [fork this
 ### Description
 
 Please describe the feature you're requesting in detail.
-
-
-

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+# Bugs and Questions
+
+### Checklist
+
+* [ ] This is not a `victory-native` specific issue. (Issues that only appear in `victory-native` should be opened [here](https://github.com/FormidableLabs/victory-native/issues/new))
+
+* [ ] I have read through the [FAQ](https://formidable.com/open-source/victory/docs/faq) and [Guides](https://formidable.com/open-source/victory/guides/) before asking a question
+
+* [ ] I am using the latest version of Victory
+
+* [ ] I've searched open issues to make sure I'm not opening a duplicate issue
+
+
+### The Problem
+
+Describe the issue you're seeing, and what you expect the behavior to be.
+
+### Reproduction
+
+Please try to reproduce the issue you're seeing in a sandbox. You can [fork this sandbox](https://codesandbox.io/s/m3xo745x2x) to get started. If you can't reproduce your issue in a sandbox, please list steps to reproduce your issue, and include exact version numbers for `victory` and `react`.
+
+# Feature Requests
+
+### Checklist
+
+* [ ] I've read through the [Docs](https://formidable.com/open-source/victory/docs) and [Guides](https://formidable.com/open-source/victory/guides) to make sure this functionality doesn't already exist
+
+* [ ] I've searched open issues to make sure I'm not opening a duplicate issue
+
+### Description
+
+Please describe the feature you're requesting in detail.
+
+
+


### PR DESCRIPTION
cc/ @coopy @ryan-roemer 

I'm adding issues templates for victory and victory-native. Please let me know if this seems appropriate or if you would like to see any changes.