### PR TITLE
don't need to clone child with parent props

### DIFF
--- a/packages/victory-shared-events/src/victory-shared-events.js
+++ b/packages/victory-shared-events/src/victory-shared-events.js
@@ -137,9 +137,8 @@ export default class VictorySharedEvents extends React.Component {
   }
 
   getBasePropsFromChildren(childComponents) {
-    const iteratee = (child, childName, parent) => {
+    const iteratee = (child, childName) => {
       if (child.type && isFunction(child.type.getBaseProps)) {
-        child = parent ? React.cloneElement(child, parent.props) : child;
         const baseProps = child.props && child.type.getBaseProps(child.props);
         return baseProps ? [[childName, baseProps]] : null;
       } else {


### PR DESCRIPTION
This is no longer necessary after the addition of the concept of shared props in `Helpers.reduceChildren`, and was causing parent styles to incorrectly override child styles