### PR TITLE
Bug/incorrect transform

### DIFF
--- a/demo/components/victory-label-demo.js
+++ b/demo/components/victory-label-demo.js
@@ -13,6 +13,7 @@ export default class App extends React.Component {
 
           <circle cx="0" cy="0" r="2" fill="red"/>
           <VictoryLabel
+            transform="translate(50)"
             x={0} y={0}
             text={"Victory is awesome.\nThis is default anchoring.\nCapisce?"}
           />
@@ -104,7 +105,7 @@ export default class App extends React.Component {
           <VictoryLabel x={0} y={1800} textAnchor="start" verticalAnchor="start"
             text={["Use", "dx", "attribute", "to", "shift", "labels", "relative to one another."]}
             inline
-            dx={"10"}
+            dx={10}
           />
 
           {/**

--- a/packages/victory-core/src/victory-util/style.js
+++ b/packages/victory-core/src/victory-util/style.js
@@ -12,9 +12,9 @@ const toTransformString = function (obj, ...more) {
   if (more.length > 0) {
     return more.reduce((memo, currentObj) => {
       return [memo, toTransformString(currentObj)].join(" ");
-    }, toTransformString(obj));
+    }, toTransformString(obj)).trim();
   } else {
-    if (obj === undefined || typeof obj === "string") {
+    if (obj === undefined || obj === null || typeof obj === "string") {
       return obj;
     }
     const transforms = [];
@@ -24,7 +24,7 @@ const toTransformString = function (obj, ...more) {
         transforms.push(`${key}(${value})`);
       }
     }
-    return transforms.join(" ");
+    return transforms.join(" ").trim();
   }
 };
 

--- a/packages/victory-core/src/victory-util/style.js
+++ b/packages/victory-core/src/victory-util/style.js
@@ -1,4 +1,3 @@
-import { isPlainObject } from "lodash";
 /**
  * Given an object with CSS/SVG transform definitions, return the string value
  * for use with the `transform` CSS property or SVG attribute. Note that we

--- a/packages/victory-core/src/victory-util/style.js
+++ b/packages/victory-core/src/victory-util/style.js
@@ -1,4 +1,4 @@
-
+import { isPlainObject } from "lodash";
 /**
  * Given an object with CSS/SVG transform definitions, return the string value
  * for use with the `transform` CSS property or SVG attribute. Note that we
@@ -14,7 +14,7 @@ const toTransformString = function (obj, ...more) {
       return [memo, toTransformString(currentObj)].join(" ");
     }, toTransformString(obj));
   } else {
-    if (!obj || typeof obj === "string") {
+    if (obj === undefined || typeof obj === "string") {
       return obj;
     }
     const transforms = [];

--- a/test/client/spec/victory-core/victory-util/style.spec.js
+++ b/test/client/spec/victory-core/victory-util/style.spec.js
@@ -19,7 +19,7 @@ describe("toTransformString", () => {
 
   it("returns at least the subsequent transforms if the first is undefined", () => {
     expect(Style.toTransformString(
-      null, { skewY: [65] }
-    )).to.contain("skewY(65)");
+      undefined, { skewY: [65] }
+    )).to.equal("skewY(65)");
   });
 });


### PR DESCRIPTION
transforms were allowing trailing spaces and zeroes. This PR corrects falsey checking and trims transform strings. Also increases specificity of test that was failing to catch this error (use `expect... to.equal` instead of `contains`)

Supports https://github.com/FormidableLabs/victory-native/issues/366