### PR TITLE
Fix issue #1120

### DIFF
--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -86,7 +86,8 @@ export default class Bar extends React.Component {
 
   getCustomBarPath(props, width) {
     const { getPath } = props;
-    return getPath(this.getPosition(props, width));
+    const propsWithCalculatedValues = { ...props, ...this.getPosition(props, width) };
+    return getPath(propsWithCalculatedValues);
   }
 
   transformAngle(angle) {
@@ -140,8 +141,8 @@ export default class Bar extends React.Component {
     }
   }
 
-  getCustomVerticalPolarBarPath(getPath, options) {
-    return getPath(options);
+  getCustomVerticalPolarBarPath(getPath, props) {
+    return getPath(props);
   }
 
   getVerticalPolarBarPath(props, cornerRadius) { // eslint-disable-line max-statements
@@ -165,8 +166,9 @@ export default class Bar extends React.Component {
     start = this.transformAngle(start);
     end = this.transformAngle(end);
     if (props.getPath) {
-      const options = { datum, start, end, r1, r2, cornerRadius };
-      return this.getCustomVerticalPolarBarPath(props.getPath, options);
+      const options = { startAngle: start, endAngle: end, r1, r2, cornerRadius };
+      const propsWithCalculatedValues = { ...props, ...options };
+      return this.getCustomVerticalPolarBarPath(props.getPath, propsWithCalculatedValues);
     }
 
     const getPath = (edge) => {

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -40,7 +40,7 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
-    polar, scale, sharedEvents, standalone, style, theme, width, labels, name, barWidth
+    polar, scale, sharedEvents, standalone, style, theme, width, labels, name, barWidth, getPath
   } = props;
   const initialChildProps = { parent: {
     domain, scale, width, height, data, standalone, name,
@@ -52,7 +52,7 @@ const getBaseProps = (props, fallbackProps) => {
     const { x, y, y0, x0 } = getBarPosition(props, datum);
     const dataProps = {
       alignment, barRatio, cornerRadius, data, datum, horizontal, index, polar, origin,
-      scale, style: style.data, width, height, x, y, y0, x0, barWidth
+      scale, style: style.data, width, height, x, y, y0, x0, barWidth, getPath
     };
 
     childProps[eventKey] = {

--- a/packages/victory-bar/src/victory-bar.js
+++ b/packages/victory-bar/src/victory-bar.js
@@ -60,6 +60,7 @@ class VictoryBar extends React.Component {
         bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
       })
     ]),
+    getPath: PropTypes.func,
     horizontal: PropTypes.bool
   };
 

--- a/stories/victory-bar.js
+++ b/stories/victory-bar.js
@@ -104,8 +104,8 @@ storiesOf("VictoryBar.cornerRadius", module)
 storiesOf("VictoryBar.getPath", module)
   .addDecorator(getChartDecorator({ domainPadding: 25 }))
   .add("custom bar path (vertical)", () => {
-    const getPathFn = (options) => {
-      const { x0, x1, y0, y1 } = options;
+    const getPathFn = (props) => {
+      const { x0, x1, y0, y1 } = props;
       return `M ${x0}, ${y0}
         L ${(x1 + x0) / 2}, ${y1}
         L ${x1}, ${y0}
@@ -116,8 +116,8 @@ storiesOf("VictoryBar.getPath", module)
     );
   })
   .add("custom bar path (horizontal)", () => {
-    const getPathFn = (options) => {
-      const { x0, x1, y0, y1 } = options;
+    const getPathFn = (props) => {
+      const { x0, x1, y0, y1 } = props;
       return `M ${y0}, ${x0}
         L ${y1}, ${(x0 + x1) / 2}
         L ${y0}, ${x1}
@@ -131,13 +131,13 @@ storiesOf("VictoryBar.getPath", module)
 storiesOf("VictoryBar.getPath", module)
   .addDecorator(getPolarChartDecorator())
   .add("custom bar path (polar)", () => {
-    const getPathFn = (options) => {
-      const { datum, start, end, r1, r2 } = options;
+    const getPathFn = (props) => {
+      const { datum, startAngle, endAngle, r1, r2 } = props;
       const pathFunction = d3Shape.arc()
       .innerRadius(r1)
       .outerRadius(r2)
-      .startAngle(end)
-      .endAngle(start)
+      .startAngle(endAngle)
+      .endAngle(startAngle)
       .cornerRadius(0);
       const path = pathFunction();
       const coords = path.split(/[A-Z]/).slice(1);

--- a/stories/victory-bar.js
+++ b/stories/victory-bar.js
@@ -8,7 +8,7 @@ import { VictoryTooltip } from "../packages/victory-tooltip/src/index";
 import { VictoryTheme } from "../packages/victory-core/src/index";
 import { getData, getStackedData, getMixedData, getTimeData, getLogData } from "./data";
 import { getChartDecorator, getPolarChartDecorator } from "./decorators";
-
+import * as d3Shape from "d3-shape";
 
 storiesOf("VictoryBar", module)
   .add("default rendering", () => <VictoryBar/>);
@@ -100,6 +100,75 @@ storiesOf("VictoryBar.cornerRadius", module)
     <VictoryBar horizontal data={getMixedData(5)} cornerRadius={5}/>
   ))
   .add("cornerRadius = 3 (20 bars)", () => <VictoryBar data={getData(20)} cornerRadius={3}/>);
+
+storiesOf("VictoryBar.getPath", module)
+  .addDecorator(getChartDecorator({ domainPadding: 25 }))
+  .add("custom bar path (vertical)", () => {
+    const getPathFn = (options) => {
+      const { x0, x1, y0, y1 } = options;
+      return `M ${x0}, ${y0}
+        L ${(x1 + x0) / 2}, ${y1}
+        L ${x1}, ${y0}
+        z`;
+    };
+    return (
+      <VictoryBar data={getData(7)} getPath={getPathFn}/>
+    );
+  })
+  .add("custom bar path (horizontal)", () => {
+    const getPathFn = (options) => {
+      const { x0, x1, y0, y1 } = options;
+      return `M ${y0}, ${x0}
+        L ${y1}, ${(x0 + x1) / 2}
+        L ${y0}, ${x1}
+        z`;
+    };
+    return (
+      <VictoryBar data={getData(4)} horizontal getPath={getPathFn}/>
+    );
+  });
+
+storiesOf("VictoryBar.getPath", module)
+  .addDecorator(getPolarChartDecorator())
+  .add("custom bar path (polar)", () => {
+    const getPathFn = (options) => {
+      const { datum, start, end, r1, r2 } = options;
+      const pathFunction = d3Shape.arc()
+      .innerRadius(r1)
+      .outerRadius(r2)
+      .startAngle(end)
+      .endAngle(start)
+      .cornerRadius(0);
+      const path = pathFunction();
+      const coords = path.split(/[A-Z]/).slice(1);
+      // add a star symbol to the end of each bar
+      const star = d3Shape.symbol().size(datum.y * 20).type(d3Shape.symbolStar)();
+      const movesStar = star.match(/[A-Z]/g);
+      const coordsStar = star.split(/[A-Z]/).slice(1);
+      const [x0, y0] = coords[0].split(",").map(Number);
+      const [x1, y1] = coords[1].split(",").slice(coords[1].split(",").length - 2).map(Number);
+      const [xOrigin, yOrigin] = [(x0 + x1) / 2, (y0 + y1) / 2];
+      const adjustedCoordsStar = coordsStar.map((coord) => {
+        if (coord.length === 0) {
+          return "";
+        }
+        const [x, y] = coord.split(",").map(Number);
+        return [x + xOrigin, y + yOrigin].join(",");
+      });
+      const adjustedStar = movesStar.map((m, i) => m + adjustedCoordsStar[i]).join();
+      return adjustedStar + pathFunction();
+    };
+    return (
+      <VictoryBar
+        alignment={"middle"}
+        polar
+        width={0}
+        data={getData(7)}
+        style={{ data: { width: 10 } }}
+        getPath={getPathFn}
+      />
+    );
+  });
 
 storiesOf("VictoryBar.data", module)
   .addDecorator(getChartDecorator({ domainPadding: 25 }))


### PR DESCRIPTION
- Add getPath prop to victory bar
- Add stories to storybook demonstrating usage
- For non-polar charts, getPath expects a function ({ x0, x1, y0, y1}) -> (string describing svg path)
- For polar charts, getPath expects a function ({ datum, start, end, r1, r2 }) -> (string describing svg path), where `datum`  is an object of shape {x, y},  `start/end` are angles derived from styles.width, and `r1/r2` are the radii (top/bottom) of each polar bar