### PR TITLE
fix(bar): Bar chart is missing bar for the first value

### DIFF
--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -42,12 +42,10 @@ const getBaseProps = (props, fallbackProps) => {
     alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
     polar, scale, sharedEvents, standalone, style, theme, width, labels, name, barWidth, getPath
   } = props;
-  const initialChildProps = {
-    parent: {
+  const initialChildProps = { parent: {
       domain, scale, width, height, data, standalone, name,
       theme, polar, origin, padding, style: style.parent
-    }
-  };
+  } };
 
   return data.reduce((childProps, datum, index) => {
     const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -43,8 +43,8 @@ const getBaseProps = (props, fallbackProps) => {
     polar, scale, sharedEvents, standalone, style, theme, width, labels, name, barWidth, getPath
   } = props;
   const initialChildProps = { parent: {
-      domain, scale, width, height, data, standalone, name,
-      theme, polar, origin, padding, style: style.parent
+    domain, scale, width, height, data, standalone, name,
+    theme, polar, origin, padding, style: style.parent
   } };
 
   return data.reduce((childProps, datum, index) => {

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -1,4 +1,4 @@
-import { assign } from "lodash";
+import { assign, isNil } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
 const getBarPosition = (props, datum) => {
@@ -42,13 +42,15 @@ const getBaseProps = (props, fallbackProps) => {
     alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
     polar, scale, sharedEvents, standalone, style, theme, width, labels, name, barWidth, getPath
   } = props;
-  const initialChildProps = { parent: {
-    domain, scale, width, height, data, standalone, name,
-    theme, polar, origin, padding, style: style.parent
-  } };
+  const initialChildProps = {
+    parent: {
+      domain, scale, width, height, data, standalone, name,
+      theme, polar, origin, padding, style: style.parent
+    }
+  };
 
   return data.reduce((childProps, datum, index) => {
-    const eventKey = datum.eventKey || index;
+    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
     const { x, y, y0, x0 } = getBarPosition(props, datum);
     const dataProps = {
       alignment, barRatio, cornerRadius, data, datum, horizontal, index, polar, origin,


### PR DESCRIPTION
fix(helper-method) getBaseProps incorrect handles when eventKey is 0 and loses the data.  Only fail over to the index if the eventKey is truly null or undefined.

Closes issue #1175  