### PR TITLE
Improvement/victory native stability

### DIFF
--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -191,6 +191,7 @@ export default class App extends React.Component {
           />
         </VictoryStack>
 
+        <VictoryChart style={style}>
         <VictoryGroup
           style={{
             parent: style.parent,
@@ -206,6 +207,7 @@ export default class App extends React.Component {
             data={[{ x: 1, y: 3 }, { x: 2, y: 2 }, { x: 3, y: 6 }, { x: 4, y: 2 }, { x: 5, y: 6 }]}
           />
         </VictoryGroup>
+        </VictoryChart>
 
         <VictoryStack
           style={{ parent: style.parent }}

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -191,7 +191,6 @@ export default class App extends React.Component {
           />
         </VictoryStack>
 
-        <VictoryChart style={style}>
         <VictoryGroup
           style={{
             parent: style.parent,
@@ -207,7 +206,6 @@ export default class App extends React.Component {
             data={[{ x: 1, y: 3 }, { x: 2, y: 2 }, { x: 3, y: 6 }, { x: 4, y: 2 }, { x: 5, y: 6 }]}
           />
         </VictoryGroup>
-        </VictoryChart>
 
         <VictoryStack
           style={{ parent: style.parent }}

--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -86,7 +86,7 @@ export default class Area extends React.Component {
   render() {
     const {
       role, shapeRendering, className, polar, origin, data, active, pathComponent, events,
-      groupComponent, clipPath
+      groupComponent, clipPath, id
     } = this.props;
     const style = Helpers.evaluateStyle(assign({ fill: "black" }, this.props.style), data, active);
     const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
@@ -99,11 +99,11 @@ export default class Area extends React.Component {
 
     const sharedProps = { className, role, shapeRendering, transform, events, clipPath };
     const area = React.cloneElement(pathComponent, assign({
-      key: "area", style: assign({}, style, { stroke: areaStroke }), d: areaFunction(data)
+      key: `${id}-area`, style: assign({}, style, { stroke: areaStroke }), d: areaFunction(data)
     }, sharedProps));
 
     const line = renderLine ? React.cloneElement(pathComponent, assign({
-      key: "area-stroke", style: assign({}, style, { fill: "none" }), d: lineFunction(data)
+      key: `${id}-area-stroke`, style: assign({}, style, { fill: "none" }), d: lineFunction(data)
     }, sharedProps)) : null;
 
     return renderLine ? React.cloneElement(groupComponent, {}, [area, line]) : area;

--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -32,6 +32,7 @@ const getAngleAccessor = (scale) => {
 export default class Area extends React.Component {
   static propTypes = {
     ...CommonProps.primitiveProps,
+    clipPath: PropTypes.string,
     groupComponent: PropTypes.element,
     interpolation: PropTypes.string,
     pathComponent: PropTypes.element
@@ -85,7 +86,7 @@ export default class Area extends React.Component {
   render() {
     const {
       role, shapeRendering, className, polar, origin, data, active, pathComponent, events,
-      groupComponent
+      groupComponent, clipPath
     } = this.props;
     const style = Helpers.evaluateStyle(assign({ fill: "black" }, this.props.style), data, active);
     const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
@@ -96,7 +97,7 @@ export default class Area extends React.Component {
 
     const areaStroke = style.stroke ? "none" : style.fill;
 
-    const sharedProps = { className, role, shapeRendering, transform, events };
+    const sharedProps = { className, role, shapeRendering, transform, events, clipPath };
     const area = React.cloneElement(pathComponent, assign({
       key: "area", style: assign({}, style, { stroke: areaStroke }), d: areaFunction(data)
     }, sharedProps));

--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -32,7 +32,6 @@ const getAngleAccessor = (scale) => {
 export default class Area extends React.Component {
   static propTypes = {
     ...CommonProps.primitiveProps,
-    clipPath: PropTypes.string,
     groupComponent: PropTypes.element,
     interpolation: PropTypes.string,
     pathComponent: PropTypes.element

--- a/packages/victory-area/src/helper-methods.js
+++ b/packages/victory-area/src/helper-methods.js
@@ -44,12 +44,12 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
-    scale, sharedEvents, standalone, style, theme, width, labels
+    scale, sharedEvents, standalone, style, theme, width, labels, name
   } = props;
   const initialChildProps = {
     parent: {
       style: style.parent, width, height, scale, data, domain,
-      standalone, theme, polar, origin, padding
+      standalone, theme, polar, origin, padding, name
     },
     all: {
       data: { polar, origin, scale, data, interpolation, groupComponent, style: style.data }

--- a/packages/victory-axis/src/helper-methods.js
+++ b/packages/victory-axis/src/helper-methods.js
@@ -309,7 +309,8 @@ const getBaseProps = (props, fallbackProps) => {
   props = modifyProps(props, fallbackProps, role);
   const calculatedValues = getCalculatedValues(props);
   const {
-    axis, style, orientation, isVertical, scale, ticks, tickFormat, anchors, domain, stringTicks
+    axis, style, orientation, isVertical, scale, ticks,
+    tickFormat, anchors, domain, stringTicks, name
   } = calculatedValues;
   const otherAxis = axis === "x" ? "y" : "x";
   const { width, height, standalone, theme, polar, padding } = props;
@@ -319,7 +320,7 @@ const getBaseProps = (props, fallbackProps) => {
   const axisLabelProps = getAxisLabelProps(props, calculatedValues, globalTransform);
   const initialChildProps = {
     parent: assign(
-      { style: style.parent, ticks, standalone, theme, width, height, padding, domain },
+      { style: style.parent, ticks, standalone, theme, width, height, padding, domain, name },
       sharedProps
     )
   };

--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -128,8 +128,7 @@ class VictoryAxis extends React.Component {
   }
 
   renderGridAndTicks(props) {
-    const { tickComponent, tickLabelComponent, gridComponent } = props;
-
+    const { tickComponent, tickLabelComponent, gridComponent, name } = props;
     return this.dataKeys.map((key, index) => {
       const tickProps = this.getComponentProps(tickComponent, "ticks", index);
       const TickComponent = React.cloneElement(tickComponent, tickProps);
@@ -137,9 +136,10 @@ class VictoryAxis extends React.Component {
       const GridComponent = React.cloneElement(gridComponent, gridProps);
       const tickLabelProps = this.getComponentProps(tickLabelComponent, "tickLabels", index);
       const TickLabel = React.cloneElement(tickLabelComponent, tickLabelProps);
-
       return React.cloneElement(
-        props.groupComponent, { key: `tick-group-${key}` }, GridComponent, TickComponent, TickLabel
+        props.groupComponent,
+        { key: `${name}-tick-group-${key}` },
+        GridComponent, TickComponent, TickLabel
       );
     });
   }

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -218,7 +218,7 @@ export default class Bar extends React.Component {
 
   render() {
     const {
-      role, datum, active, shapeRendering, className, origin, polar, pathComponent, events
+      role, datum, active, shapeRendering, className, origin, polar, pathComponent, events, clipPath
     } = this.props;
     const stroke = this.props.style && this.props.style.fill || "black";
     const baseStyle = { fill: "black", stroke };
@@ -231,7 +231,7 @@ export default class Bar extends React.Component {
     const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
     const transform = this.props.transform || defaultTransform;
     return React.cloneElement(pathComponent, {
-      d: path, transform, className, style, role, shapeRendering, events
+      d: path, transform, className, style, role, shapeRendering, events, clipPath
     });
   }
 }

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -40,10 +40,10 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
-    polar, scale, sharedEvents, standalone, style, theme, width, labels
+    polar, scale, sharedEvents, standalone, style, theme, width, labels, name
   } = props;
   const initialChildProps = { parent: {
-    domain, scale, width, height, data, standalone,
+    domain, scale, width, height, data, standalone, name,
     theme, polar, origin, padding, style: style.parent
   } };
 

--- a/packages/victory-box-plot/src/helper-methods.js
+++ b/packages/victory-box-plot/src/helper-methods.js
@@ -294,11 +294,11 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     groupComponent, width, height, padding, standalone, theme, events, sharedEvents,
-    scale, horizontal, data, style, domain
+    scale, horizontal, data, style, domain, name
   } = props;
   const initialChildProps = {
     parent: {
-      domain, scale, width, height, data, standalone,
+      domain, scale, width, height, data, standalone, name,
       theme, style: style.parent || {}, padding, groupComponent
     }
   };

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -79,10 +79,11 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
 
   getSelectBox(props, coordinates) {
     const { x, y } = coordinates;
-    const { brushStyle, brushComponent } = props;
+    const { brushStyle, brushComponent, name } = props;
     const brushComponentStyle = brushComponent.props && brushComponent.props.style;
     return x[0] !== x[1] && y[0] !== y[1] ?
       React.cloneElement(brushComponent, {
+        key: `${name}-brush`,
         width: Math.abs(x[1] - x[0]) || 1,
         height: Math.abs(y[1] - y[0]) || 1,
         x: Math.min(x[0], x[1]),
@@ -93,7 +94,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   }
 
   getHandles(props, coordinates) {
-    const { brushDimension, handleWidth, handleStyle, handleComponent } = props;
+    const { brushDimension, handleWidth, handleStyle, handleComponent, name } = props;
     const { x, y } = coordinates;
     const width = Math.abs(x[1] - x[0]) || 1;
     const height = Math.abs(y[1] - y[0]) || 1;
@@ -111,7 +112,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
       memo = handleProps[curr] ?
         memo.concat(React.cloneElement(
           handleComponent,
-          assign({ key: `handle-${curr}` }, handleProps[curr]
+          assign({ key: `${name}-handle-${curr}` }, handleProps[curr]
         ))) : memo;
       return memo;
     }, []);
@@ -125,21 +126,12 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
       defaults({}, currentDomain, brushDomain) : brushDomain;
     const coordinates = Selection.getDomainCoordinates(props, domain);
     const selectBox = this.getSelectBox(props, coordinates);
-    return selectBox ?
-      (
-        <g>
-          {selectBox}
-          {this.getHandles(props, coordinates)}
-        </g>
-      ) : null;
+    return selectBox ? [ selectBox, this.getHandles(props, coordinates)] : [];
   }
 
   // Overrides method in VictoryContainer
   getChildren(props) {
-    const children = React.Children.toArray(props.children);
-    return [...children, this.getRect(props)].map((component, i) => {
-      return component ? React.cloneElement(component, { key: i }) : null;
-    });
+    return [...React.Children.toArray(props.children), ...this.getRect(props)];
   }
 };
 

--- a/packages/victory-brush-line/src/victory-brush-line.js
+++ b/packages/victory-brush-line/src/victory-brush-line.js
@@ -115,6 +115,7 @@ export default class VictoryBrushLine extends React.Component {
     handleComponent: PropTypes.element,
     handleStyle: PropTypes.object,
     handleWidth: PropTypes.number,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     lineComponent: PropTypes.element,
     name: PropTypes.string,
     onBrushDomainChange: PropTypes.func,
@@ -372,7 +373,7 @@ export default class VictoryBrushLine extends React.Component {
 
   renderHandles(props) {
     const {
-      handleComponent, handleStyle, datum = {}, activeBrushes = {}, brushDomain
+      handleComponent, handleStyle, id, brushDomain, datum = {}, activeBrushes = {}
     } = props;
     if (!brushDomain) {
       return null;
@@ -382,12 +383,12 @@ export default class VictoryBrushLine extends React.Component {
     const minDatum = assign({ handleValue: Collection.getMinValue(brushDomain) }, datum);
     const maxDatum = assign({ handleValue: Collection.getMaxValue(brushDomain) }, datum);
     const minHandleProps = assign({
-      key: "min",
+      key: `${id}-min`,
       style: Helpers.evaluateStyle(style, minDatum, activeBrushes.minHandle)
     }, handleDimensions.min);
     const maxHandleProps = assign(
       {
-        key: "max",
+        key: `${id}-max`,
         style: Helpers.evaluateStyle(style, maxDatum, activeBrushes.maxHandle)
       }, handleDimensions.max);
     return [

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -35,7 +35,7 @@ export default class Candle extends React.Component {
     const {
       x, high, low, open, close, data, datum, active, width, candleHeight, events, groupComponent,
       rectComponent, lineComponent, role, shapeRendering, className, wickStrokeWidth, transform,
-      clipPath
+      clipPath, id
     } = this.props;
     const style = Helpers.evaluateStyle(
       assign({ stroke: "black" }, this.props.style), datum, active
@@ -47,7 +47,7 @@ export default class Candle extends React.Component {
     const sharedProps = { role, shapeRendering, className, events, transform, clipPath };
 
     const candleProps = assign({
-      key: "candle",
+      key: `${id}-candle`,
       style,
       x: candleX,
       y: Math.min(open, close),
@@ -56,7 +56,7 @@ export default class Candle extends React.Component {
     }, sharedProps);
 
     const highWickProps = assign({
-      key: "highWick",
+      key: `${id}-highWick`,
       style: wickStyle,
       x1: x,
       x2: x,
@@ -65,7 +65,7 @@ export default class Candle extends React.Component {
     }, sharedProps);
 
     const lowWickProps = assign({
-      key: "lowWick",
+      key: `${id}-lowWick`,
       style: wickStyle,
       x1: x,
       x2: x,

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -34,7 +34,8 @@ export default class Candle extends React.Component {
   render() {
     const {
       x, high, low, open, close, data, datum, active, width, candleHeight, events, groupComponent,
-      rectComponent, lineComponent, role, shapeRendering, className, wickStrokeWidth, transform
+      rectComponent, lineComponent, role, shapeRendering, className, wickStrokeWidth, transform,
+      clipPath
     } = this.props;
     const style = Helpers.evaluateStyle(
       assign({ stroke: "black" }, this.props.style), datum, active
@@ -43,7 +44,7 @@ export default class Candle extends React.Component {
     const padding = this.props.padding.left || this.props.padding;
     const candleWidth = style.width || 0.5 * (width - 2 * padding) / data.length;
     const candleX = x - candleWidth / 2;
-    const sharedProps = { role, shapeRendering, className, events, transform };
+    const sharedProps = { role, shapeRendering, className, events, transform, clipPath };
 
     const candleProps = assign({
       key: "candle",

--- a/packages/victory-candlestick/src/helper-methods.js
+++ b/packages/victory-candlestick/src/helper-methods.js
@@ -96,11 +96,11 @@ const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-stat
   const calculatedValues = getCalculatedValues(props);
   const { data, style, scale, domain, origin } = calculatedValues;
   const {
-    groupComponent, width, height, padding, standalone,
+    groupComponent, width, height, padding, standalone, name,
     theme, polar, wickStrokeWidth, labels, events, sharedEvents
   } = props;
   const initialChildProps = { parent: {
-    domain, scale, width, height, data, standalone, theme, polar, origin,
+    domain, scale, width, height, data, standalone, theme, polar, origin, name,
     style: style.parent, padding
   } };
 

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -118,7 +118,7 @@ function getChildren(props, childComponents, calculatedProps) {
   const { origin } = calculatedProps;
   const parentName = props.name || "chart";
   return childComponents.map((child, index) => {
-    const role = child.type && child.type.role || "";
+    const role = child.type && child.type.role;
     const style = Array.isArray(child.props.style) ?
       child.props.style :
       defaults({}, child.props.style, { parent: baseStyle });

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -116,16 +116,19 @@ function getChildren(props, childComponents, calculatedProps) {
   const baseStyle = calculatedProps.style.parent;
   const { height, polar, theme, width } = props;
   const { origin } = calculatedProps;
+  const parentName = props.name || "chart";
   return childComponents.map((child, index) => {
+    const role = child.type && child.type.role || "";
     const style = Array.isArray(child.props.style) ?
       child.props.style :
       defaults({}, child.props.style, { parent: baseStyle });
     const childProps = getChildProps(child, props, calculatedProps);
+    const name = child.props.name || `${parentName}-${role}-${index}`;
     const newProps = defaults({
-      height, polar, theme, width, style,
+      height, polar, theme, width, style, name,
       origin: polar ? origin : undefined,
       padding: calculatedProps.padding,
-      key: index,
+      key: `${name}-key-${index}`,
       standalone: false
     }, childProps);
 

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -97,11 +97,11 @@ export default class VictoryChart extends React.Component {
   }
 
   getContainerProps(props, calculatedProps) {
-    const { width, height, standalone, theme, polar } = props;
+    const { width, height, standalone, theme, polar, name } = props;
     const { domain, scale, style, origin, radius, horizontal } = calculatedProps;
     return {
       domain, scale, width, height, standalone, theme, style: style.parent, horizontal,
-      polar, radius, origin: polar ? origin : undefined
+      name, polar, radius, origin: polar ? origin : undefined
     };
   }
 

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.js
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.js
@@ -17,6 +17,7 @@ export default class VictoryClipContainer extends React.Component {
     ]),
     circleComponent: PropTypes.element,
     className: PropTypes.string,
+    clipChildren: PropTypes.bool,
     clipHeight: CustomPropTypes.nonNegative,
     clipId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     clipPadding: PropTypes.shape({
@@ -64,15 +65,23 @@ export default class VictoryClipContainer extends React.Component {
   }
 
   renderClippedGroup(props, clipId) {
-    const { style, events, transform, children, className, groupComponent } = props;
+    const { style, events, transform, children, className, groupComponent, clipChildren } = props;
     const clipComponent = this.renderClipComponent(props, clipId);
-    const clippedGroup = React.cloneElement(
-      groupComponent, { key: "clipped-group", clipPath: `url(#${clipId})` }, children
-    );
+    const clippedChildren = clipChildren ?
+      React.Children.toArray(children).map((child, i) => {
+        return React.cloneElement(child, {
+          key: `clipped-child-${clipId}-${i}`,
+          clipPath: `url(#${clipId})`
+        });
+      }) :
+      children;
+    const groupProps = assign({
+      className, style, transform, key: `clipped-group-${clipId}`, clipPath: `url(#${clipId})`
+    }, events);
     return React.cloneElement(
       groupComponent,
-      assign({ className, style, transform }, events),
-      [clipComponent, clippedGroup]
+      groupProps,
+      [clipComponent, ...clippedChildren]
     );
   }
 

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.js
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.js
@@ -17,7 +17,6 @@ export default class VictoryClipContainer extends React.Component {
     ]),
     circleComponent: PropTypes.element,
     className: PropTypes.string,
-    clipChildren: PropTypes.bool,
     clipHeight: CustomPropTypes.nonNegative,
     clipId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     clipPadding: PropTypes.shape({
@@ -65,23 +64,15 @@ export default class VictoryClipContainer extends React.Component {
   }
 
   renderClippedGroup(props, clipId) {
-    const { style, events, transform, children, className, groupComponent, clipChildren } = props;
+    const { style, events, transform, children, className, groupComponent } = props;
     const clipComponent = this.renderClipComponent(props, clipId);
-    const clippedChildren = clipChildren ?
-      React.Children.toArray(children).map((child, i) => {
-        return React.cloneElement(child, {
-          key: `clipped-child-${clipId}-${i}`,
-          clipPath: `url(#${clipId})`
-        });
-      }) :
-      children;
     const groupProps = assign({
       className, style, transform, key: `clipped-group-${clipId}`, clipPath: `url(#${clipId})`
     }, events);
     return React.cloneElement(
       groupComponent,
       groupProps,
-      [clipComponent, ...clippedChildren]
+      [clipComponent, ...React.Children.toArray(children)]
     );
   }
 

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.js
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.js
@@ -118,7 +118,7 @@ export default class VictoryClipContainer extends React.Component {
 
     return React.cloneElement(
       clipPathComponent,
-      assign({ key: "clip-path" }, props, { clipId }),
+      assign({ key: `clip-path-${clipId}` }, props, { clipId }),
       child
     );
   }

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -20,6 +20,7 @@ export default class VictoryContainer extends React.Component {
     desc: PropTypes.string,
     events: PropTypes.object,
     height: CustomPropTypes.nonNegative,
+    name: PropTypes.string,
     origin: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
     polar: PropTypes.bool,
     portalComponent: PropTypes.element,

--- a/packages/victory-core/src/victory-label/victory-label.js
+++ b/packages/victory-core/src/victory-label/victory-label.js
@@ -8,7 +8,7 @@ import Style from "../victory-util/style";
 import Log from "../victory-util/log";
 import TSpan from "../victory-primitives/tspan";
 import Text from "../victory-primitives/text";
-import { assign, defaults, isEmpty } from "lodash";
+import { assign, defaults, isEmpty, uniqueId } from "lodash";
 
 const defaultStyles = {
   fill: "#252525",
@@ -46,6 +46,7 @@ export default class VictoryLabel extends React.Component {
       PropTypes.func
     ]),
     events: PropTypes.object,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     inline: PropTypes.bool,
     labelPlacement: PropTypes.oneOf(["parallel", "perpendicular", "vertical"]),
@@ -110,6 +111,12 @@ export default class VictoryLabel extends React.Component {
     capHeight: 0.71, // Magic number from d3.
     lineHeight: 1
   };
+
+  constructor(props) {
+    super(props);
+    this.id = props.id === undefined ?
+      uniqueId("label-") : props.id;
+  }
 
   getPosition(props, dimension) {
     if (!props.datum) {
@@ -227,9 +234,8 @@ export default class VictoryLabel extends React.Component {
       const currentLineHeight = this.checkLineHeight(
         lineHeight, ((lineHeight[i] + (lineHeight[i - 1] || lineHeight[0])) / 2), 1
       );
-
       const tspanProps = {
-        key: i,
+        key: `${this.id}-key-${i}`,
         x: !inline ? props.x : undefined,
         dx,
         dy: i && !inline ? (currentLineHeight * fontSize) : undefined,
@@ -241,7 +247,7 @@ export default class VictoryLabel extends React.Component {
     });
     return React.cloneElement(
       props.textComponent,
-      { dx, dy, x, y, events, transform, className, title, desc },
+      { dx, dy, x, y, events, transform, className, title, desc, id: this.id },
       textChildren
     );
   }

--- a/packages/victory-core/src/victory-primitives/arc.js
+++ b/packages/victory-core/src/victory-primitives/arc.js
@@ -48,11 +48,13 @@ export default class Arc extends React.Component {
   }
 
   render() {
-    const { role, shapeRendering, className, events, pathComponent, transform } = this.props;
+    const {
+      role, shapeRendering, className, events, pathComponent, transform, clipPath
+    } = this.props;
     return React.cloneElement(pathComponent, {
       d: this.getArcPath(this.props),
       style: this.getStyle(this.props),
-      className, role, shapeRendering, events, transform
+      className, role, shapeRendering, events, transform, clipPath
     });
   }
 }

--- a/packages/victory-core/src/victory-primitives/border.js
+++ b/packages/victory-core/src/victory-primitives/border.js
@@ -21,12 +21,12 @@ export default class Border extends React.Component {
 
   render() {
     const {
-       x, y, width, height, events, datum, active, role,
+       x, y, width, height, events, datum, active, role, clipPath,
        className, shapeRendering, rectComponent, transform
       } = this.props;
     const style = Helpers.evaluateStyle(assign({ fill: "none" }, this.props.style), datum, active);
     return React.cloneElement(rectComponent, {
-      style, className, x, y, width, height, events, role, shapeRendering, transform
+      style, className, x, y, width, height, events, role, shapeRendering, transform, clipPath
     });
   }
 }

--- a/packages/victory-core/src/victory-primitives/line-segment.js
+++ b/packages/victory-core/src/victory-primitives/line-segment.js
@@ -23,13 +23,13 @@ export default class LineSegment extends React.Component {
   render() {
     const {
       x1, x2, y1, y2, events, datum, active, lineComponent, className, role, shapeRendering,
-      transform
+      transform, clipPath
     } = this.props;
     const style = Helpers.evaluateStyle(
       assign({ stroke: "black" }, this.props.style), datum, active
     );
     return React.cloneElement(lineComponent, {
-      style, className, role, shapeRendering, events, x1, x2, y1, y2, transform
+      style, className, role, shapeRendering, events, x1, x2, y1, y2, transform, clipPath
     });
   }
 }

--- a/packages/victory-core/src/victory-primitives/point.js
+++ b/packages/victory-core/src/victory-primitives/point.js
@@ -53,12 +53,12 @@ export default class Point extends React.Component {
 
   render() {
     const {
-      active, datum, role, shapeRendering, className, events, pathComponent, transform
+      active, datum, role, shapeRendering, className, events, pathComponent, transform, clipPath
     } = this.props;
     const style = Helpers.evaluateStyle(this.props.style, datum, active);
     const d = this.getPath(this.props);
     return React.cloneElement(
-      pathComponent, { style, role, shapeRendering, className, events, d, transform }
+      pathComponent, { style, role, shapeRendering, className, events, d, transform, clipPath }
     );
   }
 }

--- a/packages/victory-core/src/victory-primitives/whisker.js
+++ b/packages/victory-core/src/victory-primitives/whisker.js
@@ -33,10 +33,10 @@ export default class Whisker extends React.Component {
   render() {
     const {
       groupComponent, lineComponent, events, className, majorWhisker, minorWhisker,
-      datum, active, transform
+      datum, active, transform, clipPath
     } = this.props;
     const style = Helpers.evaluateStyle(this.props.style, datum, active);
-    const baseProps = { style, events, className, transform };
+    const baseProps = { style, events, className, transform, clipPath };
     return React.cloneElement(groupComponent, {}, [
       React.cloneElement(lineComponent, assign({ key: "major-whisker" }, baseProps, majorWhisker)),
       React.cloneElement(lineComponent, assign({ key: "minor-whisker" }, baseProps, minorWhisker))

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -129,8 +129,9 @@ export default (WrappedComponent, options) => {
     }
 
     getComponentProps(component, type, index) {
-      const { role } = WrappedComponent;
+      const name = this.props.name || WrappedComponent.role;
       const key = this.dataKeys && this.dataKeys[index] || index;
+      const id = `${name}-${type}-${key}`;
       const baseProps = this.baseProps[key] && this.baseProps[key][type] || this.baseProps[key];
       if (!baseProps && !this.hasEvents) {
         return undefined;
@@ -138,11 +139,12 @@ export default (WrappedComponent, options) => {
       if (this.hasEvents) {
         const baseEvents = this.getEvents(this.props, type, key);
         const componentProps = defaults(
-          { index, key: `${role}-${type}-${key}` },
+          { index, key: id },
           this.getEventState(key, type),
           this.getSharedEventState(key, type),
           component.props,
-          baseProps
+          baseProps,
+          { id }
         );
         const events = defaults(
           {}, Events.getPartialEvents(baseEvents, key, componentProps), componentProps.events
@@ -152,9 +154,10 @@ export default (WrappedComponent, options) => {
         );
       }
       return defaults(
-        { index, key: `${role}-${type}-${key}` },
+        { index, key: id },
         component.props,
-        baseProps
+        baseProps,
+        { id }
       );
     }
 

--- a/packages/victory-core/src/victory-util/common-props.js
+++ b/packages/victory-core/src/victory-util/common-props.js
@@ -141,6 +141,7 @@ const baseProps = {
 const primitiveProps = {
   active: PropTypes.bool,
   className: PropTypes.string,
+  clipPath: PropTypes.string,
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   events: PropTypes.object,
   index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/victory-core/src/victory-util/common-props.js
+++ b/packages/victory-core/src/victory-util/common-props.js
@@ -144,6 +144,7 @@ const primitiveProps = {
   clipPath: PropTypes.string,
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   events: PropTypes.object,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
   polar: PropTypes.bool,

--- a/packages/victory-cursor-container/src/victory-cursor-container.js
+++ b/packages/victory-cursor-container/src/victory-cursor-container.js
@@ -99,7 +99,8 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
 
   getCursorElements(props) { // eslint-disable-line max-statements
     const {
-      scale, cursorDimension, cursorLabelComponent, cursorLabel, cursorComponent, width, height
+      scale, cursorDimension, cursorLabelComponent, cursorLabel,
+      cursorComponent, width, height, name
     } = props;
     const cursorValue = this.getCursorPosition(props);
     const cursorLabelOffset = this.getCursorLabelOffset(props);
@@ -123,7 +124,7 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
             y: cursorCoordinates.y + cursorLabelOffset.y,
             text: Helpers.evaluateProp(cursorLabel, cursorValue, true),
             active: true,
-            key: "cursor-label"
+            key: `${name}-cursor-label`
           }
         )
       ));
@@ -132,7 +133,7 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
     const cursorStyle = assign({ stroke: "black" }, cursorComponent.props.style);
     if (cursorDimension === "x" || cursorDimension === undefined) {
       newElements.push(React.cloneElement(cursorComponent, {
-        key: "x-cursor",
+        key: `${name}-x-cursor`,
         x1: cursorCoordinates.x,
         x2: cursorCoordinates.x,
         y1: padding.top,
@@ -142,7 +143,7 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
     }
     if (cursorDimension === "y" || cursorDimension === undefined) {
       newElements.push(React.cloneElement(cursorComponent, {
-        key: "y-cursor",
+        key: `${name}-y-cursor`,
         x1: padding.left,
         x2: (width - padding.right),
         y1: cursorCoordinates.y,
@@ -155,10 +156,7 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
 
   // Overrides method in VictoryContainer
   getChildren(props) {
-    return [
-      ...React.Children.toArray(props.children),
-      ...this.getCursorElements(props)
-    ];
+    return [...React.Children.toArray(props.children), ...this.getCursorElements(props)];
   }
 };
 

--- a/packages/victory-errorbar/src/error-bar.js
+++ b/packages/victory-errorbar/src/error-bar.js
@@ -37,12 +37,13 @@ export default class ErrorBar extends React.Component {
 
   renderBorder(props, error, type) {
     const {
-      x, y, borderWidth, events, style, role, shapeRendering, className, lineComponent, transform
+      x, y, borderWidth, events, style, role, shapeRendering,
+      className, lineComponent, transform, id
     } = props;
     const vertical = type === "right" || type === "left";
     const borderProps = {
       role, shapeRendering, className, events, style, transform,
-      key: `border-${type}`,
+      key: `${id}-border-${type}`,
       x1: vertical ? error[type] : x - borderWidth,
       x2: vertical ? error[type] : x + borderWidth,
       y1: vertical ? y - borderWidth : error[type],
@@ -53,12 +54,12 @@ export default class ErrorBar extends React.Component {
 
   renderCross(props, error, type) {
     const {
-      x, y, events, style, role, shapeRendering, className, lineComponent, transform
+      x, y, events, style, role, shapeRendering, className, lineComponent, transform, id
     } = props;
     const vertical = type === "top" || type === "bottom";
     const borderProps = {
       role, shapeRendering, className, events, style, transform,
-      key: `cross-${type}`,
+      key: `${id}-cross-${type}`,
       x1: x,
       x2: vertical ? x : error[type],
       y1: y,

--- a/packages/victory-errorbar/src/helper-methods.js
+++ b/packages/victory-errorbar/src/helper-methods.js
@@ -111,10 +111,10 @@ const getBaseProps = (props, fallbackProps) => {
   const { data, style, scale, domain, origin } = getCalculatedValues(props, fallbackProps);
   const {
     groupComponent, height, width, borderWidth, standalone, theme, polar, padding,
-    labels, events, sharedEvents
+    labels, events, sharedEvents, name
   } = props;
   const initialChildProps = { parent: {
-    domain, scale, data, height, width, standalone, theme, polar, origin,
+    domain, scale, data, height, width, standalone, theme, polar, origin, name,
     padding, style: style.parent
   } };
 

--- a/packages/victory-group/src/helper-methods.js
+++ b/packages/victory-group/src/helper-methods.js
@@ -131,7 +131,7 @@ function getChildren(props, childComponents, calculatedProps) {
   const { datasets } = calculatedProps;
   const { labelComponent, polar } = props;
   const childProps = getChildProps(props, calculatedProps);
-
+  const parentName = props.name || "group";
   return childComponents.map((child, index) => {
     const role = child.type && child.type.role;
     const xOffset = polar ?
@@ -139,8 +139,9 @@ function getChildren(props, childComponents, calculatedProps) {
     const style = role === "voronoi" || role === "tooltip" || role === "label" ?
       child.props.style : Wrapper.getChildStyle(child, index, calculatedProps);
     const labels = props.labels ? getLabels(props, datasets, index) : child.props.labels;
+    const name = child.props.name || `${parentName}-${role}-${index}`;
     return React.cloneElement(child, assign({
-      labels, style, key: index,
+      labels, style, key: `${name}-key-${index}`, name,
       data: getDataWithOffset(props, datasets[index], xOffset),
       colorScale: getColorScale(props, child),
       labelComponent: labelComponent || child.props.labelComponent,

--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -91,11 +91,11 @@ export default class VictoryGroup extends React.Component {
   }
 
   getContainerProps(props, calculatedProps) {
-    const { width, height, standalone, theme, polar, horizontal } = props;
+    const { width, height, standalone, theme, polar, horizontal, name } = props;
     const { domain, scale, style, origin } = calculatedProps;
     return {
       domain, scale, width, height, standalone, theme, style: style.parent, horizontal,
-      polar, origin
+      polar, origin, name
     };
   }
 

--- a/packages/victory-legend/src/helper-methods.js
+++ b/packages/victory-legend/src/helper-methods.js
@@ -209,7 +209,7 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data, standalone, theme, padding, style, colorScale, gutter, rowGutter,
-    borderPadding, title, titleOrientation, x = 0, y = 0
+    borderPadding, title, titleOrientation, name, x = 0, y = 0
   } = props;
   const groupedData = groupData(props);
   const columnWidths = getColumnWidths(props, groupedData);
@@ -227,7 +227,7 @@ const getBaseProps = (props, fallbackProps) => {
   const { height, width } = getDimensions(props, fallbackProps);
   const initialProps = {
     parent: {
-      data, standalone, theme, padding,
+      data, standalone, theme, padding, name,
       height: props.height,
       width: props.width,
       style: style.parent
@@ -245,7 +245,6 @@ const getBaseProps = (props, fallbackProps) => {
     const dataProps = {
       index: i,
       data, datum,
-      key: `legend-symbol-${i}`,
       symbol: dataStyle.type || dataStyle.symbol || "circle",
       size: datum.size,
       style: dataStyle,
@@ -255,7 +254,6 @@ const getBaseProps = (props, fallbackProps) => {
 
     const labelProps = {
       datum, data,
-      key: `legend-label-${i}`,
       text: datum.name,
       style: labelStyles[i],
       y: dataProps.y,

--- a/packages/victory-legend/src/victory-legend.js
+++ b/packages/victory-legend/src/victory-legend.js
@@ -94,6 +94,7 @@ class VictoryLegend extends React.Component {
     height: CustomPropTypes.nonNegative,
     itemsPerRow: CustomPropTypes.nonNegative,
     labelComponent: PropTypes.element,
+    name: PropTypes.string,
     orientation: PropTypes.oneOf(["horizontal", "vertical"]),
     padding: PropTypes.oneOfType([
       PropTypes.number,

--- a/packages/victory-line/src/curve.js
+++ b/packages/victory-line/src/curve.js
@@ -65,7 +65,7 @@ export default class Curve extends React.Component {
 
   render() {
     const {
-      data, active, events, role, shapeRendering, className, polar, origin, pathComponent
+      data, active, events, role, shapeRendering, className, polar, origin, pathComponent, clipPath
     } = this.props;
     const style = Helpers.evaluateStyle(
       assign({ fill: "none", stroke: "black" }, this.props.style), data, active
@@ -75,7 +75,7 @@ export default class Curve extends React.Component {
     const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
     const transform = this.props.transform || defaultTransform;
     return React.cloneElement(pathComponent, {
-      className, style, role, shapeRendering, transform, events, d: path
+      className, style, role, shapeRendering, transform, events, d: path, clipPath
     });
   }
 }

--- a/packages/victory-line/src/helper-methods.js
+++ b/packages/victory-line/src/helper-methods.js
@@ -33,11 +33,12 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
-    scale, sharedEvents, standalone, style, theme, width, labels
+    scale, sharedEvents, standalone, style, theme, width, labels, name
   } = props;
   const initialChildProps = {
     parent: {
-      style: style.parent, scale, data, height, width, domain, standalone, polar, origin, padding
+      style: style.parent, scale, data, height, width, name,
+      domain, standalone, polar, origin, padding
     },
     all: { data:
       { polar, origin, scale, data, interpolation, groupComponent, theme, style: style.data }

--- a/packages/victory-pie/src/helper-methods.js
+++ b/packages/victory-pie/src/helper-methods.js
@@ -153,9 +153,9 @@ export const getBaseProps = (props, fallbackProps) => {
   props = Helpers.modifyProps(props, fallbackProps, "pie");
   const calculatedValues = getCalculatedValues(props);
   const { slices, style, pathFunction, data, origin } = calculatedValues;
-  const { labels, events, sharedEvents, height, width, standalone } = props;
+  const { labels, events, sharedEvents, height, width, standalone, name } = props;
   const initialChildProps = {
-    parent: { standalone, height, width, slices, pathFunction, style: style.parent }
+    parent: { standalone, height, width, slices, pathFunction, name, style: style.parent }
   };
 
   return slices.reduce((childProps, slice, index) => {

--- a/packages/victory-pie/src/slice.js
+++ b/packages/victory-pie/src/slice.js
@@ -19,12 +19,12 @@ export default class Slice extends React.Component {
   render() {
     const {
       datum, slice, active, role, shapeRendering, className,
-      origin, events, pathComponent, pathFunction, style
+      origin, events, pathComponent, pathFunction, style, clipPath
     } = this.props;
     const defaultTransform = origin ? `translate(${origin.x}, ${origin.y})` : undefined;
     const transform = this.props.transform || defaultTransform;
     return React.cloneElement(pathComponent, {
-      className, role, shapeRendering, events, transform,
+      className, role, shapeRendering, events, transform, clipPath,
       style: Helpers.evaluateStyle(style, datum, active),
       d: isFunction(pathFunction) ? pathFunction(slice) : undefined
     });

--- a/packages/victory-polar-axis/src/helper-methods.js
+++ b/packages/victory-polar-axis/src/helper-methods.js
@@ -278,11 +278,11 @@ const getBaseProps = (props, fallbackProps) => {
   props = modifyProps(props, fallbackProps, role);
   const calculatedValues = getCalculatedValues(props);
   const { style, scale, ticks, domain } = calculatedValues;
-  const { width, height, standalone, theme } = props;
+  const { width, height, standalone, theme, name } = props;
   const axisProps = getAxisProps(props, calculatedValues);
   const axisLabelProps = getAxisLabelProps(props, calculatedValues);
   const initialChildProps = { parent:
-    { style: style.parent, ticks, scale, width, height, domain, standalone, theme }
+    { style: style.parent, ticks, scale, width, height, domain, standalone, theme, name }
   };
 
   return ticks.reduce((childProps, tick, index) => {

--- a/packages/victory-polar-axis/src/victory-polar-axis.js
+++ b/packages/victory-polar-axis/src/victory-polar-axis.js
@@ -131,26 +131,27 @@ class VictoryPolarAxis extends React.Component {
   }
 
   renderAxis(props) {
-    const { tickComponent, tickLabelComponent } = props;
+    const { tickComponent, tickLabelComponent, name } = props;
     const axisType = props.dependentAxis ? "radial" : "angular";
     const gridComponent = axisType === "radial" ? props.circularGridComponent : props.gridComponent;
     const tickComponents = this.dataKeys.map((key, index) => {
       const tickProps = assign(
-        { key: `tick-${key}` }, this.getComponentProps(tickComponent, "ticks", index)
+        { key: `${name}-tick-${key}` }, this.getComponentProps(tickComponent, "ticks", index)
       );
       return React.cloneElement(tickComponent, tickProps);
     });
 
     const gridComponents = this.dataKeys.map((key, index) => {
       const gridProps = assign(
-        { key: `grid-${key}` }, this.getComponentProps(gridComponent, "grid", index)
+        { key: `${name}-grid-${key}` }, this.getComponentProps(gridComponent, "grid", index)
       );
       return React.cloneElement(gridComponent, gridProps);
     });
 
     const tickLabelComponents = this.dataKeys.map((key, index) => {
       const tickLabelProps = assign(
-        { key: `tick-${key}` }, this.getComponentProps(tickLabelComponent, "tickLabels", index)
+        { key: `${name}-tick-${key}` },
+        this.getComponentProps(tickLabelComponent, "tickLabels", index)
       );
       return React.cloneElement(tickLabelComponent, tickLabelProps);
     });

--- a/packages/victory-scatter/src/helper-methods.js
+++ b/packages/victory-scatter/src/helper-methods.js
@@ -69,12 +69,12 @@ const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "scatter");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
-    data, domain, events, height, origin, padding, polar, scale,
+    data, domain, events, height, origin, padding, polar, scale, name,
     sharedEvents, standalone, style, theme, width, labels
   } = props;
   const initialChildProps = { parent: {
     style: style.parent, scale, domain, data, height, width, standalone, theme,
-    origin, polar, padding
+    origin, polar, padding, name
   } };
 
   return data.reduce((childProps, datum, index) => {

--- a/packages/victory-selection-container/src/victory-selection-container.js
+++ b/packages/victory-selection-container/src/victory-selection-container.js
@@ -56,21 +56,21 @@ export const selectionContainerMixin = (base) => class VictorySelectionContainer
   };
 
   getRect(props) {
-    const { x1, x2, y1, y2, selectionStyle, selectionComponent } = props;
+    const { x1, x2, y1, y2, selectionStyle, selectionComponent, name } = props;
     const width = Math.abs(x2 - x1) || 1;
     const height = Math.abs(y2 - y1) || 1;
     const x = Math.min(x1, x2);
     const y = Math.min(y1, y2);
     return y2 && x2 && x1 && y1 ?
-      React.cloneElement(selectionComponent, { x, y, width, height, style: selectionStyle }) : null;
+      React.cloneElement(
+        selectionComponent,
+        { key: `${name}-selection`, x, y, width, height, style: selectionStyle }
+      ) : null;
   }
 
   // Overrides method in VictoryContainer
   getChildren(props) {
-    const children = React.Children.toArray(props.children);
-    return [...children, this.getRect(props)].map((component, i) => {
-      return component ? React.cloneElement(component, { key: i }) : null;
-    });
+    return [...React.Children.toArray(props.children), this.getRect(props)];
   }
 };
 

--- a/packages/victory-stack/src/helper-methods.js
+++ b/packages/victory-stack/src/helper-methods.js
@@ -182,7 +182,8 @@ function getChildren(props, childComponents, calculatedProps) {
     const name = child.props.name || `${parentName}-${role}-${index}`;
     return React.cloneElement(child, assign({
       key: `${name}-key-${index}`,
-      labels, name,
+      labels,
+      name,
       domainPadding: child.props.domainPadding || props.domainPadding,
       theme: props.theme,
       labelComponent: props.labelComponent || child.props.labelComponent,

--- a/packages/victory-stack/src/helper-methods.js
+++ b/packages/victory-stack/src/helper-methods.js
@@ -173,15 +173,16 @@ function getChildren(props, childComponents, calculatedProps) {
   calculatedProps = calculatedProps || getCalculatedProps(props, childComponents);
   const { datasets } = calculatedProps;
   const childProps = getChildProps(props, calculatedProps);
-
+  const parentName = props.name || "stack";
   return childComponents.map((child, index) => {
+    const role = child.type && child.type.role;
     const data = datasets[index];
     const style = Wrapper.getChildStyle(child, index, calculatedProps);
     const labels = props.labels ? getLabels(props, datasets, index) : child.props.labels;
-
+    const name = child.props.name || `${parentName}-${role}-${index}`;
     return React.cloneElement(child, assign({
-      key: index,
-      labels,
+      key: `${name}-key-${index}`,
+      labels, name,
       domainPadding: child.props.domainPadding || props.domainPadding,
       theme: props.theme,
       labelComponent: props.labelComponent || child.props.labelComponent,

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -98,11 +98,11 @@ export default class VictoryStack extends React.Component {
   }
 
   getContainerProps(props, calculatedProps) {
-    const { width, height, standalone, theme, polar, horizontal } = props;
+    const { width, height, standalone, theme, polar, horizontal, name } = props;
     const { domain, scale, style, origin } = calculatedProps;
     return {
       domain, scale, width, height, standalone, theme, style: style.parent, horizontal,
-      polar, origin
+      polar, origin, name
     };
   }
 

--- a/packages/victory-tooltip/src/flyout.js
+++ b/packages/victory-tooltip/src/flyout.js
@@ -83,12 +83,13 @@ export default class Flyout extends React.Component {
 
   render() {
     const {
-      datum, active, role, shapeRendering, className, events, pathComponent, transform
+      datum, active, role, shapeRendering, className, events, pathComponent, transform, clipPath
     } = this.props;
     const style = Helpers.evaluateStyle(this.props.style, datum, active);
     const path = this.getFlyoutPath(this.props);
     return React.cloneElement(
-      pathComponent, { style, className, shapeRendering, role, events, transform, d: path }
+      pathComponent,
+      { style, className, shapeRendering, role, events, transform, d: path, clipPath }
     );
   }
 }

--- a/packages/victory-tooltip/src/victory-tooltip.js
+++ b/packages/victory-tooltip/src/victory-tooltip.js
@@ -5,7 +5,7 @@ import {
   VictoryPortal
 } from "victory-core";
 import Flyout from "./flyout";
-import { assign, defaults } from "lodash";
+import { assign, defaults, uniqueId } from "lodash";
 
 const fallbackProps = {
   cornerRadius: 5,
@@ -46,6 +46,7 @@ export default class VictoryTooltip extends React.Component {
       PropTypes.func
     ]),
     horizontal: PropTypes.bool,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     labelComponent: PropTypes.element,
     orientation: PropTypes.oneOfType([
@@ -128,6 +129,12 @@ export default class VictoryTooltip extends React.Component {
       }
     }];
   };
+
+  constructor(props) {
+    super(props);
+    this.id = props.id === undefined ?
+      uniqueId("tooltip-") : props.id;
+  }
 
   getDefaultOrientation(props) {
     const { datum, horizontal, polar } = props;
@@ -305,7 +312,7 @@ export default class VictoryTooltip extends React.Component {
       {},
       labelComponent.props,
       {
-        key: `label-${index}`,
+        key: `${this.id}-label-${index}`,
         text, datum, textAnchor, dy, dx,
         style: labelStyle,
         x: !textAnchor || textAnchor === "middle" ?
@@ -328,7 +335,7 @@ export default class VictoryTooltip extends React.Component {
       flyoutComponent.props,
       {
         x, y, dx, dy, datum, index, orientation, pointerLength, pointerWidth, cornerRadius, events,
-        key: `flyout-${index}`,
+        key: `${this.id}-tooltip-${index}`,
         width: flyoutDimensions.width,
         height: flyoutDimensions.height,
         style: flyoutStyle

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -202,10 +202,11 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
     // remove properties from first point to make datum
     // eslint-disable-next-line no-unused-vars
     const { childName, eventKey, style, continuous, ...datum } = points[0];
+    const name = props.name === childName ? childName : `${props.name}-${childName}`;
     const labelProps = defaults(
       {
-        key: `${childName}-${eventKey}-voronoi-tooltip`,
-        id: `${childName}-${eventKey}-voronoi-tooltip`,
+        key: `${name}-${eventKey}-voronoi-tooltip`,
+        id: `${name}-${eventKey}-voronoi-tooltip`,
         active: true,
         flyoutStyle: this.getStyle(props, points, "flyout")[0],
         renderInPortal: false,

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -201,10 +201,11 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
 
     // remove properties from first point to make datum
     // eslint-disable-next-line no-unused-vars
-    const { childName, style, continuous, ...datum } = points[0];
-
+    const { childName, eventKey, style, continuous, ...datum } = points[0];
     const labelProps = defaults(
       {
+        key: `${childName}-${eventKey}-voronoi-tooltip`,
+        id: `${childName}-${eventKey}-voronoi-tooltip`,
         active: true,
         flyoutStyle: this.getStyle(props, points, "flyout")[0],
         renderInPortal: false,
@@ -235,10 +236,7 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
 
   // Overrides method in VictoryContainer
   getChildren(props) {
-    const children = React.Children.toArray(props.children);
-    return [...children, this.getTooltip(props)].map((component, i) => {
-      return component ? React.cloneElement(component, { key: i }) : null;
-    });
+    return [...React.Children.toArray(props.children), this.getTooltip(props)];
   }
 };
 

--- a/packages/victory-voronoi/src/helper-methods.js
+++ b/packages/victory-voronoi/src/helper-methods.js
@@ -44,11 +44,11 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data, domain, events, height, origin, padding, polar, polygons,
-    scale, sharedEvents, standalone, style, theme, width, labels
+    scale, sharedEvents, standalone, style, theme, width, labels, name
   } = props;
   const initialChildProps = { parent: {
     style: style.parent, scale, domain, data, standalone, height, width, theme,
-    origin, polar, padding
+    origin, polar, padding, name
   } };
 
   return data.reduce((childProps, datum, index) => {

--- a/packages/victory-voronoi/src/voronoi.js
+++ b/packages/victory-voronoi/src/voronoi.js
@@ -41,7 +41,7 @@ export default class Voronoi extends React.Component {
   render() {
     const {
       datum, active, role, shapeRendering, className, events, x, y, transform,
-      pathComponent, clipPathComponent, groupComponent, circleComponent
+      pathComponent, clipPathComponent, groupComponent, circleComponent, id
     } = this.props;
     const voronoiPath = this.getVoronoiPath(this.props);
     const style = Helpers.evaluateStyle(this.props.style, datum, active);
@@ -49,12 +49,12 @@ export default class Voronoi extends React.Component {
 
     if (size) {
       const circle = React.cloneElement(circleComponent, {
-        key: "circle", style, className, role, shapeRendering, events,
+        key: `${id}-circle-clip`, style, className, role, shapeRendering, events,
         clipPath: `url(#${this.clipId})`, cx: x, cy: y, r: size
       });
       const voronoiClipPath = React.cloneElement(
         clipPathComponent,
-        { key: "voronoi-clip", clipId: this.clipId },
+        { key: `${id}-voronoi-clip`, clipId: this.clipId },
         React.cloneElement(pathComponent, { d: voronoiPath, className })
       );
       return React.cloneElement(groupComponent, {}, [voronoiClipPath, circle]);

--- a/test/client/spec/victory-errorbars/victory-errorbars.spec.js
+++ b/test/client/spec/victory-errorbars/victory-errorbars.spec.js
@@ -129,6 +129,7 @@ describe("components/victory-errorbar", () => {
           <VictoryErrorBar
             data={createData(data)}
             borderWidth={borderWidth}
+            name="error"
             {...svgDimensions}
           />
         );
@@ -148,7 +149,9 @@ describe("components/victory-errorbar", () => {
           const positiveErrorX = errorX >= xScaleMax
             ? xScaleMax : errorX;
           // right border
-          const rightBorder = node.find(Line).findWhere((n) => n.key() === "border-right");
+          const rightBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-right") !== -1
+          );
           expect(rightBorder.props().x1).to.equal(positiveErrorX);
           expect(rightBorder.props().x2).to.equal(positiveErrorX);
           expect(rightBorder.props().y1).to.equal(yScale(data[i].y) - borderWidth);
@@ -188,7 +191,9 @@ describe("components/victory-errorbar", () => {
             ? xScaleMin : errorX;
 
           // left border
-          const leftBorder = node.find(Line).findWhere((n) => n.key() === "border-left");
+          const leftBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-left") !== -1
+          );
           expect(leftBorder.props().x1).to.equal(negativeErrorX);
           expect(leftBorder.props().x2).to.equal(negativeErrorX);
           expect(leftBorder.props().y1).to.equal(yScale(data[i].y) - borderWidth);
@@ -228,7 +233,9 @@ describe("components/victory-errorbar", () => {
             ? yScaleMin : errorY;
 
           // bottom border
-          const bottomBorder = node.find(Line).findWhere((n) => n.key() === "border-bottom");
+          const bottomBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-bottom") !== -1
+          );
           expect(bottomBorder.props().x1).to.equal(xScale(data[i].x) - borderWidth);
           expect(bottomBorder.props().x2).to.equal(xScale(data[i].x) + borderWidth);
           expect(bottomBorder.props().y1).to.equal(negativeErrorY);
@@ -268,7 +275,9 @@ describe("components/victory-errorbar", () => {
             ? yScaleMax : errorY;
 
           // top border
-          const topBorder = node.find(Line).findWhere((n) => n.key() === "border-top");
+          const topBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-top") !== -1
+          );
           expect(topBorder.props().x1).to.equal(xScale(data[i].x) - borderWidth);
           expect(topBorder.props().x2).to.equal(xScale(data[i].x) + borderWidth);
           expect(topBorder.props().y1).to.equal(positiveErrorY);
@@ -305,7 +314,9 @@ describe("components/victory-errorbar", () => {
           const positiveErrorY = errorY >= yScaleMax
             ? yScaleMax : errorY;
 
-          const topCross = node.find(Line).findWhere((n) => n.key() === "cross-top");
+          const topCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-top") !== -1
+          );
           expect(topCross.props().x1).to.equal(xScale(data[i].x));
           expect(topCross.props().x2).to.equal(xScale(data[i].x));
           expect(topCross.props().y1).to.equal(yScale(data[i].y));
@@ -342,7 +353,9 @@ describe("components/victory-errorbar", () => {
           const negativeErrorY = errorY <= yScaleMin
             ? yScaleMin : errorY;
 
-          const bottomCross = node.find(Line).findWhere((n) => n.key() === "cross-bottom");
+          const bottomCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-bottom") !== -1
+          );
           expect(bottomCross.props().x1).to.equal(xScale(data[i].x));
           expect(bottomCross.props().x2).to.equal(xScale(data[i].x));
           expect(bottomCross.props().y1).to.equal(yScale(data[i].y));
@@ -379,7 +392,9 @@ describe("components/victory-errorbar", () => {
           const negativeErrorX = errorX <= xScaleMin
             ? xScaleMin : errorX;
 
-          const leftCross = node.find(Line).findWhere((n) => n.key() === "cross-left");
+          const leftCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-left") !== -1
+          );
           expect(leftCross.props().x1).to.equal(xScale(data[i].x));
           expect(leftCross.props().x2).to.equal(negativeErrorX);
           expect(leftCross.props().y1).to.equal(yScale(data[i].y));
@@ -416,7 +431,9 @@ describe("components/victory-errorbar", () => {
           const positiveErrorX = errorX >= xScaleMax
             ? xScaleMax : errorX;
 
-          const rightCross = node.find(Line).findWhere((n) => n.key() === "cross-right");
+          const rightCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-right") !== -1
+          );
           expect(rightCross.props().x1).to.equal(xScale(data[i].x));
           expect(rightCross.props().x2).to.equal(positiveErrorX);
           expect(rightCross.props().y1).to.equal(yScale(data[i].y));
@@ -496,7 +513,9 @@ describe("components/victory-errorbar", () => {
             ? xScaleMax : errorX;
 
           // right border
-          const rightBorder = node.find(Line).findWhere((n) => n.key() === "border-right");
+          const rightBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-right") !== -1
+          );
           expect(rightBorder.props().x1).to.equal(positiveErrorX);
           expect(rightBorder.props().x2).to.equal(positiveErrorX);
           expect(rightBorder.props().y1).to.equal(yScale(data[i].y) - borderWidth);
@@ -536,7 +555,9 @@ describe("components/victory-errorbar", () => {
             ? xScaleMin : errorX;
 
           // left border
-          const leftBorder = node.find(Line).findWhere((n) => n.key() === "border-left");
+          const leftBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-left") !== -1
+          );
           expect(leftBorder.props().x1).to.equal(negativeErrorX);
           expect(leftBorder.props().x2).to.equal(negativeErrorX);
           expect(leftBorder.props().y1).to.equal(yScale(data[i].y) - borderWidth);
@@ -576,7 +597,9 @@ describe("components/victory-errorbar", () => {
             ? yScaleMin : errorY;
 
           // bottom border
-          const bottomBorder = node.find(Line).findWhere((n) => n.key() === "border-bottom");
+          const bottomBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-bottom") !== -1
+          );
           expect(bottomBorder.props().x1).to.equal(xScale(data[i].x) - borderWidth);
           expect(bottomBorder.props().x2).to.equal(xScale(data[i].x) + borderWidth);
           expect(bottomBorder.props().y1).to.equal(negativeErrorY);
@@ -615,7 +638,9 @@ describe("components/victory-errorbar", () => {
           const positiveErrorY = errorY >= yScaleMax
             ? yScaleMax : errorY;
 
-          const topBorder = node.find(Line).findWhere((n) => n.key() === "border-top");
+          const topBorder = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("border-top") !== -1
+          );
           expect(topBorder.props().x1).to.equal(xScale(data[i].x) - borderWidth);
           expect(topBorder.props().x2).to.equal(xScale(data[i].x) + borderWidth);
           expect(topBorder.props().y1).to.equal(positiveErrorY);
@@ -652,7 +677,9 @@ describe("components/victory-errorbar", () => {
           const positiveErrorY = errorY >= yScaleMax
             ? yScaleMax : errorY;
 
-          const topCross = node.find(Line).findWhere((n) => n.key() === "cross-top");
+          const topCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-top") !== -1
+          );
           expect(topCross.props().x1).to.equal(xScale(data[i].x));
           expect(topCross.props().x2).to.equal(xScale(data[i].x));
           expect(topCross.props().y1).to.equal(yScale(data[i].y));
@@ -689,7 +716,9 @@ describe("components/victory-errorbar", () => {
           const negativeErrorY = errorY <= yScaleMin
             ? yScaleMin : errorY;
 
-          const bottomCross = node.find(Line).findWhere((n) => n.key() === "cross-bottom");
+          const bottomCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-bottom") !== -1
+          );
           expect(bottomCross.props().x1).to.equal(xScale(data[i].x));
           expect(bottomCross.props().x2).to.equal(xScale(data[i].x));
           expect(bottomCross.props().y1).to.equal(yScale(data[i].y));
@@ -726,7 +755,9 @@ describe("components/victory-errorbar", () => {
           const negativeErrorX = errorX <= xScaleMin
             ? xScaleMin : errorX;
 
-          const leftCross = node.find(Line).findWhere((n) => n.key() === "cross-left");
+          const leftCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-left") !== -1
+          );
           expect(leftCross.props().x1).to.equal(xScale(data[i].x));
           expect(leftCross.props().x2).to.equal(negativeErrorX);
           expect(leftCross.props().y1).to.equal(yScale(data[i].y));
@@ -763,7 +794,9 @@ describe("components/victory-errorbar", () => {
           const positiveErrorX = errorX >= xScaleMax
             ? xScaleMax : errorX;
 
-          const rightCross = node.find(Line).findWhere((n) => n.key() === "cross-right");
+          const rightCross = node.find(Line).findWhere(
+            (n) => n.key() && n.key().indexOf("cross-right") !== -1
+          );
           expect(rightCross.props().x1).to.equal(xScale(data[i].x));
           expect(rightCross.props().x2).to.equal(positiveErrorX);
           expect(rightCross.props().y1).to.equal(yScale(data[i].y));


### PR DESCRIPTION
this PR 
- Adds the ability to set a `clipPath` prop on all primitive components
- generates all keys based on `name` prop or `id` prop (primitive components and labels)

This _should not_ be a breaking change, but it may break snapshot tests as keys for most victory components have changed.