### PR TITLE
audit and replace all instances of Object.assign with lodash assign

### DIFF
--- a/demo/components/external-events-demo.js
+++ b/demo/components/external-events-demo.js
@@ -9,7 +9,7 @@ import { VictoryBar } from "../../packages/victory-bar/src/index";
 import { VictoryLine } from "../../packages/victory-line/src/index";
 import { VictoryZoomContainer } from "../../packages/victory-zoom-container/src/index";
 import { VictoryVoronoiContainer } from "../../packages/victory-voronoi-container/src/index";
-import { range } from "lodash";
+import { range, assign } from "lodash";
 
 class App extends React.Component {
   constructor() {
@@ -52,8 +52,8 @@ class App extends React.Component {
         mutation: (props) => {
           const fill = props.style && props.style.fill;
           return fill === "blue" ?
-            { style: Object.assign({}, props.style, { fill: "red" }) } :
-            { style: Object.assign({}, props.style, { fill: "blue" }) };
+            { style: assign({}, props.style, { fill: "red" }) } :
+            { style: assign({}, props.style, { fill: "blue" }) };
         },
         callback
       }]

--- a/demo/components/victory-errorbar-demo.js
+++ b/demo/components/victory-errorbar-demo.js
@@ -2,7 +2,7 @@
 /*eslint-disable no-magic-numbers */
 import React from "react";
 import PropTypes from "prop-types";
-import { merge, random, range } from "lodash";
+import { assign, merge, random, range } from "lodash";
 import { VictoryChart } from "../../packages/victory-chart/src/index";
 import { VictoryLine } from "../../packages/victory-line/src/index";
 import { VictoryErrorBar, ErrorBar } from "../../packages/victory-errorbar/src/index";
@@ -91,7 +91,7 @@ export default class App extends React.Component {
             <VictoryContainer
               title="ErrorBar Chart"
               desc="This is a errorbar chart with data points!"
-              style={Object.assign({}, style.parent, { border: "1px solid red" })}
+              style={assign({}, style.parent, { border: "1px solid red" })}
             />
           }
         />

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -2,7 +2,7 @@
 /*eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { merge, random, range } from "lodash";
+import { assign, merge, random, range } from "lodash";
 import { VictoryScatter } from "../../packages/victory-scatter/src/index";
 import {
   VictoryLabel, VictoryContainer, VictoryTheme
@@ -121,7 +121,7 @@ export default class App extends React.Component {
             <VictoryContainer
               title="Scatter Chart"
               desc="This is a scatter chart with cat data points!"
-              style={Object.assign({}, style.parent, { border: "1px solid red" })}
+              style={assign({}, style.parent, { border: "1px solid red" })}
             />
           }
         />

--- a/packages/victory-pie/src/helper-methods.js
+++ b/packages/victory-pie/src/helper-methods.js
@@ -100,7 +100,7 @@ const getLabelPosition = (arc, slice, position) => {
     startAngle: position === "startAngle" ? slice.endAngle : slice.startAngle,
     endAngle: position === "endAngle" ? slice.startAngle : slice.endAngle
   };
-  const clonedArc = Object.assign({}, slice, construct);
+  const clonedArc = assign({}, slice, construct);
   return arc.centroid(clonedArc);
 };
 

--- a/test/client/spec/svg-test-helper.js
+++ b/test/client/spec/svg-test-helper.js
@@ -1,7 +1,7 @@
 import * as d3Shape from "d3-shape";
 import * as d3Scale from "d3-scale";
 import { voronoi as d3Voronoi } from "d3-voronoi";
-import { without, min, max, property } from "lodash";
+import { assign, without, min, max, property } from "lodash";
 
 const RECTANGULAR_SEQUENCE = ["M", "A", "L", "A", "L", "A", "L", "A", "z"];
 const CIRCULAR_SEQUENCE = ["M", "m", "a", "a"];
@@ -292,4 +292,4 @@ const helpers = {
   }
 };
 
-export default Object.assign({}, expectations, helpers);
+export default assign({}, expectations, helpers);

--- a/test/client/spec/victory-bar/bar.spec.js
+++ b/test/client/spec/victory-bar/bar.spec.js
@@ -3,7 +3,7 @@ import { mount } from "enzyme";
 import Bar from "packages/victory-bar/src/bar";
 import SvgTestHelper from "../svg-test-helper";
 import * as d3Scale from "d3-scale";
-import { merge } from "lodash";
+import { assign, merge } from "lodash";
 
 describe("victory-primitives/bar", () => {
   const baseProps = {
@@ -50,7 +50,7 @@ describe("victory-primitives/bar", () => {
   });
 
   it("should allow override of width by passing a style", () => {
-    const props = Object.assign({}, baseProps, { style: { width: 3 } });
+    const props = assign({}, baseProps, { style: { width: 3 } });
 
     const wrapper = mount(<Bar {...props}/>);
     const barShape = SvgTestHelper.getBarShape(wrapper);
@@ -59,7 +59,7 @@ describe("victory-primitives/bar", () => {
   });
 
   it("should allow modification of width by passing barRatio", () => {
-    const props = Object.assign({}, baseProps,
+    const props = assign({}, baseProps,
       {
         data: [
           { _x: 2, x: 2, _y: 4, y: 4, eventKey: 0 }

--- a/test/client/spec/victory-core/victory-primitives/point.spec.js
+++ b/test/client/spec/victory-core/victory-primitives/point.spec.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { shallow } from "enzyme";
+import { assign } from "lodash";
 import Point from "packages/victory-core/src/victory-primitives/point";
 import Path from "packages/victory-core/src/victory-primitives/path";
 import pathHelpers from "packages/victory-core/src/victory-primitives/path-helpers";
@@ -35,7 +36,7 @@ describe("victory-primitives/point", () => {
       "star"
     ].forEach((symbol) => {
       const stub = sandbox.stub(pathHelpers, symbol).returns(`${symbol} symbol`);
-      const props = Object.assign({}, baseProps, { symbol });
+      const props = assign({}, baseProps, { symbol });
       const wrapper = shallow(<Point {...props} />);
       const directions = wrapper.find(Path).prop("d");
 

--- a/test/client/spec/victory-selection-container/selection-helpers.spec.js
+++ b/test/client/spec/victory-selection-container/selection-helpers.spec.js
@@ -5,6 +5,7 @@ import { SelectionHelpers } from "packages/victory-selection-container/src/index
 import { VictoryBar } from "packages/victory-bar/src/index";
 import React from "react";
 import * as d3Scale from "d3-scale";
+import { assign } from "lodash";
 
 const scale = { x: d3Scale.scaleLinear(), y: d3Scale.scaleLinear() };
 
@@ -49,7 +50,7 @@ describe("helpers/selection", () => {
       const props = { scale, x1: 0, y1: 0, x2: 0.5, y2: 0.5 };
       const filteredData = SelectionHelpers.filterDatasets(props, datasets, bounds);
       const expected = { eventKey: [0], data: [data[0]] };
-      expect(filteredData).to.eql([Object.assign({ childName }, expected)]);
+      expect(filteredData).to.eql([assign({ childName }, expected)]);
     });
   });
 });

--- a/test/client/spec/victory-shared-events/victory-shared-events.spec.js
+++ b/test/client/spec/victory-shared-events/victory-shared-events.spec.js
@@ -1,7 +1,7 @@
 /**
  * Client tests
  */
-import { forEach } from "lodash";
+import { assign, forEach } from "lodash";
 import { mount } from "enzyme";
 import React from "react";
 import { addEvents } from "packages/victory-core/src/index";
@@ -54,7 +54,7 @@ describe("components/victory-shared-events", () => {
                   childName: ["one", "three"],
                   mutation: (props) => {
                     return {
-                      style: Object.assign({}, props.style, { fill: "tomato" })
+                      style: assign({}, props.style, { fill: "tomato" })
                     };
                   }
                 }];


### PR DESCRIPTION
This PR replaces all instances of `Object.assign` with lodash `assign`

fixes https://github.com/FormidableLabs/victory/issues/1142