### PR TITLE
Fix/issue 895 1119

### DIFF
--- a/demo/components/victory-polar-chart-demo.js
+++ b/demo/components/victory-polar-chart-demo.js
@@ -369,7 +369,7 @@ class App extends React.Component {
                 ]}
               />
               <VictoryBar name="bar-3"
-                cornerRadius={5}
+                cornerRadius={{ topLeft: 5 }}
                 style={{ data: { fill: "gold", width: 20 } }}
                 data={[
                   { x: 45, y: 20 },

--- a/package.json
+++ b/package.json
@@ -102,5 +102,6 @@
     "webpack-dev-server": "^1.10.0",
     "webpack-stats-plugin": "^0.1.1"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {}
 }

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -2,9 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Helpers, Path, CommonProps } from "victory-core";
 import { assign, isPlainObject, isFunction } from "lodash";
-import * as d3Shape from "d3-shape";
 
-import { Circle, Point } from "./geometry-helper-methods";
+import {
+  getVerticalBarPath,
+  getHorizontalBarPath,
+  getVerticalPolarBarPath,
+  getCustomBarPath
+} from "./path-helper-methods";
 
 export default class Bar extends React.Component {
 
@@ -39,260 +43,18 @@ export default class Bar extends React.Component {
     defaultBarWidth: 8
   };
 
-  getPosition(props, width) {
-    const { x, y, y0, horizontal } = props;
-    const alignment = props.alignment || "middle";
-    const size = alignment === "middle" ? width / 2 : width;
-    const sign = horizontal ? -1 : 1;
-    return {
-      x0: alignment === "start" ? x : x - (sign * size),
-      x1: alignment === "end" ? x : x + (sign * size),
-      y0,
-      y1: y
-    };
-  }
-
-  getVerticalBarPath(props, width, cornerRadius) { // eslint-disable-line max-statements
-    const { x0, x1, y0, y1 } = this.getPosition(props, width);
-    const sign = y0 > y1 ? 1 : -1;
-    const direction = sign > 0 ? "0 0 1" : "0 0 0";
-
-    const isSelfIntersecting = sign === 1 ?
-      (y0 - cornerRadius.bottom) < (y1 + cornerRadius.top) :
-      (y1 - cornerRadius.bottom) < (y0 + cornerRadius.top);
-
-    const topArc = `${cornerRadius.top} ${cornerRadius.top} ${direction}`;
-    const bottomArc = `${cornerRadius.bottom} ${cornerRadius.bottom} ${direction}`;
-
-    let start = `M ${x0 + cornerRadius.bottom}, ${y0}`;
-    let bottomLeftArc = `A ${bottomArc}, ${x0}, ${y0 - sign * cornerRadius.bottom}`;
-    let leftLine = `L ${x0}, ${y1 + sign * cornerRadius.top}`;
-    let topLeftArc = `A ${topArc}, ${x0 + cornerRadius.top}, ${y1}`;
-    let topLine = `L ${x1 - cornerRadius.top}, ${y1}`;
-    let topRightArc = `A ${topArc}, ${x1}, ${y1 + sign * cornerRadius.top}`;
-    let rightLine = `L ${x1}, ${y0 - sign * cornerRadius.bottom}`;
-    let bottomRightArc = `A ${bottomArc}, ${x1 - cornerRadius.bottom}, ${y0}`;
-    const end = "z";
-
-    if (isSelfIntersecting) {
-
-      const topLeftCenter = new Point(x0 + cornerRadius.top, y1 + sign * cornerRadius.top);
-      const topLeftCircle = new Circle(topLeftCenter, cornerRadius.top);
-      const bottomLeftCenter = new Point(x0 + cornerRadius.bottom, y0 - sign * cornerRadius.bottom);
-      const bottomLeftCircle = new Circle(bottomLeftCenter, cornerRadius.bottom);
-      const topRightCenter = new Point(x1 - cornerRadius.top, y1 + sign * cornerRadius.top);
-      const topRightCircle = new Circle(topRightCenter, cornerRadius.top);
-      // eslint-disable-next-line max-len
-      const bottomRightCenter = new Point(x1 - cornerRadius.bottom, y0 - sign * cornerRadius.bottom);
-      const bottomRightCircle = new Circle(bottomRightCenter, cornerRadius.bottom);
-
-      leftLine = null;
-      rightLine = null;
-
-      if (cornerRadius.top !== 0 && cornerRadius.bottom !== 0) {
-
-        // find intersection of top left and bottom left arc
-        // circles intersect at two points, get the left-most point
-        const intrxnLeft = topLeftCircle.intersection(bottomLeftCircle)[0];
-
-        // find intersection of top right and bottom right arc
-        // circles intersect at two points, get the right-most point
-        const intrxnRight = topRightCircle.intersection(bottomRightCircle)[1];
-
-        bottomLeftArc = `A ${bottomArc}, ${intrxnLeft.x}, ${intrxnLeft.y}`;
-        topRightArc = `A ${topArc}, ${intrxnRight.x}, ${intrxnRight.y}`;
-      }
-
-      if (cornerRadius.top !== 0 && cornerRadius.bottom === 0) {
-
-        // find intersection of y0 and the top left/right arc
-        const intrxnLeftX = topLeftCircle.solveX(y0)[0];
-        const intrxnRightX = topRightCircle.solveX(y0)[1];
-
-        start = `M ${intrxnLeftX}, ${y0}`;
-        bottomLeftArc = null;
-        topRightArc = `A ${topArc}, ${intrxnRightX}, ${y0}`;
-        bottomRightArc = null;
-
-      }
-
-      if (cornerRadius.top === 0 && cornerRadius.bottom !== 0) {
-
-        // find intersection of y1 and the bottom left/right arc
-        const intrxnLeftX = bottomLeftCircle.solveX(y1)[0];
-        const intrxnRightX = bottomRightCircle.solveX(y1)[1];
-
-        bottomLeftArc = `A ${bottomArc}, ${intrxnLeftX}, ${y1}`;
-        topLeftArc = null;
-        topLine = `L ${intrxnRightX}, ${y1}`;
-        topRightArc = null;
-
-      }
-    }
-
-    return [ start,
-      bottomLeftArc,
-      leftLine,
-      topLeftArc,
-      topLine,
-      topRightArc,
-      rightLine,
-      bottomRightArc,
-      end ].filter((l) => l !== null).join("\n");
-
-  }
-
-  getHorizontalBarPath(props, width, cornerRadius) {
-    const { x0, x1, y0, y1 } = this.getPosition(props, width);
-    const sign = y1 > y0 ? 1 : -1;
-    const direction = sign > 0 ? "0 0 1" : "0 0 0";
-    const topArc = `${cornerRadius.top} ${cornerRadius.top} ${direction}`;
-    const bottomArc = `${cornerRadius.bottom} ${cornerRadius.bottom} ${direction}`;
-
-    const start = `M ${y0}, ${x1 + sign * cornerRadius.bottom}`;
-    const topLeftArc = `A ${bottomArc}, ${y0 + cornerRadius.bottom}, ${x1}`;
-    const topLine = `L ${y1 - sign * cornerRadius.top}, ${x1}`;
-    const topRightArc = `A ${topArc}, ${y1}, ${x1 + cornerRadius.top}`;
-    const rightLine = `L ${y1}, ${x0 - cornerRadius.top}`;
-    const bottomRightArc = `A ${topArc}, ${y1 - sign * cornerRadius.top}, ${x0}`;
-    const bottomLine = `L ${y0 + cornerRadius.bottom}, ${x0 }`;
-    const bottomLeftArc = `A ${bottomArc}, ${y0}, ${x0 - sign * cornerRadius.bottom}`;
-    const end = "z";
-
-    return [ start,
-      topLeftArc,
-      topLine,
-      topRightArc,
-      rightLine,
-      bottomRightArc,
-      bottomLine,
-      bottomLeftArc,
-      end ].join("\n");
-
-  }
-
-  getCustomBarPath(props, width) {
-    const { getPath } = props;
-    const propsWithCalculatedValues = { ...props, ...this.getPosition(props, width) };
-    return getPath(propsWithCalculatedValues);
-  }
-
-  transformAngle(angle) {
-    return -1 * angle + (Math.PI / 2);
-  }
-
-  getAngularWidth(props, width) {
-    const { scale } = props;
-    const range = scale.y.range();
-    const r = Math.max(...range);
-    const angularRange = Math.abs(scale.x.range()[1] - scale.x.range()[0]);
-    return (width / (2 * Math.PI * r)) * angularRange;
-  }
-
-  getAngle(props, index) {
-    const { data, scale } = props;
-    const x = data[index]._x1 === undefined ? "_x" : "_x1";
-    return scale.x(data[index][x]);
-  }
-
-  getStartAngle(props, index) {
-    const { data, scale, alignment } = props;
-    const currentAngle = this.getAngle(props, index);
-    const angularRange = Math.abs(scale.x.range()[1] - scale.x.range()[0]);
-    const previousAngle = index === 0 ?
-      this.getAngle(props, data.length - 1) - (Math.PI * 2) :
-      this.getAngle(props, index - 1);
-    if (index === 0 && angularRange < (2 * Math.PI)) {
-      return scale.x.range()[0];
-    } else if (alignment === "start" || alignment === "end") {
-      return alignment === "start" ? previousAngle : currentAngle;
-    } else {
-      return (currentAngle + previousAngle) / 2;
-    }
-  }
-
-  getEndAngle(props, index) {
-    const { data, scale, alignment } = props;
-    const currentAngle = this.getAngle(props, index);
-    const angularRange = Math.abs(scale.x.range()[1] - scale.x.range()[0]);
-    const lastAngle = scale.x.range()[1] === (2 * Math.PI) ?
-      this.getAngle(props, 0) + (Math.PI * 2) : scale.x.range()[1];
-    const nextAngle = index === data.length - 1 ?
-      this.getAngle(props, 0) + (Math.PI * 2) : this.getAngle(props, index + 1);
-    if (index === data.length - 1 && angularRange < (2 * Math.PI)) {
-      return lastAngle;
-    } else if (alignment === "start" || alignment === "end") {
-      return alignment === "start" ? currentAngle : nextAngle;
-    } else {
-      return (currentAngle + nextAngle) / 2;
-    }
-  }
-
-  getCustomVerticalPolarBarPath(getPath, props) {
-    return getPath(props);
-  }
-
-  getVerticalPolarBarPath(props, cornerRadius) { // eslint-disable-line max-statements
-    const { datum, scale, index, alignment } = props;
-    const style = Helpers.evaluateStyle(props.style, datum, props.active);
-    const r1 = scale.y(datum._y0 || 0);
-    const r2 = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
-    const currentAngle = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
-    let start;
-    let end;
-    if (style.width) {
-      const width = this.getAngularWidth(props, style.width);
-      const size = alignment === "middle" ? width / 2 : width;
-      start = alignment === "start" ? currentAngle : currentAngle - size;
-      end = alignment === "end" ? currentAngle : currentAngle + size;
-    } else {
-      start = this.getStartAngle(props, index);
-      end = this.getEndAngle(props, index);
-    }
-
-    start = this.transformAngle(start);
-    end = this.transformAngle(end);
-    if (props.getPath) {
-      const options = { startAngle: start, endAngle: end, r1, r2, cornerRadius };
-      const propsWithCalculatedValues = { ...props, ...options };
-      return this.getCustomVerticalPolarBarPath(props.getPath, propsWithCalculatedValues);
-    }
-
-    const getPath = (edge) => {
-      const pathFunction = d3Shape.arc()
-      .innerRadius(r1)
-      .outerRadius(r2)
-      .startAngle(start)
-      .endAngle(end)
-      .cornerRadius(cornerRadius[edge]);
-      const path = pathFunction();
-      const moves = path.match(/[A-Z]/g);
-      const middle = moves.indexOf("L");
-      const coords = path.split(/[A-Z]/).slice(1);
-      const subMoves = edge === "top" ? moves.slice(0, middle) : moves.slice(middle);
-      const subCoords = edge === "top" ? coords.slice(0, middle) : coords.slice(middle);
-      return subMoves.map((m, i) => ({ command: m, coords: subCoords[i].split(",") }));
-    };
-
-    const moves = getPath("top").concat(getPath("bottom"));
-    return moves.reduce((memo, move) => {
-      memo += `${move.command} ${move.coords.join()}`;
-      return memo;
-    }, "");
-  }
-
   getBarPath(props, width, cornerRadius) {
     if (props.getPath) {
-      return this.getCustomBarPath(props, width);
+      return getCustomBarPath(props, width);
     }
     return props.horizontal ?
-      this.getHorizontalBarPath(props, width, cornerRadius) :
-      this.getVerticalBarPath(props, width, cornerRadius);
+      getHorizontalBarPath(props, width, cornerRadius) :
+      getVerticalBarPath(props, width, cornerRadius);
   }
 
   getPolarBarPath(props, cornerRadius) {
     // TODO Radial bars
-    return this.getVerticalPolarBarPath(props, cornerRadius);
+    return getVerticalPolarBarPath(props, cornerRadius);
   }
 
   getBarWidth(props, style) {

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -56,15 +56,26 @@ export default class Bar extends React.Component {
     const direction = sign > 0 ? "0 0 1" : "0 0 0";
     const topArc = `${cornerRadius.top} ${cornerRadius.top} ${direction}`;
     const bottomArc = `${cornerRadius.bottom} ${cornerRadius.bottom} ${direction}`;
-    return `M ${x0 + cornerRadius.bottom}, ${y0}
-      A ${bottomArc}, ${x0}, ${y0 - sign * cornerRadius.bottom}
-      L ${x0}, ${y1 + sign * cornerRadius.top}
-      A ${topArc}, ${x0 + cornerRadius.top}, ${y1}
-      L ${x1 - cornerRadius.top}, ${y1}
-      A ${topArc}, ${x1}, ${y1 + sign * cornerRadius.top}
-      L ${x1}, ${y0 - sign * cornerRadius.bottom}
-      A ${bottomArc}, ${x1 - cornerRadius.bottom}, ${y0}
-      z`;
+
+    const start = `M ${x0 + cornerRadius.bottom}, ${y0}`;
+    const bottomLeftArc = `A ${bottomArc}, ${x0}, ${y0 - sign * cornerRadius.bottom}`;
+    const leftLine = `L ${x0}, ${y1 + sign * cornerRadius.top}`;
+    const topLeftArc = `A ${topArc}, ${x0 + cornerRadius.top}, ${y1}`;
+    const topLine = `L ${x1 - cornerRadius.top}, ${y1}`;
+    const topRightArc = `A ${topArc}, ${x1}, ${y1 + sign * cornerRadius.top}`;
+    const rightLine = `L ${x1}, ${y0 - sign * cornerRadius.bottom}`;
+    const bottomRightArc = `A ${bottomArc}, ${x1 - cornerRadius.bottom}, ${y0}`;
+    const end = "z";
+
+    return [ start,
+      bottomLeftArc,
+      leftLine,
+      topLeftArc,
+      topLine,
+      topRightArc,
+      rightLine,
+      bottomRightArc,
+      end ].join("\n");
   }
 
   getHorizontalBarPath(props, width, cornerRadius) {
@@ -73,15 +84,26 @@ export default class Bar extends React.Component {
     const direction = sign > 0 ? "0 0 1" : "0 0 0";
     const topArc = `${cornerRadius.top} ${cornerRadius.top} ${direction}`;
     const bottomArc = `${cornerRadius.bottom} ${cornerRadius.bottom} ${direction}`;
-    return `M ${y0}, ${x1 + sign * cornerRadius.bottom}
-      A ${bottomArc}, ${y0 + cornerRadius.bottom}, ${x1}
-      L ${y1 - sign * cornerRadius.top}, ${x1}
-      A ${topArc}, ${y1}, ${x1 + cornerRadius.top}
-      L ${y1}, ${x0 - cornerRadius.top}
-      A ${topArc}, ${y1 - sign * cornerRadius.top}, ${x0}
-      L ${y0 + cornerRadius.bottom}, ${x0 }
-      A ${bottomArc}, ${y0}, ${x0 - sign * cornerRadius.bottom}
-      z`;
+
+    const start = `M ${y0}, ${x1 + sign * cornerRadius.bottom}`;
+    const topLeftArc = `A ${bottomArc}, ${y0 + cornerRadius.bottom}, ${x1}`;
+    const topLine = `L ${y1 - sign * cornerRadius.top}, ${x1}`;
+    const topRightArc = `A ${topArc}, ${y1}, ${x1 + cornerRadius.top}`;
+    const rightLine = `L ${y1}, ${x0 - cornerRadius.top}`;
+    const bottomRightArc = `A ${topArc}, ${y1 - sign * cornerRadius.top}, ${x0}`;
+    const bottomLine = `L ${y0 + cornerRadius.bottom}, ${x0 }`;
+    const bottomLeftArc = `A ${bottomArc}, ${y0}, ${x0 - sign * cornerRadius.bottom}`;
+    const end = "z";
+
+    return [ start,
+      topLeftArc,
+      topLine,
+      topRightArc,
+      rightLine,
+      bottomRightArc,
+      bottomLine,
+      bottomLeftArc,
+      end ].join("\n");
   }
 
   getCustomBarPath(props, width) {

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Helpers, Path, CommonProps } from "victory-core";
-import { assign, isPlainObject, isFunction } from "lodash";
+import { assign, isPlainObject, isFunction, isNil } from "lodash";
 
 import {
   getVerticalBarPath,
@@ -76,14 +76,35 @@ export default class Bar extends React.Component {
     return Math.max(1, defaultWidth);
   }
 
+  getCornerRadiusFromObject(props) {
+    const { cornerRadius, datum, active } = props;
+    const realCornerRadius = { topLeft: 0, topRight: 0, bottomLeft: 0, bottomRight: 0 };
+    const updateCornerRadius = (corner, fallback) => {
+      if (!isNil(cornerRadius[corner])) {
+        realCornerRadius[corner] = Helpers.evaluateProp(cornerRadius[corner], datum, active);
+      } else if (!isNil(cornerRadius[fallback])) {
+        realCornerRadius[corner] = Helpers.evaluateProp(cornerRadius[fallback], datum, active);
+      }
+    };
+    updateCornerRadius("topLeft", "top");
+    updateCornerRadius("topRight", "top");
+    updateCornerRadius("bottomLeft", "bottom");
+    updateCornerRadius("bottomRight", "right");
+    return realCornerRadius;
+  }
+
   getCornerRadius(props) {
     const { cornerRadius, datum, active } = props;
-    const top = isPlainObject(cornerRadius) ? cornerRadius.top : cornerRadius || 0;
-    const bottom = isPlainObject(cornerRadius) ? cornerRadius.bottom : 0;
-    return {
-      top: Helpers.evaluateProp(top, datum, active),
-      bottom: Helpers.evaluateProp(bottom, datum, active)
-    };
+    const realCornerRadius = { topLeft: 0, topRight: 0, bottomLeft: 0, bottomRight: 0 };
+    if (!cornerRadius) {
+      return realCornerRadius;
+    }
+    if (isPlainObject(cornerRadius)) {
+      return this.getCornerRadiusFromObject(props);
+    }
+    realCornerRadius.topLeft = Helpers.evaluateProp(cornerRadius, datum, active);
+    realCornerRadius.topRight = Helpers.evaluateProp(cornerRadius, datum, active);
+    return realCornerRadius;
   }
 
   render() {

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -25,7 +25,11 @@ export default class Bar extends React.Component {
       PropTypes.func,
       PropTypes.shape({
         top: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-        bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
+        topLeft: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        topRight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        bottomLeft: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        bottomRight: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
       })
     ]),
     datum: PropTypes.object,

--- a/packages/victory-bar/src/geometry-helper-methods.js
+++ b/packages/victory-bar/src/geometry-helper-methods.js
@@ -106,4 +106,9 @@ Circle.prototype.solveX = function (y) {
   return [ this.center.x - sqrt, this.center.x + sqrt ];
 };
 
+Circle.prototype.solveY = function (x) {
+  const sqrt = Math.sqrt(this.radius ** 2 - (x - this.center.x) ** 2);
+  return [ this.center.y - sqrt, this.center.y + sqrt ];
+};
+
 export { Circle, Point };

--- a/packages/victory-bar/src/geometry-helper-methods.js
+++ b/packages/victory-bar/src/geometry-helper-methods.js
@@ -1,114 +1,108 @@
 /**
  * A point in the 2d plane
- * @constructor
  * @param {number} x - x coordinate
  * @param {number} y - y coordinate
+ * @returns {object} - point object
  */
-const Point = function (x, y) {
-  this.x = x; // eslint-disable-line no-invalid-this
-  this.y = y; // eslint-disable-line no-invalid-this
-};
-
-Point.prototype.distance = function (p1) {
-  return Math.sqrt((this.x - p1.x) ** 2 + (this.y - p1.y) ** 2);
-};
-
-// vector addition in 2d plane
-Point.prototype.add = function (p1) {
-  return new Point(this.x + p1.x, this.y + p1.y);
-};
-
-// vector subtraction in 2d
-// returns p0 - p1
-Point.prototype.subtract = function (p1) {
-  return new Point(this.x - p1.x, this.y - p1.y);
-};
-
-// multiply a 2d point by a scalar
-Point.prototype.scalarMult = function (n) {
-  return new Point(this.x * n, this.y * n);
-};
-
-Point.prototype.scalarDivide = function (n) {
-  if (n === 0) {
-    throw new Error("Division by 0 error");
-  }
-  return new Point(this.x / n, this.y / n);
-};
-
-Point.prototype.equals = function (p1) {
-  return this.x === p1.x && this.y === p1.y;
+const point = function (x, y) {
+  return {
+    x,
+    y,
+    distance(p1) {
+      return Math.sqrt((this.x - p1.x) ** 2 + (this.y - p1.y) ** 2);
+    },
+    // vector addition in 2d plane
+    add(p1) {
+      return point(this.x + p1.x, this.y + p1.y);
+    },
+    // vector subtraction in 2d
+    // returns p0 - p1
+    subtract(p1) {
+      return point(this.x - p1.x, this.y - p1.y);
+    },
+    // multiply a 2d point by a scalar
+    scalarMult(n) {
+      return point(this.x * n, this.y * n);
+    },
+    scalarDivide(n) {
+      if (n === 0) {
+        throw new Error("Division by 0 error");
+      }
+      return point(this.x / n, this.y / n);
+    },
+    equals(p1) {
+      return this.x === p1.x && this.y === p1.y;
+    }
+  };
 };
 
 /**
- * @constructor
- * @param {Point} center - center of circle
+ * A circle in the 2d plane
+ * @param {point} center - center of circle
  * @param {number} radius - radius of circle
+ * @returns {object} - point object
  */
-const Circle = function (center, radius) {
-  this.center = center; // eslint-disable-line no-invalid-this
-  this.radius = radius; // eslint-disable-line no-invalid-this
+const circle = function (center, radius) {
+  return {
+    center,
+    radius,
+    hasIntersection(circle1) {
+      const P0 = this.center;
+      const P1 = circle1.center;
+      const r0 = this.radius;
+      const r1 = circle1.radius;
+      const d = P0.distance(P1);
+
+      if (d > r0 + r1) {
+        return false; // separate circles
+      }
+      if (d < Math.abs(r0 - r1)) {
+        return false; // one circle contains another
+      }
+      return true;
+    },
+    equals(circle1) {
+      const P0 = this.center;
+      const P1 = circle1.center;
+      const r0 = this.radius;
+      const r1 = circle1.radius;
+      return r0 === r1 && P0.equals(P1);
+    },
+    // Source: http://paulbourke.net/geometry/circlesphere/
+    // "Intersection of two circles" by Paul Bourke
+    // Left-most point is returned as 0th element of array
+    // Right-most point is returned as 1st elemennt of array
+    intersection(circle1) { // eslint-disable-line max-statements
+      const P0 = this.center;
+      const P1 = circle1.center;
+      const r0 = this.radius;
+      const r1 = circle1.radius;
+      const d = P0.distance(P1);
+      if (!this.hasIntersection(circle1) || this.equals(circle1)) {
+        return [];
+      }
+      const a = (r0 ** 2 - r1 ** 2 + d ** 2) / (2 * d);
+      const h = Math.sqrt(r0 ** 2 - a ** 2);
+      const P2 = P0.add(P1.subtract(P0).scalarMult(a).scalarDivide(d));
+      const { x: x0, y: y0 } = P0;
+      const { x: x1, y: y1 } = P1;
+      const { x: x2, y: y2 } = P2;
+      const P3s = [
+        point(x2 - h * (y1 - y0) / d, y2 + h * (x1 - x0) / d),
+        point(x2 + h * (y1 - y0) / d, y2 - h * (x1 - x0) / d)
+      ];
+      P3s.sort((Point1, Point2) => Point1.x - Point2.x);
+      return P3s;
+    },
+    solveX(y) {
+      const sqrt = Math.sqrt(this.radius ** 2 - (y - this.center.y) ** 2);
+      return [ this.center.x - sqrt, this.center.x + sqrt ];
+    },
+    solveY(x) {
+      const sqrt = Math.sqrt(this.radius ** 2 - (x - this.center.x) ** 2);
+      return [ this.center.y - sqrt, this.center.y + sqrt ];
+    }
+  };
 };
 
-Circle.prototype.hasIntersection = function (circle1) {
-  const P0 = this.center;
-  const P1 = circle1.center;
-  const r0 = this.radius;
-  const r1 = circle1.radius;
-  const d = P0.distance(P1);
-
-  if (d > r0 + r1) {
-    return false; // separate circles
-  }
-  if (d < Math.abs(r0 - r1)) {
-    return false; // one circle contains another
-  }
-  return true;
-};
-
-Circle.prototype.equals = function (circle1) {
-  const P0 = this.center;
-  const P1 = circle1.center;
-  const r0 = this.radius;
-  const r1 = circle1.radius;
-  return r0 === r1 && P0.equals(P1);
-};
-
-// Source: http://paulbourke.net/geometry/circlesphere/
-// "Intersection of two circles" by Paul Bourke
-// Left-most point is returned as 0th element of array
-// Right-most point is returned as 1st elemennt of array
-Circle.prototype.intersection = function (circle1) { // eslint-disable-line max-statements
-  const P0 = this.center;
-  const P1 = circle1.center;
-  const r0 = this.radius;
-  const r1 = circle1.radius;
-  const d = P0.distance(P1);
-  if (!this.hasIntersection(circle1) || this.equals(circle1)) {
-    return [];
-  }
-  const a = (r0 ** 2 - r1 ** 2 + d ** 2) / (2 * d);
-  const h = Math.sqrt(r0 ** 2 - a ** 2);
-  const P2 = P0.add(P1.subtract(P0).scalarMult(a).scalarDivide(d));
-  const { x: x0, y: y0 } = P0;
-  const { x: x1, y: y1 } = P1;
-  const { x: x2, y: y2 } = P2;
-  const P3s = [
-    new Point(x2 - h * (y1 - y0) / d, y2 + h * (x1 - x0) / d),
-    new Point(x2 + h * (y1 - y0) / d, y2 - h * (x1 - x0) / d)
-  ];
-  P3s.sort((Point1, Point2) => Point1.x - Point2.x);
-  return P3s;
-};
-
-Circle.prototype.solveX = function (y) {
-  const sqrt = Math.sqrt(this.radius ** 2 - (y - this.center.y) ** 2);
-  return [ this.center.x - sqrt, this.center.x + sqrt ];
-};
-
-Circle.prototype.solveY = function (x) {
-  const sqrt = Math.sqrt(this.radius ** 2 - (x - this.center.x) ** 2);
-  return [ this.center.y - sqrt, this.center.y + sqrt ];
-};
-
-export { Circle, Point };
+export { circle, point };

--- a/packages/victory-bar/src/geometry-helper-methods.js
+++ b/packages/victory-bar/src/geometry-helper-methods.js
@@ -1,0 +1,109 @@
+/**
+ * A point in the 2d plane
+ * @constructor
+ * @param {number} x - x coordinate
+ * @param {number} y - y coordinate
+ */
+const Point = function (x, y) {
+  this.x = x; // eslint-disable-line no-invalid-this
+  this.y = y; // eslint-disable-line no-invalid-this
+};
+
+Point.prototype.distance = function (p1) {
+  return Math.sqrt((this.x - p1.x) ** 2 + (this.y - p1.y) ** 2);
+};
+
+// vector addition in 2d plane
+Point.prototype.add = function (p1) {
+  return new Point(this.x + p1.x, this.y + p1.y);
+};
+
+// vector subtraction in 2d
+// returns p0 - p1
+Point.prototype.subtract = function (p1) {
+  return new Point(this.x - p1.x, this.y - p1.y);
+};
+
+// multiply a 2d point by a scalar
+Point.prototype.scalarMult = function (n) {
+  return new Point(this.x * n, this.y * n);
+};
+
+Point.prototype.scalarDivide = function (n) {
+  if (n === 0) {
+    throw new Error("Division by 0 error");
+  }
+  return new Point(this.x / n, this.y / n);
+};
+
+Point.prototype.equals = function (p1) {
+  return this.x === p1.x && this.y === p1.y;
+};
+
+/**
+ * @constructor
+ * @param {Point} center - center of circle
+ * @param {number} radius - radius of circle
+ */
+const Circle = function (center, radius) {
+  this.center = center; // eslint-disable-line no-invalid-this
+  this.radius = radius; // eslint-disable-line no-invalid-this
+};
+
+Circle.prototype.hasIntersection = function (circle1) {
+  const P0 = this.center;
+  const P1 = circle1.center;
+  const r0 = this.radius;
+  const r1 = circle1.radius;
+  const d = P0.distance(P1);
+
+  if (d > r0 + r1) {
+    return false; // separate circles
+  }
+  if (d < Math.abs(r0 - r1)) {
+    return false; // one circle contains another
+  }
+  return true;
+};
+
+Circle.prototype.equals = function (circle1) {
+  const P0 = this.center;
+  const P1 = circle1.center;
+  const r0 = this.radius;
+  const r1 = circle1.radius;
+  return r0 === r1 && P0.equals(P1);
+};
+
+// Source: http://paulbourke.net/geometry/circlesphere/
+// "Intersection of two circles" by Paul Bourke
+// Left-most point is returned as 0th element of array
+// Right-most point is returned as 1st elemennt of array
+Circle.prototype.intersection = function (circle1) { // eslint-disable-line max-statements
+  const P0 = this.center;
+  const P1 = circle1.center;
+  const r0 = this.radius;
+  const r1 = circle1.radius;
+  const d = P0.distance(P1);
+  if (!this.hasIntersection(circle1) || this.equals(circle1)) {
+    return [];
+  }
+  const a = (r0 ** 2 - r1 ** 2 + d ** 2) / (2 * d);
+  const h = Math.sqrt(r0 ** 2 - a ** 2);
+  const P2 = P0.add(P1.subtract(P0).scalarMult(a).scalarDivide(d));
+  const { x: x0, y: y0 } = P0;
+  const { x: x1, y: y1 } = P1;
+  const { x: x2, y: y2 } = P2;
+  const P3s = [
+    new Point(x2 - h * (y1 - y0) / d, y2 + h * (x1 - x0) / d),
+    new Point(x2 + h * (y1 - y0) / d, y2 - h * (x1 - x0) / d)
+  ];
+  P3s.sort((Point1, Point2) => Point1.x - Point2.x);
+  return P3s;
+};
+
+Circle.prototype.solveX = function (y) {
+  const sqrt = Math.sqrt(this.radius ** 2 - (y - this.center.y) ** 2);
+  return [ this.center.x - sqrt, this.center.x + sqrt ];
+};
+
+export { Circle, Point };

--- a/packages/victory-bar/src/index.js
+++ b/packages/victory-bar/src/index.js
@@ -1,2 +1,7 @@
 export { default as VictoryBar } from "./victory-bar";
 export { default as Bar } from "./bar";
+export {
+  getVerticalBarPath,
+  getHorizontalBarPath,
+  getVerticalPolarBarPath
+} from "./geometry-helper-methods"

--- a/packages/victory-bar/src/index.js
+++ b/packages/victory-bar/src/index.js
@@ -4,4 +4,4 @@ export {
   getVerticalBarPath,
   getHorizontalBarPath,
   getVerticalPolarBarPath
-} from "./geometry-helper-methods"
+} from "./geometry-helper-methods";

--- a/packages/victory-bar/src/path-helper-methods.js
+++ b/packages/victory-bar/src/path-helper-methods.js
@@ -1,0 +1,249 @@
+import { Helpers } from "victory-core";
+import * as d3Shape from "d3-shape";
+
+import { Circle, Point } from "./geometry-helper-methods";
+
+const getPosition = (props, width) => {
+  const { x, y, y0, horizontal } = props;
+  const alignment = props.alignment || "middle";
+  const size = alignment === "middle" ? width / 2 : width;
+  const sign = horizontal ? -1 : 1;
+  return {
+    x0: alignment === "start" ? x : x - (sign * size),
+    x1: alignment === "end" ? x : x + (sign * size),
+    y0,
+    y1: y
+  };
+};
+
+const getAngle = (props, index) => {
+  const { data, scale } = props;
+  const x = data[index]._x1 === undefined ? "_x" : "_x1";
+  return scale.x(data[index][x]);
+};
+
+const getAngularWidth = (props, width) => {
+  const { scale } = props;
+  const range = scale.y.range();
+  const r = Math.max(...range);
+  const angularRange = Math.abs(scale.x.range()[1] - scale.x.range()[0]);
+  return (width / (2 * Math.PI * r)) * angularRange;
+};
+
+const transformAngle = (angle) => {
+  return -1 * angle + (Math.PI / 2);
+};
+
+export const getCustomBarPath = (props, width) => {
+  const { getPath } = props;
+  const propsWithCalculatedValues = { ...props, ...getPosition(props, width) };
+  return getPath(propsWithCalculatedValues);
+};
+
+const getStartAngle = (props, index) => {
+  const { data, scale, alignment } = props;
+  const currentAngle = getAngle(props, index);
+  const angularRange = Math.abs(scale.x.range()[1] - scale.x.range()[0]);
+  const previousAngle = index === 0 ?
+    getAngle(props, data.length - 1) - (Math.PI * 2) :
+    getAngle(props, index - 1);
+  if (index === 0 && angularRange < (2 * Math.PI)) {
+    return scale.x.range()[0];
+  } else if (alignment === "start" || alignment === "end") {
+    return alignment === "start" ? previousAngle : currentAngle;
+  } else {
+    return (currentAngle + previousAngle) / 2;
+  }
+};
+
+const getEndAngle = (props, index) => {
+  const { data, scale, alignment } = props;
+  const currentAngle = getAngle(props, index);
+  const angularRange = Math.abs(scale.x.range()[1] - scale.x.range()[0]);
+  const lastAngle = scale.x.range()[1] === (2 * Math.PI) ?
+    getAngle(props, 0) + (Math.PI * 2) : scale.x.range()[1];
+  const nextAngle = index === data.length - 1 ?
+    getAngle(props, 0) + (Math.PI * 2) : getAngle(props, index + 1);
+  if (index === data.length - 1 && angularRange < (2 * Math.PI)) {
+    return lastAngle;
+  } else if (alignment === "start" || alignment === "end") {
+    return alignment === "start" ? currentAngle : nextAngle;
+  } else {
+    return (currentAngle + nextAngle) / 2;
+  }
+};
+
+// eslint-disable-next-line max-statements, max-len
+export const getVerticalBarPath = (props, width, cornerRadius) => {
+
+  const { x0, x1, y0, y1 } = getPosition(props, width);
+  const sign = y0 > y1 ? 1 : -1;
+  const direction = sign > 0 ? "0 0 1" : "0 0 0";
+
+  const isSelfIntersecting = sign === 1 ?
+    (y0 - cornerRadius.bottom) < (y1 + cornerRadius.top) :
+    (y1 - cornerRadius.bottom) < (y0 + cornerRadius.top);
+
+  const topArc = `${cornerRadius.top} ${cornerRadius.top} ${direction}`;
+  const bottomArc = `${cornerRadius.bottom} ${cornerRadius.bottom} ${direction}`;
+
+  let start = `M ${x0 + cornerRadius.bottom}, ${y0}`;
+  let bottomLeftArc = `A ${bottomArc}, ${x0}, ${y0 - sign * cornerRadius.bottom}`;
+  let leftLine = `L ${x0}, ${y1 + sign * cornerRadius.top}`;
+  let topLeftArc = `A ${topArc}, ${x0 + cornerRadius.top}, ${y1}`;
+  let topLine = `L ${x1 - cornerRadius.top}, ${y1}`;
+  let topRightArc = `A ${topArc}, ${x1}, ${y1 + sign * cornerRadius.top}`;
+  let rightLine = `L ${x1}, ${y0 - sign * cornerRadius.bottom}`;
+  let bottomRightArc = `A ${bottomArc}, ${x1 - cornerRadius.bottom}, ${y0}`;
+  const end = "z";
+
+  if (isSelfIntersecting) {
+
+    const topLeftCenter = new Point(x0 + cornerRadius.top, y1 + sign * cornerRadius.top);
+    const topLeftCircle = new Circle(topLeftCenter, cornerRadius.top);
+    const bottomLeftCenter = new Point(x0 + cornerRadius.bottom, y0 - sign * cornerRadius.bottom);
+    const bottomLeftCircle = new Circle(bottomLeftCenter, cornerRadius.bottom);
+    const topRightCenter = new Point(x1 - cornerRadius.top, y1 + sign * cornerRadius.top);
+    const topRightCircle = new Circle(topRightCenter, cornerRadius.top);
+    // eslint-disable-next-line max-len
+    const bottomRightCenter = new Point(x1 - cornerRadius.bottom, y0 - sign * cornerRadius.bottom);
+    const bottomRightCircle = new Circle(bottomRightCenter, cornerRadius.bottom);
+
+    leftLine = null;
+    rightLine = null;
+
+    if (cornerRadius.top !== 0 && cornerRadius.bottom !== 0) {
+
+      // find intersection of top left and bottom left arc
+      // circles intersect at two points, get the left-most point
+      const intrxnLeft = topLeftCircle.intersection(bottomLeftCircle)[0];
+
+      // find intersection of top right and bottom right arc
+      // circles intersect at two points, get the right-most point
+      const intrxnRight = topRightCircle.intersection(bottomRightCircle)[1];
+
+      bottomLeftArc = `A ${bottomArc}, ${intrxnLeft.x}, ${intrxnLeft.y}`;
+      topRightArc = `A ${topArc}, ${intrxnRight.x}, ${intrxnRight.y}`;
+    }
+
+    if (cornerRadius.top !== 0 && cornerRadius.bottom === 0) {
+
+      // find intersection of y0 and the top left/right arc
+      const intrxnLeftX = topLeftCircle.solveX(y0)[0];
+      const intrxnRightX = topRightCircle.solveX(y0)[1];
+
+      start = `M ${intrxnLeftX}, ${y0}`;
+      bottomLeftArc = null;
+      topRightArc = `A ${topArc}, ${intrxnRightX}, ${y0}`;
+      bottomRightArc = null;
+
+    }
+
+    if (cornerRadius.top === 0 && cornerRadius.bottom !== 0) {
+
+      // find intersection of y1 and the bottom left/right arc
+      const intrxnLeftX = bottomLeftCircle.solveX(y1)[0];
+      const intrxnRightX = bottomRightCircle.solveX(y1)[1];
+
+      bottomLeftArc = `A ${bottomArc}, ${intrxnLeftX}, ${y1}`;
+      topLeftArc = null;
+      topLine = `L ${intrxnRightX}, ${y1}`;
+      topRightArc = null;
+
+    }
+  }
+
+  return [ start,
+    bottomLeftArc,
+    leftLine,
+    topLeftArc,
+    topLine,
+    topRightArc,
+    rightLine,
+    bottomRightArc,
+    end ].filter((l) => l !== null).join("\n");
+
+};
+
+export const getHorizontalBarPath = (props, width, cornerRadius) => {
+  const { x0, x1, y0, y1 } = getPosition(props, width);
+  const sign = y1 > y0 ? 1 : -1;
+  const direction = sign > 0 ? "0 0 1" : "0 0 0";
+  const topArc = `${cornerRadius.top} ${cornerRadius.top} ${direction}`;
+  const bottomArc = `${cornerRadius.bottom} ${cornerRadius.bottom} ${direction}`;
+
+  const start = `M ${y0}, ${x1 + sign * cornerRadius.bottom}`;
+  const topLeftArc = `A ${bottomArc}, ${y0 + cornerRadius.bottom}, ${x1}`;
+  const topLine = `L ${y1 - sign * cornerRadius.top}, ${x1}`;
+  const topRightArc = `A ${topArc}, ${y1}, ${x1 + cornerRadius.top}`;
+  const rightLine = `L ${y1}, ${x0 - cornerRadius.top}`;
+  const bottomRightArc = `A ${topArc}, ${y1 - sign * cornerRadius.top}, ${x0}`;
+  const bottomLine = `L ${y0 + cornerRadius.bottom}, ${x0 }`;
+  const bottomLeftArc = `A ${bottomArc}, ${y0}, ${x0 - sign * cornerRadius.bottom}`;
+  const end = "z";
+
+  return [ start,
+    topLeftArc,
+    topLine,
+    topRightArc,
+    rightLine,
+    bottomRightArc,
+    bottomLine,
+    bottomLeftArc,
+    end ].join("\n");
+
+};
+
+const getCustomVerticalPolarBarPath = (getPath, props) => {
+  return getPath(props);
+};
+
+// eslint-disable-next-line max-statements, max-len
+export const getVerticalPolarBarPath = (props, cornerRadius) => {
+  const { datum, scale, index, alignment } = props;
+  const style = Helpers.evaluateStyle(props.style, datum, props.active);
+  const r1 = scale.y(datum._y0 || 0);
+  const r2 = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
+  const currentAngle = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
+  let start;
+  let end;
+  if (style.width) {
+    const width = getAngularWidth(props, style.width);
+    const size = alignment === "middle" ? width / 2 : width;
+    start = alignment === "start" ? currentAngle : currentAngle - size;
+    end = alignment === "end" ? currentAngle : currentAngle + size;
+  } else {
+    start = getStartAngle(props, index);
+    end = getEndAngle(props, index);
+  }
+
+  start = transformAngle(start);
+  end = transformAngle(end);
+  if (props.getPath) {
+    const options = { startAngle: start, endAngle: end, r1, r2, cornerRadius };
+    const propsWithCalculatedValues = { ...props, ...options };
+    return getCustomVerticalPolarBarPath(props.getPath, propsWithCalculatedValues);
+  }
+
+  const getPath = (edge) => {
+    const pathFunction = d3Shape.arc()
+    .innerRadius(r1)
+    .outerRadius(r2)
+    .startAngle(start)
+    .endAngle(end)
+    .cornerRadius(cornerRadius[edge]);
+    const path = pathFunction();
+    const moves = path.match(/[A-Z]/g);
+    const middle = moves.indexOf("L");
+    const coords = path.split(/[A-Z]/).slice(1);
+    const subMoves = edge === "top" ? moves.slice(0, middle) : moves.slice(middle);
+    const subCoords = edge === "top" ? coords.slice(0, middle) : coords.slice(middle);
+    return subMoves.map((m, i) => ({ command: m, coords: subCoords[i].split(",") }));
+  };
+
+  const moves = getPath("top").concat(getPath("bottom"));
+  return moves.reduce((memo, move) => {
+    memo += `${move.command} ${move.coords.join()}`;
+    return memo;
+  }, "");
+};

--- a/packages/victory-bar/src/path-helper-methods.js
+++ b/packages/victory-bar/src/path-helper-methods.js
@@ -218,6 +218,7 @@ const getCustomVerticalPolarBarPath = (getPath, props) => {
 };
 
 // eslint-disable-next-line max-statements, max-len
+// TODO: Fix this to support cornerRadius with topLeft, topRight, etc
 export const getVerticalPolarBarPath = (props, cornerRadius) => {
 
   const { datum, scale, index, alignment } = props;
@@ -256,6 +257,7 @@ export const getVerticalPolarBarPath = (props, cornerRadius) => {
     const moves = path.match(/[A-Z]/g);
     const coords = path.split(/[A-Z]/).slice(1);
     let moveStart;
+    // jank code
     if (edge === "topRight") {
       moveStart = 0;
     } else if (edge === "topLeft") {

--- a/packages/victory-bar/src/path-helper-methods.js
+++ b/packages/victory-bar/src/path-helper-methods.js
@@ -1,7 +1,7 @@
 import { Helpers } from "victory-core";
 import * as d3Shape from "d3-shape";
 
-import { Circle, Point } from "./geometry-helper-methods";
+import { circle, point } from "./geometry-helper-methods";
 
 const getPosition = (props, width) => {
   const { x, y, y0, horizontal } = props;
@@ -108,11 +108,10 @@ const getVerticalBarPoints = (position, sign, cr) => {
       y0 + cr[`bottom${side}`] > y1 - cr[`top${side}`];
 
     if (hasIntersection) {
-      const topCenter = new Point(x + signL * cr[`top${side}`], y1 + sign * cr[`top${side}`]);
-      const topCircle = new Circle(topCenter, cr[`top${side}`]);
-      const bottomCenter = new Point(x + signL * cr[`bottom${side}`],
-                                     y0 - sign * cr[`bottom${side}`]);
-      const bottomCircle = new Circle(bottomCenter, cr[`bottom${side}`]);
+      const topCenter = point(x + signL * cr[`top${side}`], y1 + sign * cr[`top${side}`]);
+      const topCircle = circle(topCenter, cr[`top${side}`]);
+      const bottomCenter = point(x + signL * cr[`bottom${side}`], y0 - sign * cr[`bottom${side}`]);
+      const bottomCircle = circle(bottomCenter, cr[`bottom${side}`]);
       const circleIntersection = topCircle.intersection(bottomCircle);
       const hasArcIntersection = circleIntersection.length > 0;
       if (hasArcIntersection) {
@@ -170,11 +169,10 @@ const getHorizontalBarPoints = (position, sign, cr) => {
       y0 + cr[`bottom${side}`] > y1 - cr[`top${side}`] :
       y0 - cr[`bottom${side}`] < y1 + cr[`top${side}`];
     if (hasIntersection) {
-      const topCenter = new Point(y1 - sign * cr[`top${side}`], x + signL * cr[`top${side}`]);
-      const topCircle = new Circle(topCenter, cr[`top${side}`]);
-      const bottomCenter = new Point(y0 + sign * cr[`bottom${side}`],
-                                     x + signL * cr[`bottom${side}`]);
-      const bottomCircle = new Circle(bottomCenter, cr[`bottom${side}`]);
+      const topCenter = point(y1 - sign * cr[`top${side}`], x + signL * cr[`top${side}`]);
+      const topCircle = circle(topCenter, cr[`top${side}`]);
+      const bottomCenter = point(y0 + sign * cr[`bottom${side}`], x + signL * cr[`bottom${side}`]);
+      const bottomCircle = circle(bottomCenter, cr[`bottom${side}`]);
       const circleIntersection = topCircle.intersection(bottomCircle);
       const hasArcIntersection = circleIntersection.length > 0;
       if (hasArcIntersection) {

--- a/packages/victory-bar/src/path-helper-methods.js
+++ b/packages/victory-bar/src/path-helper-methods.js
@@ -217,8 +217,8 @@ const getCustomVerticalPolarBarPath = (getPath, props) => {
   return getPath(props);
 };
 
-// eslint-disable-next-line max-statements, max-len
 // TODO: Fix this to support cornerRadius with topLeft, topRight, etc
+// eslint-disable-next-line max-statements, max-len
 export const getVerticalPolarBarPath = (props, cornerRadius) => {
 
   const { datum, scale, index, alignment } = props;

--- a/packages/victory-bar/src/victory-bar.js
+++ b/packages/victory-bar/src/victory-bar.js
@@ -57,7 +57,11 @@ class VictoryBar extends React.Component {
       PropTypes.func,
       PropTypes.shape({
         top: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-        bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
+        topLeft: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        topRight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        bottomLeft: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        bottomRight: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
       })
     ]),
     getPath: PropTypes.func,

--- a/stories/data.js
+++ b/stories/data.js
@@ -33,6 +33,15 @@ const getData = (num, seed) => {
   return range(num).map((v) => ({ x: v + 1, y: rand() }));
 };
 
+const getDescendingSmallData = () => {
+  return [
+    { x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: .5 },
+    { x: 4, y: .2 }, { x: 5, y: .1 }, { x: 6, y: -.1 },
+    { x: 7, y: -.2 }, { x: 8, y: -.5 }, { x: 9, y: -1 },
+    { x: 10, y: -2 }
+  ];
+};
+
 const getStringData = (num, seed) => {
   seed = seed || "getData";
   const baseSeed = seedrandom(seed);
@@ -84,5 +93,6 @@ const getStackedData = (num, samples, useStrings) => {
 
 export {
   getData, getStringData, getMixedData, getTimeData,
-  getLogData, getFourQuadrantData, getArrayData, getStackedData
+  getLogData, getFourQuadrantData, getArrayData, getStackedData,
+  getDescendingSmallData
 };

--- a/stories/victory-bar.js
+++ b/stories/victory-bar.js
@@ -6,8 +6,15 @@ import { VictoryStack } from "../packages/victory-stack/src/index";
 import { VictoryBar } from "../packages/victory-bar/src/index";
 import { VictoryTooltip } from "../packages/victory-tooltip/src/index";
 import { VictoryTheme } from "../packages/victory-core/src/index";
-import { getData, getStackedData, getMixedData, getTimeData, getLogData } from "./data";
 import { getChartDecorator, getPolarChartDecorator } from "./decorators";
+import {
+  getData,
+  getStackedData,
+  getMixedData,
+  getTimeData,
+  getLogData,
+  getDescendingSmallData
+} from "./data";
 import * as d3Shape from "d3-shape";
 
 storiesOf("VictoryBar", module)
@@ -99,7 +106,20 @@ storiesOf("VictoryBar.cornerRadius", module)
   .add("cornerRadius = 5 (horizontal negative values)", () => (
     <VictoryBar horizontal data={getMixedData(5)} cornerRadius={5}/>
   ))
-  .add("cornerRadius = 3 (20 bars)", () => <VictoryBar data={getData(20)} cornerRadius={3}/>);
+  .add("cornerRadius = 3 (20 bars)", () => <VictoryBar data={getData(20)} cornerRadius={3}/>)
+  .add("cornerRadius = mixed", () => (
+    <VictoryBar
+      data={getDescendingSmallData()}
+      cornerRadius={{ topLeft: 5, topRight: 2, bottomLeft: 7, bottomRight: 3 }}
+    />
+  ))
+  .add("cornerRadius = mixed (horizontal)", () => (
+    <VictoryBar
+      horizontal
+      data={getDescendingSmallData()}
+      cornerRadius={{ topLeft: 5, topRight: 2, bottomLeft: 7, bottomRight: 3 }}
+    />
+  ));
 
 storiesOf("VictoryBar.getPath", module)
   .addDecorator(getChartDecorator({ domainPadding: 25 }))

--- a/stories/victory-bar.js
+++ b/stories/victory-bar.js
@@ -6,6 +6,8 @@ import { VictoryStack } from "../packages/victory-stack/src/index";
 import { VictoryBar } from "../packages/victory-bar/src/index";
 import { VictoryTooltip } from "../packages/victory-tooltip/src/index";
 import { VictoryTheme } from "../packages/victory-core/src/index";
+import { VictoryPolarAxis } from "../packages/victory-polar-axis/src/index";
+import { VictoryChart } from "../packages/victory-chart/src/index";
 import { getChartDecorator, getPolarChartDecorator } from "./decorators";
 import {
   getData,
@@ -119,6 +121,32 @@ storiesOf("VictoryBar.cornerRadius", module)
       data={getDescendingSmallData()}
       cornerRadius={{ topLeft: 5, topRight: 2, bottomLeft: 7, bottomRight: 3 }}
     />
+  ));
+
+storiesOf("VictoryBar.cornerRadius", module)
+  .add("cornerRadius = mixed (polar)", () => (
+    <VictoryChart polar
+      theme={VictoryTheme.material}
+      domain={{ x: [0, 360] }}
+      innerRadius={60}
+    >
+      <VictoryPolarAxis
+        labelPlacement="parallel"
+        tickValues={[0, 45, 90, 135, 180, 225, 270, 315]}
+      />
+      <VictoryBar
+        cornerRadius={{ topRight: 1, topLeft: 10, bottomRight: 5, bottomLeft: 0 }}
+        style={{ data: { fill: "tomato", width: 20 } }}
+        data={[
+          { x: 45, y: 20 },
+          { x: 90, y: 30 },
+          { x: 135, y: 65 },
+          { x: 180, y: 50 },
+          { x: 270, y: 40 },
+          { x: 315, y: 30 }
+        ]}
+      />
+    </VictoryChart>
   ));
 
 storiesOf("VictoryBar.getPath", module)

--- a/test/client/spec/victory-bar/geometry-helper-methods.spec.js
+++ b/test/client/spec/victory-bar/geometry-helper-methods.spec.js
@@ -1,48 +1,48 @@
-import { Circle, Point } from "packages/victory-bar/src/geometry-helper-methods";
+import { circle, point } from "packages/victory-bar/src/geometry-helper-methods";
 
 const epsilon = 0.01; // float imprecision
 
-describe("Point", () => {
+describe("point", () => {
   it("calculates distance correctly for positive coordinates", () => {
-    const p0 = new Point(1, 2);
-    const p1 = new Point(2, 3);
+    const p0 = point(1, 2);
+    const p1 = point(2, 3);
     const answer = Math.sqrt(2);
     expect(p0.distance(p1)).to.be.within(answer - epsilon, answer + epsilon);
   });
   it("calculates distance correctly for negative coordinates", () => {
-    const p0 = new Point(-1, -2);
-    const p1 = new Point(-2, -3);
+    const p0 = point(-1, -2);
+    const p1 = point(-2, -3);
     const answer = Math.sqrt(2);
     expect(p0.distance(p1)).to.be.within(answer - epsilon, answer + epsilon);
   });
   it("calculates distance correctly for zero coordinates", () => {
-    const p0 = new Point(0, 0);
-    const p1 = new Point(0, 0);
+    const p0 = point(0, 0);
+    const p1 = point(0, 0);
     const answer = 0;
     expect(p0.distance(p1)).to.be.within(answer - epsilon, answer + epsilon);
   });
   it("can add correctly", () => {
-    const p0 = new Point(1, 1);
-    const p1 = new Point(2, 3);
+    const p0 = point(1, 1);
+    const p1 = point(2, 3);
     const { x, y } = p0.add(p1);
     expect(x).to.equal(3);
     expect(y).to.equal(4);
   });
   it("can subtract correctly", () => {
-    const p0 = new Point(1, 1);
-    const p1 = new Point(2, 3);
+    const p0 = point(1, 1);
+    const p1 = point(2, 3);
     const { x, y } = p1.subtract(p0);
     expect(x).to.equal(1);
     expect(y).to.equal(2);
   });
   it("can scalar multiply correctly", () => {
-    const p = new Point(3, 4);
+    const p = point(3, 4);
     const { x, y } = p.scalarMult(-2);
     expect(x).to.equal(-6);
     expect(y).to.equal(-8);
   });
   it("can scalar divide correctly", () => {
-    const p = new Point(3, 4);
+    const p = point(3, 4);
     const { x, y } = p.scalarDivide(2);
     const answerX = 1.5;
     const answerY = 2;
@@ -50,53 +50,57 @@ describe("Point", () => {
     expect(y).to.be.within(answerY - epsilon, answerY + epsilon);
   });
   it("throws when dividing by zero", () => {
-    const p = new Point(3, 4);
+    const p = point(3, 4);
     expect(() => p.scalarDivide(0)).to.throw();
   });
   it("can check for equality correctly", () => {
-    const p0 = new Point(3, 4);
-    const p1 = new Point(3, 4);
+    const p0 = point(3, 4);
+    const p1 = point(3, 4);
     expect(p0.equals(p1)).to.equal(true);
   });
 });
 
-describe("Circle", () => {
+describe("circle", () => {
   describe("calculates circle-circle intersection correctly", () => {
     it("handles separate circles", () => {
-      const c0 = new Circle(new Point(0, 0), 1);
-      const c1 = new Circle(new Point(0, 10), 1);
+      const c0 = circle(point(0, 0), 1);
+      const c1 = circle(point(0, 10), 1);
       expect(c0.intersection(c1)).to.eql([]);
     });
     it("handles one circle containing another", () => {
-      const c0 = new Circle(new Point(0, 0), 2);
-      const c1 = new Circle(new Point(0, 0), 10);
+      const c0 = circle(point(0, 0), 2);
+      const c1 = circle(point(0, 0), 10);
       expect(c0.intersection(c1)).to.eql([]);
     });
     it("handles same circle case", () => {
-      const c0 = new Circle(new Point(0, 0), 1);
-      const c1 = new Circle(new Point(0, 0), 1);
+      const c0 = circle(point(0, 0), 1);
+      const c1 = circle(point(0, 0), 1);
       expect(c0.intersection(c1)).to.eql([]);
     });
     it("handles circles of zero radius", () => {
       // I chose to define the intersection as 'none'
-      // instead of Point(0, 0) to stay consistent with
+      // instead of point(0, 0) to stay consistent with
       // the "handles same circle case" above
-      const c0 = new Circle(new Point(0, 0), 0);
-      const c1 = new Circle(new Point(0, 0), 0);
+      const c0 = circle(point(0, 0), 0);
+      const c1 = circle(point(0, 0), 0);
       expect(c0.intersection(c1)).to.eql([]);
 
-      const c2 = new Circle(new Point(0, 0), 0);
-      const c3 = new Circle(new Point(0, 1), 0);
+      const c2 = circle(point(0, 0), 0);
+      const c3 = circle(point(0, 1), 0);
       expect(c2.intersection(c3)).to.eql([]);
     });
     it("handles circles meeting at exactly one point", () => {
-      const c0 = new Circle(new Point(0, 0), 1);
-      const c1 = new Circle(new Point(0, 2), 1);
-      expect(c0.intersection(c1)).to.eql([new Point(0, 1), new Point(0, 1)]);
+      const c0 = circle(point(0, 0), 1);
+      const c1 = circle(point(0, 2), 1);
+      const [{ x: x0, y: y0 }, { x: x1, y: y1 }] = c0.intersection(c1);
+      expect(x0).to.equal(0);
+      expect(x1).to.equal(0);
+      expect(y0).to.equal(1);
+      expect(y1).to.equal(1);
     });
     it("handles circles meeting at two points", () => {
-      const c0 = new Circle(new Point(2, 3), 3);
-      const c1 = new Circle(new Point(1, -1), 4);
+      const c0 = circle(point(2, 3), 3);
+      const c1 = circle(point(1, -1), 4);
       const [ { x: x0, y: y0 }, { x: x1, y: y1 } ] = c0.intersection(c1);
       expect(x0).to.be.within(-0.96 - epsilon, -0.96 + epsilon);
       expect(y0).to.be.within(2.49 - epsilon, 2.49 + epsilon);
@@ -104,8 +108,8 @@ describe("Circle", () => {
       expect(y1).to.be.within(1.16 - epsilon, 1.16 + epsilon);
     });
     it("the left-most point is the 0th element, the right-most is the 1st", () => {
-      const c0 = new Circle(new Point(2, 3), 3);
-      const c1 = new Circle(new Point(1, -1), 4);
+      const c0 = circle(point(2, 3), 3);
+      const c1 = circle(point(1, -1), 4);
       const [ { x: x0 }, { x: x1 } ] = c0.intersection(c1);
       expect(x0 <= x1).to.equal(true);
     });

--- a/test/client/spec/victory-bar/geometry-helper-methods.spec.js
+++ b/test/client/spec/victory-bar/geometry-helper-methods.spec.js
@@ -1,0 +1,115 @@
+import { Circle, Point } from "packages/victory-bar/src/geometry-helper-methods";
+
+const epsilon = 0.01; // float imprecision
+
+describe("Point", () => {
+  it("calculates distance correctly for positive coordinates", () => {
+    const p0 = new Point(1, 2);
+    const p1 = new Point(2, 3);
+    const answer = Math.sqrt(2);
+    expect(p0.distance(p1)).to.be.within(answer - epsilon, answer + epsilon);
+  });
+  it("calculates distance correctly for negative coordinates", () => {
+    const p0 = new Point(-1, -2);
+    const p1 = new Point(-2, -3);
+    const answer = Math.sqrt(2);
+    expect(p0.distance(p1)).to.be.within(answer - epsilon, answer + epsilon);
+  });
+  it("calculates distance correctly for zero coordinates", () => {
+    const p0 = new Point(0, 0);
+    const p1 = new Point(0, 0);
+    const answer = 0;
+    expect(p0.distance(p1)).to.be.within(answer - epsilon, answer + epsilon);
+  });
+  it("can add correctly", () => {
+    const p0 = new Point(1, 1);
+    const p1 = new Point(2, 3);
+    const { x, y } = p0.add(p1);
+    expect(x).to.equal(3);
+    expect(y).to.equal(4);
+  });
+  it("can subtract correctly", () => {
+    const p0 = new Point(1, 1);
+    const p1 = new Point(2, 3);
+    const { x, y } = p1.subtract(p0);
+    expect(x).to.equal(1);
+    expect(y).to.equal(2);
+  });
+  it("can scalar multiply correctly", () => {
+    const p = new Point(3, 4);
+    const { x, y } = p.scalarMult(-2);
+    expect(x).to.equal(-6);
+    expect(y).to.equal(-8);
+  });
+  it("can scalar divide correctly", () => {
+    const p = new Point(3, 4);
+    const { x, y } = p.scalarDivide(2);
+    const answerX = 1.5;
+    const answerY = 2;
+    expect(x).to.be.within(answerX - epsilon, answerX + epsilon);
+    expect(y).to.be.within(answerY - epsilon, answerY + epsilon);
+  });
+  it("throws when dividing by zero", () => {
+    const p = new Point(3, 4);
+    expect(() => p.scalarDivide(0)).to.throw();
+  });
+  it("can check for equality correctly", () => {
+    const p0 = new Point(3, 4);
+    const p1 = new Point(3, 4);
+    expect(p0.equals(p1)).to.equal(true);
+  });
+});
+
+describe("Circle", () => {
+  describe("calculates circle-circle intersection correctly", () => {
+    it("handles separate circles", () => {
+      const c0 = new Circle(new Point(0, 0), 1);
+      const c1 = new Circle(new Point(0, 10), 1);
+      expect(c0.intersection(c1)).to.eql([]);
+    });
+    it("handles one circle containing another", () => {
+      const c0 = new Circle(new Point(0, 0), 2);
+      const c1 = new Circle(new Point(0, 0), 10);
+      expect(c0.intersection(c1)).to.eql([]);
+    });
+    it("handles same circle case", () => {
+      const c0 = new Circle(new Point(0, 0), 1);
+      const c1 = new Circle(new Point(0, 0), 1);
+      expect(c0.intersection(c1)).to.eql([]);
+    });
+    it("handles circles of zero radius", () => {
+      // I chose to define the intersection as 'none'
+      // instead of Point(0, 0) to stay consistent with
+      // the "handles same circle case" above
+      const c0 = new Circle(new Point(0, 0), 0);
+      const c1 = new Circle(new Point(0, 0), 0);
+      expect(c0.intersection(c1)).to.eql([]);
+
+      const c2 = new Circle(new Point(0, 0), 0);
+      const c3 = new Circle(new Point(0, 1), 0);
+      expect(c2.intersection(c3)).to.eql([]);
+    });
+    it("handles circles meeting at exactly one point", () => {
+      const c0 = new Circle(new Point(0, 0), 1);
+      const c1 = new Circle(new Point(0, 2), 1);
+      expect(c0.intersection(c1)).to.eql([new Point(0, 1), new Point(0, 1)]);
+    });
+    it("handles circles meeting at two points", () => {
+      const c0 = new Circle(new Point(2, 3), 3);
+      const c1 = new Circle(new Point(1, -1), 4);
+      const [ { x: x0, y: y0 }, { x: x1, y: y1 } ] = c0.intersection(c1);
+      expect(x0).to.be.within(-0.96 - epsilon, -0.96 + epsilon);
+      expect(y0).to.be.within(2.49 - epsilon, 2.49 + epsilon);
+      expect(x1).to.be.within(4.37 - epsilon, 4.37 + epsilon);
+      expect(y1).to.be.within(1.16 - epsilon, 1.16 + epsilon);
+    });
+    it("the left-most point is the 0th element, the right-most is the 1st", () => {
+      const c0 = new Circle(new Point(2, 3), 3);
+      const c1 = new Circle(new Point(1, -1), 4);
+      const [ { x: x0 }, { x: x1 } ] = c0.intersection(c1);
+      expect(x0 <= x1).to.equal(true);
+    });
+  });
+});
+
+


### PR DESCRIPTION
This PR:

- Adds support or `topLeft`, `topRight`, `bottomLeft` and `bottomRight` values for `cornerRadius` for `VictoryBar` fixes #1119 

- Prevents weird artifacts when bars with cornerRadius are too short fixes #895 

@narinluangrath the fix for polar bar corner radius ended up being super fiddly! 