### PR TITLE
Improvement/language direction

### DIFF
--- a/demo/components/victory-label-demo.js
+++ b/demo/components/victory-label-demo.js
@@ -13,8 +13,9 @@ export default class App extends React.Component {
 
           <circle cx="0" cy="0" r="2" fill="red"/>
           <VictoryLabel
+            style={{ direction: "ltr" }}
             x={0} y={0}
-            text={"Victory is awesome.\nThis is default anchoring.\nCapisce?"}
+            text={"Victory is awesome.\nThis is default anchoring.\nسلام?"}
           />
 
           <circle cx="200" cy="50" r="2" fill="red"/>
@@ -33,13 +34,9 @@ export default class App extends React.Component {
           />
 
           <circle cx="300" cy="150" r="2" fill="green"/>
-          <VictoryLabel x={300} y={150} textAnchor="end" verticalAnchor="start"
-            style={[
-              { fill: "tomato", fontSize: 20 },
-              { fill: "blue", fontSize: 15, angle: 45 },
-              { fill: "black", fontSize: 10, padding: 10, textAnchor: "middle" }
-            ]}
-            text={"Victory is awesome.\nThis is (end, start) anchoring.\nOK?"}
+          <VictoryLabel direction="rtl" verticalAnchor="start"
+            style={[{ fill: "red", fontSize: 20 }]}
+            text={"سلام world"}
           />
 
           <circle cx="300" cy="300" r="2" fill="blue"/>

--- a/packages/victory-core/src/victory-label/victory-label.js
+++ b/packages/victory-core/src/victory-label/victory-label.js
@@ -35,6 +35,7 @@ export default class VictoryLabel extends React.Component {
     data: PropTypes.array,
     datum: PropTypes.any,
     desc: PropTypes.string,
+    direction: PropTypes.oneOf(["rtl", "ltr", "inherit"]),
     dx: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
@@ -106,6 +107,7 @@ export default class VictoryLabel extends React.Component {
   };
 
   static defaultProps = {
+    direction: "inherit",
     textComponent: <Text/>,
     tspanComponent: <TSpan/>,
     capHeight: 0.71, // Magic number from d3.
@@ -217,7 +219,7 @@ export default class VictoryLabel extends React.Component {
   }
 
   renderElements(props, content) {
-    const { datum, active, inline, className, title, desc, events } = props;
+    const { datum, active, inline, className, title, desc, events, direction } = props;
     const style = this.getStyles(props);
     const lineHeight = this.getHeight(props, "lineHeight");
     const textAnchor = props.textAnchor ?
@@ -248,7 +250,7 @@ export default class VictoryLabel extends React.Component {
     });
     return React.cloneElement(
       props.textComponent,
-      { dx, dy, x, y, events, transform, className, title, desc, id: this.id },
+      { direction, dx, dy, x, y, events, transform, className, title, desc, id: this.id },
       textChildren
     );
   }

--- a/packages/victory-core/src/victory-primitives/text.js
+++ b/packages/victory-core/src/victory-primitives/text.js
@@ -7,6 +7,7 @@ export default class Text extends React.Component {
     children: PropTypes.node,
     className: PropTypes.string,
     desc: PropTypes.string,
+    direction: PropTypes.oneOf(["ltr", "rtl", "inherit"]),
     dx: PropTypes.number,
     dy: PropTypes.number,
     events: PropTypes.object,
@@ -29,10 +30,11 @@ export default class Text extends React.Component {
 
   render() {
     const {
-      x, y, dx, dy, events, className, children, style, title, desc, transform
+      x, y, dx, dy, events, className, children, style, title, desc, transform, direction
     } = this.props;
     return (
       <text
+        direction={direction}
         className={className} x={x} dx={dx} y={y} dy={dy}
         transform={transform} style={style}
         {...events}


### PR DESCRIPTION
This PR adds support for a direction prop on `VictoryLabel` that gets passed to `Text`. Options for this prop are "rtl", "ltr" and "inherit". The default value of this prop is "inherit"

fixes https://github.com/FormidableLabs/victory/issues/1086