### PR TITLE
Change cursor when allowResize and allowDrag are false

### DIFF
--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -83,6 +83,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     const { x, y } = coordinates;
     const { brushStyle, brushComponent, name } = props;
     const brushComponentStyle = brushComponent.props && brushComponent.props.style;
+    const cursor = !props.allowDrag && !props.allowResize ? "pointer" : "move";
     return x[0] !== x[1] && y[0] !== y[1] ?
       React.cloneElement(brushComponent, {
         key: `${name}-brush`,
@@ -90,7 +91,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
         height: Math.abs(y[1] - y[0]) || 1,
         x: Math.min(x[0], x[1]),
         y: Math.min(y[0], y[1]),
-        cursor: "move",
+        cursor,
         style: defaults({}, brushComponentStyle, brushStyle)
       }) : null;
   }
@@ -103,7 +104,14 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     const handleComponentStyle = handleComponent.props && handleComponent.props.style || {};
     const style = defaults({}, handleComponentStyle, handleStyle);
     const yProps = { style, width, height: handleWidth, cursor: "ns-resize" };
-    const xProps = { style, width: handleWidth, height, cursor: "ew-resize" };
+    let xProps = { style, width: handleWidth, height, cursor: "ew-resize" };
+
+    if (!props.allowResize && props.allowDrag) {
+      xProps = assign(xProps, { cursor: "move" });
+    } else if (!props.allowDrag && !props.allowResize) {
+      xProps = assign(xProps, { cursor: "pointer" });
+    }
+
     const handleProps = {
       top: brushDimension !== "x" && assign({ x: x[0], y: y[1] - (handleWidth / 2) }, yProps),
       bottom: brushDimension !== "x" && assign({ x: x[0], y: y[0] - (handleWidth / 2) }, yProps),

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -97,18 +97,18 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   }
 
   getCursorPointers(props) {
-    const pointers = {
+    const cursors = {
       "yProps": "ns-resize",
       "xProps": "ew-resize"
     };
     if (!props.allowResize && props.allowDrag) {
-      pointers.xProps = "move";
-      pointers.yProps = "auto";
+      cursors.xProps = "move";
+      cursors.yProps = "auto";
     } else if (!props.allowResize && !props.allowDrag) {
-      pointers.xProps = "auto";
-      pointers.yProps = "auto";
+      cursors.xProps = "auto";
+      cursors.yProps = "auto";
     }
-    return pointers;
+    return cursors;
   }
 
   getHandles(props, coordinates) {
@@ -119,9 +119,9 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     const handleComponentStyle = handleComponent.props && handleComponent.props.style || {};
     const style = defaults({}, handleComponentStyle, handleStyle);
 
-    const pointers = this.getCursorPointers(props);
-    const yProps = { style, width, height: handleWidth, cursor: pointers.yProps };
-    const xProps = { style, width: handleWidth, height, cursor: pointers.xProps };
+    const cursors = this.getCursorPointers(props);
+    const yProps = { style, width, height: handleWidth, cursor: cursors.yProps };
+    const xProps = { style, width: handleWidth, height, cursor: cursors.xProps };
 
     const handleProps = {
       top: brushDimension !== "x" && assign({ x: x[0], y: y[1] - (handleWidth / 2) }, yProps),

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -103,7 +103,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     };
     if (!props.allowResize && props.allowDrag) {
       cursors.xProps = "move";
-      cursors.yProps = "auto";
+      cursors.yProps = "move";
     } else if (!props.allowResize && !props.allowDrag) {
       cursors.xProps = "auto";
       cursors.yProps = "auto";

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -83,7 +83,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     const { x, y } = coordinates;
     const { brushStyle, brushComponent, name } = props;
     const brushComponentStyle = brushComponent.props && brushComponent.props.style;
-    const cursor = !props.allowDrag && !props.allowResize ? "pointer" : "move";
+    const cursor = !props.allowDrag && !props.allowResize ? "auto" : "move";
     return x[0] !== x[1] && y[0] !== y[1] ?
       React.cloneElement(brushComponent, {
         key: `${name}-brush`,
@@ -103,15 +103,17 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     const height = Math.abs(y[1] - y[0]) || 1;
     const handleComponentStyle = handleComponent.props && handleComponent.props.style || {};
     const style = defaults({}, handleComponentStyle, handleStyle);
-    const yProps = { style, width, height: handleWidth, cursor: "ns-resize" };
+
+    let yProps = { style, width, height: handleWidth, cursor: "ns-resize" };
     let xProps = { style, width: handleWidth, height, cursor: "ew-resize" };
 
     if (!props.allowResize && props.allowDrag) {
       xProps = assign(xProps, { cursor: "move" });
-    } else if (!props.allowDrag && !props.allowResize) {
-      xProps = assign(xProps, { cursor: "pointer" });
+      yProps = assign(yProps, { cursor: "auto" });
+    } else if (!props.allowResize && !props.allowDrag) {
+      xProps = assign(xProps, { cursor: "auto" });
+      yProps = assign(yProps, { cursor: "auto" });
     }
-
     const handleProps = {
       top: brushDimension !== "x" && assign({ x: x[0], y: y[1] - (handleWidth / 2) }, yProps),
       bottom: brushDimension !== "x" && assign({ x: x[0], y: y[0] - (handleWidth / 2) }, yProps),

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -96,6 +96,21 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
       }) : null;
   }
 
+  getCursorPointers(props) {
+    const pointers = {
+      "yProps": "ns-resize",
+      "xProps": "ew-resize"
+    };
+    if (!props.allowResize && props.allowDrag) {
+      pointers.xProps = "move";
+      pointers.yProps = "auto";
+    } else if (!props.allowResize && !props.allowDrag) {
+      pointers.xProps = "auto";
+      pointers.yProps = "auto";
+    }
+    return pointers;
+  }
+
   getHandles(props, coordinates) {
     const { brushDimension, handleWidth, handleStyle, handleComponent, name } = props;
     const { x, y } = coordinates;
@@ -104,16 +119,10 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     const handleComponentStyle = handleComponent.props && handleComponent.props.style || {};
     const style = defaults({}, handleComponentStyle, handleStyle);
 
-    let yProps = { style, width, height: handleWidth, cursor: "ns-resize" };
-    let xProps = { style, width: handleWidth, height, cursor: "ew-resize" };
+    const pointers = this.getCursorPointers(props);
+    const yProps = { style, width, height: handleWidth, cursor: pointers.yProps };
+    const xProps = { style, width: handleWidth, height, cursor: pointers.xProps };
 
-    if (!props.allowResize && props.allowDrag) {
-      xProps = assign(xProps, { cursor: "move" });
-      yProps = assign(yProps, { cursor: "auto" });
-    } else if (!props.allowResize && !props.allowDrag) {
-      xProps = assign(xProps, { cursor: "auto" });
-      yProps = assign(yProps, { cursor: "auto" });
-    }
     const handleProps = {
       top: brushDimension !== "x" && assign({ x: x[0], y: y[1] - (handleWidth / 2) }, yProps),
       bottom: brushDimension !== "x" && assign({ x: x[0], y: y[0] - (handleWidth / 2) }, yProps),


### PR DESCRIPTION
This fixes VictoryBrushContainer should not show "rezise-cursor" when allowResize property is false, https://github.com/FormidableLabs/victory/issues/1095