### PR TITLE
fix inconsistent behavior with BrushContainer + minor bug

### DIFF
--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -246,8 +246,9 @@ const Helpers = {
     const {
       x1, y1, x2, y2, onBrushDomainChange, onBrushCleared, domain, allowResize, defaultBrushArea
     } = targetProps;
-    // if the mouse hasn't moved since a mouseDown event, select the whole domain region
-    if (allowResize && x1 === x2 || y1 === y2) {
+    // if the mouse hasn't moved since a mouseDown event, select the default brush area
+    const defaultBrushHasArea = defaultBrushArea !== undefined && defaultBrushArea !== "none";
+    if ((allowResize || defaultBrushHasArea) && (x1 === x2 || y1 === y2)) {
       const cachedDomain = targetProps.cachedCurrentDomain || targetProps.currentDomain;
       const currentDomain = this.getDefaultBrushArea(defaultBrushArea, domain, cachedDomain);
       const mutatedProps = { isPanning: false, isSelecting: false, currentDomain };


### PR DESCRIPTION
The inconsistent behavior is a discrepancy in how the brush container handles redrawing the brush depending on the value of the allowResize prop if defaultArea is set to 'disable'  

Here's a quick demo: https://codesandbox.io/s/4jvl663pkw

This PR makes two changes, both small:

* fix a bug in a conditional check. I caught this by dumb luck, this bug is only surfaced if you defined brushDimension="x" and allowResize="false" on the brush container.
* added a check if the defaultBrushArea is defined and has area, for consistency with the behavior described in the [documentation](https://formidable.com/open-source/victory/docs/victory-brush-container/#defaultbrusharea)


I didn't add unit tests since there didn't seem to be any around the events for the brush helper. I feel bad submitting a PR without unit tests - I'm happy to add some if y'all have guidance on a preferred approach to testing this.