### PR TITLE
Improvement/bar width

### DIFF
--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Helpers, Path, CommonProps } from "victory-core";
-import { assign, isObject } from "lodash";
+import { assign, isObject, isFunction } from "lodash";
 import * as d3Shape from "d3-shape";
 
 export default class Bar extends React.Component {
@@ -10,6 +10,10 @@ export default class Bar extends React.Component {
     ...CommonProps.primitiveProps,
     alignment: PropTypes.oneOf(["start", "middle", "end"]),
     barRatio: PropTypes.number,
+    barWidth: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.func
+    ]),
     cornerRadius: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.func,
@@ -20,10 +24,6 @@ export default class Bar extends React.Component {
     ]),
     datum: PropTypes.object,
     horizontal: PropTypes.bool,
-    padding: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.object
-    ]),
     pathComponent: PropTypes.element,
     width: PropTypes.number,
     x: PropTypes.number,
@@ -187,10 +187,12 @@ export default class Bar extends React.Component {
   }
 
   getBarWidth(props, style) {
-    if (style.width) {
+    const { active, scale, data, barWidth, defaultBarWidth } = props;
+    if (barWidth) {
+      return isFunction(barWidth) ? Helpers.evaluateProp(barWidth, active) : barWidth;
+    } else if (style.width) {
       return style.width;
     }
-    const { scale, data, defaultBarWidth } = props;
     const range = scale.x.range();
     const extent = Math.abs(range[1] - range[0]);
     const bars = data.length + 2;

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -32,7 +32,7 @@ const getCalculatedValues = (props) => {
     y: horizontal ? xScale : yScale
   };
   const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-  return { style, data, scale, domain, origin, padding };
+  return { style, data, scale, domain, origin };
 };
 
 const getBaseProps = (props, fallbackProps) => {

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -32,7 +32,7 @@ const getCalculatedValues = (props) => {
     y: horizontal ? xScale : yScale
   };
   const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-  return { style, data, scale, domain, origin };
+  return { style, data, scale, domain, origin, padding };
 };
 
 const getBaseProps = (props, fallbackProps) => {
@@ -40,7 +40,7 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
-    polar, scale, sharedEvents, standalone, style, theme, width, labels, name
+    polar, scale, sharedEvents, standalone, style, theme, width, labels, name, barWidth
   } = props;
   const initialChildProps = { parent: {
     domain, scale, width, height, data, standalone, name,
@@ -51,8 +51,8 @@ const getBaseProps = (props, fallbackProps) => {
     const eventKey = datum.eventKey || index;
     const { x, y, y0, x0 } = getBarPosition(props, datum);
     const dataProps = {
-      alignment, barRatio, cornerRadius, data, datum, horizontal, index, padding, polar, origin,
-      scale, style: style.data, width, height, x, y, y0, x0
+      alignment, barRatio, cornerRadius, data, datum, horizontal, index, polar, origin,
+      scale, style: style.data, width, height, x, y, y0, x0, barWidth
     };
 
     childProps[eventKey] = {

--- a/packages/victory-bar/src/victory-bar.js
+++ b/packages/victory-bar/src/victory-bar.js
@@ -48,6 +48,10 @@ class VictoryBar extends React.Component {
     ...CommonProps.dataProps,
     alignment: PropTypes.oneOf(["start", "middle", "end"]),
     barRatio: PropTypes.number,
+    barWidth: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.func
+    ]),
     cornerRadius: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.func,

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -1,4 +1,4 @@
-/*eslint no-magic-numbers: ["error", { "ignore": [0, 1, 0.5, 2] }]*/
+/*eslint no-magic-numbers: ["error", { "ignore": [0, 0.5, 1, 2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
 import { Helpers, CommonProps, Rect, Line } from "victory-core";
@@ -27,13 +27,14 @@ export default class Candle extends React.Component {
   }
 
   static defaultProps = {
+    defaultCandleWidth: 8,
     groupComponent: <g/>,
     lineComponent: <Line/>,
     rectComponent: <Rect/>
   };
 
   getCandleWidth(props, style) {
-    const { active, datum, data, candleWidth, scale } = props;
+    const { active, datum, data, candleWidth, scale, defaultCandleWidth } = props;
     if (candleWidth) {
       return isFunction(candleWidth) ?
         Helpers.evaluateProp(candleWidth, datum, active) : candleWidth;
@@ -44,7 +45,6 @@ export default class Candle extends React.Component {
     const extent = Math.abs(range[1] - range[0]);
     const candles = data.length + 2;
     const candleRatio = props.candleRatio || 0.5;
-    const defaultCandleWidth = 8;
     const defaultWidth = candleRatio * (data.length < 2 ? defaultCandleWidth : extent / candles);
     return Math.max(1, defaultWidth);
   }

--- a/packages/victory-candlestick/src/helper-methods.js
+++ b/packages/victory-candlestick/src/helper-methods.js
@@ -41,7 +41,6 @@ const getCalculatedValues = (props) => {
   const defaultStyle = theme && theme.candlestick && theme.candlestick.style ?
     theme.candlestick.style : {};
   const style = Helpers.getStyles(props.style, defaultStyle);
-  const padding = Helpers.getPadding(props);
   const data = getData(props);
   const range = {
     x: Helpers.getRange(props, "x"),
@@ -56,7 +55,7 @@ const getCalculatedValues = (props) => {
     y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
   };
   const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-  return { domain, data, scale, style, origin, padding };
+  return { domain, data, scale, style, origin };
 };
 
 const isTransparent = (attr) => {
@@ -96,7 +95,7 @@ const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-stat
   const calculatedValues = getCalculatedValues(props);
   const { data, style, scale, domain, origin } = calculatedValues;
   const {
-    groupComponent, width, height, padding, standalone, name, candleWidth,
+    groupComponent, width, height, padding, standalone, name, candleWidth, candleRatio,
     theme, polar, wickStrokeWidth, labels, events, sharedEvents
   } = props;
   const initialChildProps = { parent: {
@@ -113,7 +112,7 @@ const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-stat
     const low = scale.y(datum._low);
     const dataStyle = getDataStyles(datum, style.data, props);
     const dataProps = {
-      x, high, low, candleWidth, scale, data, datum, groupComponent, index,
+      x, high, low, candleWidth, candleRatio, scale, data, datum, groupComponent, index,
       style: dataStyle, width, polar, origin, wickStrokeWidth, open, close
     };
 

--- a/packages/victory-candlestick/src/helper-methods.js
+++ b/packages/victory-candlestick/src/helper-methods.js
@@ -41,6 +41,7 @@ const getCalculatedValues = (props) => {
   const defaultStyle = theme && theme.candlestick && theme.candlestick.style ?
     theme.candlestick.style : {};
   const style = Helpers.getStyles(props.style, defaultStyle);
+  const padding = Helpers.getPadding(props);
   const data = getData(props);
   const range = {
     x: Helpers.getRange(props, "x"),
@@ -55,9 +56,8 @@ const getCalculatedValues = (props) => {
     y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
   };
   const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-  return { domain, data, scale, style, origin };
+  return { domain, data, scale, style, origin, padding };
 };
-
 
 const isTransparent = (attr) => {
   return attr === "none" || attr === "transparent";
@@ -96,7 +96,7 @@ const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-stat
   const calculatedValues = getCalculatedValues(props);
   const { data, style, scale, domain, origin } = calculatedValues;
   const {
-    groupComponent, width, height, padding, standalone, name,
+    groupComponent, width, height, padding, standalone, name, candleWidth,
     theme, polar, wickStrokeWidth, labels, events, sharedEvents
   } = props;
   const initialChildProps = { parent: {
@@ -111,11 +111,10 @@ const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-stat
     const close = scale.y(datum._close);
     const open = scale.y(datum._open);
     const low = scale.y(datum._low);
-    const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
     const dataStyle = getDataStyles(datum, style.data, props);
     const dataProps = {
-      x, high, low, candleHeight, scale, data, datum, groupComponent, index,
-      style: dataStyle, padding, width, polar, origin, wickStrokeWidth, open, close
+      x, high, low, candleWidth, scale, data, datum, groupComponent, index,
+      style: dataStyle, width, polar, origin, wickStrokeWidth, open, close
     };
 
     childProps[eventKey] = {

--- a/packages/victory-candlestick/src/victory-candlestick.js
+++ b/packages/victory-candlestick/src/victory-candlestick.js
@@ -43,6 +43,11 @@ class VictoryCandlestick extends React.Component {
     ...CommonProps.baseProps,
     ...CommonProps.dataProps,
     candleColors: PropTypes.shape({ positive: PropTypes.string, negative: PropTypes.string }),
+    candleRatio: PropTypes.number,
+    candleWidth: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.number
+    ]),
     close: PropTypes.oneOfType([
       PropTypes.func,
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),

--- a/test/client/spec/victory-bar/bar.spec.js
+++ b/test/client/spec/victory-bar/bar.spec.js
@@ -15,8 +15,6 @@ describe("victory-primitives/bar", () => {
     x: 2,
     y: 10,
     y0: 0,
-    width: 5,
-    padding: 2,
     scale: {
       x: d3Scale.scaleLinear(),
       y: d3Scale.scaleLinear()

--- a/test/client/spec/victory-candlestick/candle.spec.js
+++ b/test/client/spec/victory-candlestick/candle.spec.js
@@ -2,7 +2,8 @@ import React from "react";
 import { shallow } from "enzyme";
 import Candle from "packages/victory-candlestick/src/candle";
 import { Line, Rect } from "packages/victory-core";
-import { merge } from "lodash";
+import * as d3Scale from "d3-scale";
+import { assign } from "lodash";
 
 describe("victory-primitives/candle", () => {
   const baseProps = {
@@ -11,14 +12,16 @@ describe("victory-primitives/candle", () => {
       { x: 2, open: 40, close: 80, high: 100, low: 10, eventKey: 1 }
     ],
     datum: { x: 1, open: 10, close: 30, high: 50, low: 5, eventKey: 0 },
+    scale: {
+      x: d3Scale.scaleLinear(),
+      y: d3Scale.scaleLinear()
+    },
+    candleWidth: 2,
     x: 5,
     high: 50,
     low: 5,
     close: 30,
-    open: 10,
-    candleHeight: 20,
-    width: 10,
-    padding: 1
+    open: 10
   };
 
   it("should render a wick line", () => {
@@ -58,8 +61,9 @@ describe("victory-primitives/candle", () => {
     expect(rect.prop("y")).to.eql(10);
   });
 
-  it("should allow style to override width", () => {
-    const props = merge({}, baseProps, {
+  it("should use width from style when no candleWidth is given", () => {
+    const props = assign({}, baseProps, {
+      candleWidth: undefined,
       style: {
         width: 5
       }


### PR DESCRIPTION
This PR: 
- Adds `barWidth` and `candleWidth` ratios to `VictoryBar` and `VictoryCandlestick` respectively. These props should be used in place of `width` on styles. This change was made because `width` as it is used in these components is not a standard svg style attribute. This change should reduce confusion.
- _Does not_ deprecate the use of `width` in styles for `VictoryBar` or `VictoryCandlestick`, however, the new props will take precedence.
- Adds a `candleRatio` prop that works the same was as `barRatio` 
- Cleans up methods and props on `Bar` and `Candle` primitive components