### PR TITLE
Add onTouchEnd to the cursor-helpers to use in native cursor container

### DIFF
--- a/packages/victory-cursor-container/src/cursor-helpers.js
+++ b/packages/victory-cursor-container/src/cursor-helpers.js
@@ -47,6 +47,20 @@ const CursorHelpers = {
       eventKey: "parent",
       mutation: () => ({ cursorValue, parentSVG })
     }];
+  },
+
+  onTouchEnd(evt, targetProps) {
+    const { onCursorChange } = targetProps;
+
+    if (isFunction(targetProps.onCursorChange)) {
+      onCursorChange(null, targetProps);
+    }
+
+    return [{
+      target: "parent",
+      eventKey: "parent",
+      mutation: () => ({ cursorValue: null })
+    }];
   }
 };
 
@@ -54,5 +68,6 @@ export default {
   onMouseMove: throttle(
     CursorHelpers.onMouseMove.bind(CursorHelpers),
     32, // eslint-disable-line no-magic-numbers
-    { leading: true, trailing: false })
+    { leading: true, trailing: false }),
+  onTouchEnd: CursorHelpers.onTouchEnd.bind(CursorHelpers)
 };


### PR DESCRIPTION
This is for a fix in victory-native.

Issue: https://github.com/FormidableLabs/victory-native/issues/349#issuecomment-430391540
Related PR in victory-native: https://github.com/FormidableLabs/victory-native/pull/394