### PR TITLE
turn off source-maps for test

### DIFF
--- a/config/webpack/webpack.config.test.js
+++ b/config/webpack/webpack.config.test.js
@@ -30,12 +30,11 @@ module.exports = {
         test: /\.js$/,
         // Use include specifically of our sources
         // Do _not_ use an `exclude` here.
-        include: FILES.concat([path.resolve("test"), path.resolve("perf")]),
+        include: FILES.concat([path.resolve("test")]),
         loader: "babel-loader"
       }
     ]
   },
-  devtool: "source-map",
   devServer: {
     port: WDS_PORT,
     noInfo: false


### PR DESCRIPTION
`karma start ./config/karma/karma.conf.js` started failing with the following: 
```
==== JS stack trace =========================================

Security context: 0x261bcfc257c1 <JSObject>
    1: /* anonymous */ [/Users/boygirl/formidable/v/victory/node_modules/webpack-sources/node_modules/source-map/lib/source-node.js:~342] [pc=0xf645ddea247](this=0x261b1100c211 <JSGlobal Object>,chunk=0x261b8c7b38b9 <String[33]\: /*! exports provided: default */\n>,original=0x261b6f771d19 <Object map = 0x261bd7ed1bf1>)
    2: SourceNode_walk [/Users/boygirl/formidable/v/victory/node_modules/webp...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
...
```

removing `devtool: "source-map"` from `config/webpack/webpack.config.test.js` solves the issue. 

This is a temporary solution so that I can publish `30.1.0` as planned. I will also open an issue to investigate / optimize tests

related: 
https://github.com/karma-runner/karma/issues/1868