### PR TITLE
Call labels with the appropriate params.

### DIFF
--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -159,7 +159,7 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
     const componentStyleArray = type === "flyout" ?
       componentProps.flyoutStyle : componentProps.style;
     return points.reduce((memo, point, index) => {
-      const text = Helpers.evaluateProp(labels, point, true);
+      const text = isFunction(labels) ? labels(point, index, points) : undefined;
       const textArray = text !== undefined ? `${text}`.split("\n") : [];
       const baseStyle = point.style && point.style[type] || {};
       const componentStyle = Array.isArray(componentStyleArray) ?


### PR DESCRIPTION
Call the `labels` function in VictoryVoronoiContainer consistently with the same params (`point, index, points` as documented instead of `point, active` in `getStyle`).