### PR TITLE
docs(victory-bar): Typo fix

### DIFF
--- a/packages/victory-bar/README.md
+++ b/packages/victory-bar/README.md
@@ -99,7 +99,7 @@ containerComponent={<VictoryVoronoiContainer/>}
 
 `type: function || number || { top: number || function, bottom: number || function }`
 
-The `cornerRadius` prop specifies a radius to apply to each bar. If this prop is given as a single number, the radius will only be applied to the _top_ of each bar. When this prop is given as a function, it will be evaulated with the arguments `datum`, and `active`.
+The `cornerRadius` prop specifies a radius to apply to each bar. If this prop is given as a single number, the radius will only be applied to the _top_ of each bar. When this prop is given as a function, it will be evaluated with the arguments `datum`, and `active`.
 
 ```playground
 <VictoryChart


### PR DESCRIPTION
`evaulated` => `evaluated`