### PR TITLE
Improvement/domain padding

### DIFF
--- a/packages/victory-core/src/victory-util/domain.js
+++ b/packages/victory-core/src/victory-util/domain.js
@@ -76,12 +76,12 @@ function padDomain(domain, props, axis) {
   const range = Helpers.getRange(props, axis);
   const rangeExtent = Math.abs(range[0] - range[1]);
   const paddedRangeExtent = Math.max(rangeExtent - padding.left - padding.right, 1);
-  const newDomainExtent = (Math.abs(max - min) / paddedRangeExtent) * rangeExtent;
+  const domainExtent = (Math.abs(max - min) / paddedRangeExtent) * rangeExtent;
 
   // Naive initial padding calculation
   const initialPadding = {
-    left: newDomainExtent * padding.left / rangeExtent,
-    right: newDomainExtent * padding.right / rangeExtent
+    left: domainExtent * padding.left / rangeExtent,
+    right: domainExtent * padding.right / rangeExtent
   };
 
   const singleQuadrantDomainPadding = isPlainObject(props.singleQuadrantDomainPadding) ?

--- a/packages/victory-core/src/victory-util/domain.js
+++ b/packages/victory-core/src/victory-util/domain.js
@@ -75,11 +75,13 @@ function padDomain(domain, props, axis) {
   const max = Collection.getMaxValue(domain);
   const range = Helpers.getRange(props, axis);
   const rangeExtent = Math.abs(range[0] - range[1]);
+  const paddedRangeExtent = Math.max(rangeExtent - padding.left - padding.right, 1);
+  const newDomainExtent = (Math.abs(max - min) / paddedRangeExtent) * rangeExtent;
 
   // Naive initial padding calculation
   const initialPadding = {
-    left: Math.abs(max - min) * padding.left / rangeExtent,
-    right: Math.abs(max - min) * padding.right / rangeExtent
+    left: newDomainExtent * padding.left / rangeExtent,
+    right: newDomainExtent * padding.right / rangeExtent
   };
 
   const singleQuadrantDomainPadding = isPlainObject(props.singleQuadrantDomainPadding) ?
@@ -95,21 +97,9 @@ function padDomain(domain, props, axis) {
   };
 
   // Adjust the domain by the initial padding
-  const adjustedDomain = {
+  const paddedDomain = {
     min: adjust(min.valueOf() - initialPadding.left, "min"),
     max: adjust(max.valueOf() + initialPadding.right, "max")
-  };
-
-  // re-calculate padding, taking the adjusted domain into account
-  const finalPadding = {
-    left: Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.left / rangeExtent,
-    right: Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.right / rangeExtent
-  };
-
-  // Adjust the domain by the final padding
-  const paddedDomain = {
-    min: adjust(min.valueOf() - finalPadding.left, "min"),
-    max: adjust(max.valueOf() + finalPadding.right, "max")
   };
 
   // default to minDomain / maxDomain if they exist

--- a/test/client/spec/victory-core/victory-util/domain.spec.js
+++ b/test/client/spec/victory-core/victory-util/domain.spec.js
@@ -59,10 +59,11 @@ describe("victory-util/domain", () => {
         const domainPadding = { x: pad };
         const props = { ...baseProps, domainPadding };
         const paddedDomain = Domain.formatDomain(domain, props, "x");
-        const adjustedDomain = domain[1] + pad;
-        const adjustedPercent = adjustedDomain / (baseProps.width - baseProps.padding);
-        const totalPadding = adjustedPercent * pad;
-        expect(paddedDomain).to.eql([0, domain[1] + totalPadding]);
+        const rangeExtent = baseProps.width - baseProps.padding;
+        const paddedRangeExtent = rangeExtent - 2 * pad;
+        const domainExtent = (Math.abs(domain[0] - domain[1]) / paddedRangeExtent) * rangeExtent;
+        const percent = domainExtent / rangeExtent;
+        expect(paddedDomain).to.eql([0, domain[1] + pad * percent]);
       });
     });
 


### PR DESCRIPTION
Figured out a better way to calculate the final padded domain from initial domain and domainPadding

closes https://github.com/FormidableLabs/victory/issues/472

This issue was complex because altering the domain impacted the relationship between domain and range.

For example: imagine a chart 100 pixels wide expressing data from x = 10 to x = 11. The chart is one _data unit_ wide and 100 pixel units wide. To pad the domain by 10 _pixels_ we were previously:
1) converting padding to data units (data width / pixel width * pixel padding) `1 / 100 * 10 = 0.1`
2) adding the padding to the original domain `[10 - 0.1, 11 + 0.1] = [9.9, 11.1]`
3) Repeating this calculation with the new domain to take into account how the padding impacted the data width / pixel width ratio `(11.1 - 9.9) / 100 * 10 = 0.1) ->  [10 - 0.1, 11 + 0.1] = [9.88, 11.12]`

Better: 
1) reduce the pixel width (range) by the desired padding `100 - 2 * 10 = 80`
2) calculate the data / pixel ratio using the _old data width_ and the _new pixel width_ `1 / 80 = 0.0125` 
3) Multiply the ratio by domainPadding to find the new domain
``[10 - (0.0125 * 10), 11 + (0.0125 * 10)] = [9.875, 11.125]`