### PR TITLE
Pie Label Positioning

### DIFF
--- a/demo/components/victory-pie-demo.js
+++ b/demo/components/victory-pie-demo.js
@@ -146,7 +146,16 @@ export default class App extends React.Component {
             padding={{ bottom: 50, left: 50, right: 10 }}
             width={400} height={200}
           />
-
+          <VictoryPie
+            style={{ parent: parentStyle }}
+            labelPosition="endAngle"
+            width={200} height={400}
+          />
+          <VictoryPie
+            style={{ parent: parentStyle }}
+            labelPosition="startAngle"
+            width={200} height={400}
+          />
           <VictoryPie
             style={{ parent: parentStyle }}
             width={200} height={400}

--- a/packages/victory-pie/README.md
+++ b/packages/victory-pie/README.md
@@ -250,6 +250,22 @@ The `innerRadius` prop determines the number of pixels between the center of the
 />
 ```
 
+### labelPosition
+
+`type: "centroid" || "startAngle" || "endAngle"`
+
+The `labelPosition` prop defines the position inside the arc that will be used for positioning each slice label. If this props is not set, the label position will default to the centroid of the arc itself.
+
+*default:* `"centroid"`
+
+```playground
+<VictoryPie
+  data={sampleData}
+  labelPosition="endAngle"
+  style={{ labels: { fill: "white", fontSize: 20, fontWeight: "bold" } }}
+/>
+```
+
 ### labelRadius
 
 `type: number`

--- a/packages/victory-pie/src/helper-methods.js
+++ b/packages/victory-pie/src/helper-methods.js
@@ -87,12 +87,21 @@ const getLabelText = (props, datum, index) => {
   return checkForValidText(text);
 };
 
-const getLabelPosition = (radius, labelRadius, style) => {
+const getLabelArc = (radius, labelRadius, style) => {
   const padding = style && style.padding || 0;
   const arcRadius = labelRadius || radius + padding;
   return d3Shape.arc()
     .outerRadius(arcRadius)
     .innerRadius(arcRadius);
+};
+
+const getLabelPosition = (arc, slice, position) => {
+  const construct = {
+    startAngle: position === "startAngle" ? slice.endAngle : slice.startAngle,
+    endAngle: position === "endAngle" ? slice.startAngle : slice.endAngle
+  };
+  const clonedArc = Object.assign({}, slice, construct);
+  return arc.centroid(clonedArc);
 };
 
 const getLabelOrientation = (slice) => {
@@ -134,8 +143,8 @@ const getLabelProps = (props, dataProps, calculatedValues) => {
     assign({ padding: 0 }, style.labels), datum, props.active
   );
   const labelRadius = Helpers.evaluateProp(props.labelRadius, datum);
-  const labelPosition = getLabelPosition(radius, labelRadius, labelStyle);
-  const position = labelPosition.centroid(slice);
+  const labelArc = getLabelArc(radius, labelRadius, labelStyle);
+  const position = getLabelPosition(labelArc, slice, props.labelPosition);
   const orientation = getLabelOrientation(slice);
   return {
     index, datum, data, slice, orientation,

--- a/packages/victory-pie/src/victory-pie.js
+++ b/packages/victory-pie/src/victory-pie.js
@@ -27,7 +27,8 @@ const fallbackProps = {
     "#525252",
     "#252525",
     "#000000"
-  ]
+  ],
+  labelPosition: "centroid"
 };
 
 const animationWhitelist = [
@@ -100,6 +101,7 @@ class VictoryPie extends React.Component {
     height: CustomPropTypes.nonNegative,
     innerRadius: CustomPropTypes.nonNegative,
     labelComponent: PropTypes.element,
+    labelPosition: PropTypes.oneOf(["startAngle", "centroid", "endAngle"]),
     labelRadius: PropTypes.oneOfType([ CustomPropTypes.nonNegative, PropTypes.func ]),
     labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
     name: PropTypes.string,

--- a/stories/victory-pie.js
+++ b/stories/victory-pie.js
@@ -76,6 +76,11 @@ storiesOf("VictoryPie", module)
       origin={{ x: 150, y: 150 }}
     />
   ))
+  .add("with a label position different than centroid", () => (
+    <VictoryPie
+      labelPosition={"startAngle"}
+    />
+  ))
   .add("with custom data and colors", () => (
     <VictoryPie
       style={{


### PR DESCRIPTION
Added the option for "startAngle" and "endAngle" for the label to be
positioned.

The default is "centroid" which does not altere the original behavior.

As posted on the issue #1117 it would be nice to position the label
inside the actual slice but as per one rule of no-magic-numbers I can't
multiply by 0.9 to do this equally for all labels. This could be left
for later.

Closes #1117