### PR TITLE
Bug/stacked groups

### DIFF
--- a/demo/components/debug-demo.js
+++ b/demo/components/debug-demo.js
@@ -3,7 +3,11 @@
 import React from "react";
 import { VictoryChart } from "../../packages/victory-chart/src/index";
 import { VictoryStack } from "../../packages/victory-stack/src/index";
+import { VictoryGroup } from "../../packages/victory-group/src/index";
 import { VictoryBar } from "../../packages/victory-bar/src/index";
+import { VictoryArea } from "../../packages/victory-area/src/index";
+import { VictoryScatter } from "../../packages/victory-scatter/src/index";
+import { VictoryPortal } from "../../packages/victory-core/src/index";
 import { VictorySelectionContainer } from "../../packages/victory-selection-container/src/index";
 import { VictoryVoronoiContainer } from "../../packages/victory-voronoi-container/src/index";
 
@@ -20,6 +24,71 @@ class App extends React.Component {
     const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
     return (
       <div style={containerStyle}>
+        <VictoryChart style={chartStyle} >
+          <VictoryStack colorScale="warm">
+            <VictoryGroup
+              data={[
+                { x: 1, y: 2 },
+                { x: 2, y: 3 },
+                { x: 3, y: 5 },
+                { x: 4, y: 4 }
+              ]}
+            >
+              <VictoryArea/>
+              <VictoryPortal>
+                <VictoryScatter
+                  style={{ data: { fill: "black" } }}
+                />
+              </VictoryPortal>
+            </VictoryGroup>
+            <VictoryGroup
+              data={[
+                { x: 1, y: 4 },
+                { x: 2, y: 3 },
+                { x: 3, y: 2 },
+                { x: 4, y: 5 }
+              ]}
+            >
+              <VictoryArea/>
+              <VictoryPortal>
+                <VictoryScatter
+                  style={{ data: { fill: "green" } }}
+                />
+              </VictoryPortal>
+            </VictoryGroup>
+            <VictoryGroup
+              data={[
+                { x: 1, y: 3 },
+                { x: 2, y: 1 },
+                { x: 3, y: 4 },
+                { x: 4, y: 2 }
+              ]}
+            >
+              <VictoryArea/>
+              <VictoryPortal>
+                <VictoryScatter
+                  style={{ data: { fill: "blue" } }}
+                />
+              </VictoryPortal>
+            </VictoryGroup>
+            <VictoryGroup
+              data={[
+                { x: 1, y: 3 },
+                { x: 2, y: 1 },
+                { x: 3, y: 4 },
+                { x: 4, y: 2 }
+              ]}
+            >
+              <VictoryArea/>
+              <VictoryPortal>
+                <VictoryScatter
+                  style={{ data: { fill: "cyan" } }}
+                />
+              </VictoryPortal>
+            </VictoryGroup>
+          </VictoryStack>
+        </VictoryChart>
+
         <VictoryChart style={chartStyle}
           containerComponent={
             <VictoryVoronoiContainer

--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -170,6 +170,8 @@ export default {
   getDataFromChildren(props, childComponents) {
     const { polar, startAngle, endAngle, categories, minDomain, maxDomain } = props;
     const parentProps = { polar, startAngle, endAngle, categories, minDomain, maxDomain };
+
+    let stack = 0;
     const iteratee = (child, childName, parent) => {
       const role = child.type && child.type.role;
       const childProps = assign({}, child.props, parentProps);
@@ -182,14 +184,14 @@ export default {
       } else {
         childData = Data.getData(childProps);
       }
-      return childData.map((datum) => assign({ childName }, datum));
+      stack += 1;
+      return childData.map((datum) => assign({ stack }, datum));
     };
-
     const children = childComponents ?
-      childComponents.slice(0) : React.Children.toArray(props.children);
-    const datasets = Helpers.reduceChildren(children, iteratee, props);
+    childComponents.slice(0) : React.Children.toArray(props.children);
     const stacked = children.filter((c) => c.type && c.type.role === "stack").length;
-    const group = stacked ? "eventKey" : "childName";
+    const datasets = Helpers.reduceChildren(children, iteratee, props);
+    const group = stacked ? "eventKey" : "stack";
     return values(groupBy(datasets, group));
   },
 

--- a/packages/victory-group/src/helper-methods.js
+++ b/packages/victory-group/src/helper-methods.js
@@ -141,7 +141,7 @@ function getChildren(props, childComponents, calculatedProps) {
     const labels = props.labels ? getLabels(props, datasets, index) : child.props.labels;
     const name = child.props.name || `${parentName}-${role}-${index}`;
     return React.cloneElement(child, assign({
-      labels, style, key: `${name}-key-${index}`, name,
+      labels, style, key: `${name}-key-${index}`,
       data: getDataWithOffset(props, datasets[index], xOffset),
       colorScale: getColorScale(props, child),
       labelComponent: labelComponent || child.props.labelComponent,

--- a/packages/victory-group/src/helper-methods.js
+++ b/packages/victory-group/src/helper-methods.js
@@ -141,7 +141,7 @@ function getChildren(props, childComponents, calculatedProps) {
     const labels = props.labels ? getLabels(props, datasets, index) : child.props.labels;
     const name = child.props.name || `${parentName}-${role}-${index}`;
     return React.cloneElement(child, assign({
-      labels, style, key: `${name}-key-${index}`,
+      labels, style, key: `${name}-key-${index}`, name,
       data: getDataWithOffset(props, datasets[index], xOffset),
       colorScale: getColorScale(props, child),
       labelComponent: labelComponent || child.props.labelComponent,


### PR DESCRIPTION
This PR fixes a bug that was introduced by altering the `name` prop in children of  `VictoryStack` and `VictoryGroup`. This bug was caused because the method `VictoryStack` relied on for grouping sets of child data used the `childName` to group datasets. This made the method fragile to name changes. A stack count was added instead.