### PR TITLE
Added react and prop-types to peer dependencies

### DIFF
--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -40,6 +40,10 @@
     "victory-voronoi-container": "^30.0.0",
     "victory-zoom-container": "^30.0.0"
   },
+  "peerDependencies": {
+    "react": ">=15.0.0",
+    "prop-types": ">=15.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },


### PR DESCRIPTION
Among others, tools like `bundlephobia` (bundlephobia.com) depend on the `peerDependecies` field to be able to determine external dependencies.