### PR TITLE
allow closed curves for cartesian charts

### DIFF
--- a/packages/victory-line/src/curve.js
+++ b/packages/victory-line/src/curve.js
@@ -40,8 +40,10 @@ export default class Curve extends React.Component {
   };
 
   getLineFunction(props) {
-    const { polar, scale, openCurve } = props;
-    const interpolation = polar && !openCurve ?
+    const { polar, scale } = props;
+    const defaultOpenCurve = polar ? false : true;
+    const openCurve = props.openCurve === undefined ? defaultOpenCurve : props.openCurve;
+    const interpolation = !openCurve ?
       `${this.toNewName(props.interpolation)}Closed` : this.toNewName(props.interpolation);
     return polar ?
       d3Shape.lineRadial()


### PR DESCRIPTION
@HalHaig This PR allows closed curves for cartesian charts.

polar charts will still default to closed interpolation, and cartesian charts will still default to open interpolations. To change this behavior:

```
<VictoryLine
  dataComponent={<Curve openCurve={false} />}
  ...
/>
```