### PR TITLE
Victory legend auto rows

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -28,6 +28,7 @@ const loadStories = () => {
   require("../stories/victory-chart");
   require("../stories/victory-errorbar");
   require("../stories/victory-line");
+  require("../stories/victory-legend");
   require("../stories/victory-polar-axis");
   require("../stories/victory-scatter");
   require("../stories/containers-and-addons");

--- a/packages/victory-legend/src/helper-methods.js
+++ b/packages/victory-legend/src/helper-methods.js
@@ -204,9 +204,37 @@ const getDimensions = (props, fallbackProps) => {
   };
 };
 
+const getItemsPerRow = (props) => {
+  props = getCalculatedValues(props);
+  const { data, isHorizontal, legendWidth } = props;
+  const useLegendWidth = legendWidth && !props.itemsPerRow && data && data.length
+
+  const tryItemsPerRow = (itemsPerRow) => {
+    const dimensions = getDimensions(assign({}, props, { itemsPerRow }));
+    const currentWidth = isHorizontal ? dimensions.width : dimensions.height;
+    return (
+      // NOTE: Technically, this ternary is *chained*, not *nested*
+      /*eslint-disable no-nested-ternary*/
+      itemsPerRow >= data.length
+        ? undefined
+      : currentWidth > legendWidth
+        ? Math.max(itemsPerRow - 1, 1)
+      : tryItemsPerRow(itemsPerRow + 1)
+      /*eslint-enable no-nested-ternary*/
+    );
+  };
+
+  return assign({}, props, { itemsPerRow: useLegendWidth ? tryItemsPerRow(1) : props.itemsPerRow });
+};
+
 const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "legend");
-  props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  props = assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+    getItemsPerRow(modifiedProps)
+  );
   const {
     data, standalone, theme, padding, style, colorScale, gutter, rowGutter,
     borderPadding, title, titleOrientation, name, x = 0, y = 0

--- a/packages/victory-legend/src/helper-methods.js
+++ b/packages/victory-legend/src/helper-methods.js
@@ -193,13 +193,13 @@ const _getDimensionsInternal = (props) => {
 };
 
 const _getDimensionsWithBorderPadding = (props) => {
-  const { height: contentHeight, width: contentWidth } = _getDimensionsInternal(props)
+  const { height: contentHeight, width: contentWidth } = _getDimensionsInternal(props);
   return pick(getBorderProps(props, contentHeight, contentWidth), ["height", "width"]);
 };
 
 const getItemsPerRow = (props) => {
   const { data, isHorizontal, legendWidth } = props;
-  const useLegendWidth = legendWidth && !props.itemsPerRow && data && data.length
+  const useLegendWidth = legendWidth && !props.itemsPerRow && data && data.length;
 
   const tryItemsPerRow = (itemsPerRow) => {
     const dimensions = _getDimensionsWithBorderPadding(assign({}, props, { itemsPerRow }));

--- a/packages/victory-legend/src/helper-methods.js
+++ b/packages/victory-legend/src/helper-methods.js
@@ -1,4 +1,4 @@
-import { defaults, assign, groupBy, keys, sum, range } from "lodash";
+import { defaults, assign, groupBy, keys, pick, sum, range } from "lodash";
 import { Helpers, Style, TextSize } from "victory-core";
 
 const getColorScale = (props) => {
@@ -204,13 +204,18 @@ const getDimensions = (props, fallbackProps) => {
   };
 };
 
+const _getDimensionsWithBorderPadding = (props) => {
+  const { height: contentHeight, width: contentWidth } = getDimensions(props)
+  return pick(getBorderProps(props, contentHeight, contentWidth), ["height", "width"]);
+};
+
 const getItemsPerRow = (props) => {
   props = getCalculatedValues(props);
   const { data, isHorizontal, legendWidth } = props;
   const useLegendWidth = legendWidth && !props.itemsPerRow && data && data.length
 
   const tryItemsPerRow = (itemsPerRow) => {
-    const dimensions = getDimensions(assign({}, props, { itemsPerRow }));
+    const dimensions = _getDimensionsWithBorderPadding(assign({}, props, { itemsPerRow }));
     const currentWidth = isHorizontal ? dimensions.width : dimensions.height;
     return (
       // NOTE: Technically, this ternary is *chained*, not *nested*

--- a/stories/victory-legend.js
+++ b/stories/victory-legend.js
@@ -10,7 +10,7 @@ import LineSegment from "../packages/victory-core/src/victory-primitives/line-se
 const getBlankChartDecorator = (props) => {
   const blankAxisStyle = {
     axis: { stroke: "none" },
-    tickLabels: { fill: "none" },
+    tickLabels: { fill: "none" }
   };
 
   return (story) => {

--- a/stories/victory-legend.js
+++ b/stories/victory-legend.js
@@ -111,4 +111,11 @@ storiesOf("VictoryLegend.legendWidth", module)
       titleOrientation={'left'}
       data={getLoremLegendData(18)}
     />
+  ))
+  .add("with borderPadding", () => (
+    <LegendWidthTester
+      legendWidth={200}
+      borderPadding={30}
+      data={getLoremLegendData(18)}
+    />
   ));

--- a/stories/victory-legend.js
+++ b/stories/victory-legend.js
@@ -1,0 +1,114 @@
+/*eslint-disable react/no-multi-comp*/
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { startCase } from "lodash";
+import { VictoryLegend } from "../packages/victory-legend/src/index";
+import { VictoryChart } from "../packages/victory-chart/src/index";
+import VictoryAxis from "../packages/victory-axis/src/victory-axis";
+import LineSegment from "../packages/victory-core/src/victory-primitives/line-segment";
+
+const getBlankChartDecorator = (props) => {
+  const blankAxisStyle = {
+    axis: { stroke: "none" },
+    tickLabels: { fill: "none" },
+  };
+
+  return (story) => {
+    return (
+      <VictoryChart {...props}>
+        <VictoryAxis style={blankAxisStyle}/>
+        <VictoryAxis dependentAxis style={blankAxisStyle}/>
+        {story()}
+      </VictoryChart>
+    );
+  };
+};
+
+const loremText = (
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut" +
+  " labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco" +
+  " laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in" +
+  " voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat" +
+  " cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+);
+
+const getLoremLegendData = (num) => loremText
+  .split(" ")
+  .slice(0, num)
+  .map((word) => ({
+    name: startCase(word.replace(/[.,]/g, ""))
+  }));
+
+const legendWidthDemonstrationStyle = {
+  labels: { fontSize: 8 },
+  border: { stroke: "black" }
+};
+
+const LegendMaxWidthIndicator = (props) => {
+  //eslint-disable-next-line react/prop-types
+  const { width, height, orientation, legendWidth } = props;
+  const isHorizontal = orientation === "horizontal";
+  const geometryProps = isHorizontal ?
+  {
+    x1: legendWidth,
+    x2: legendWidth,
+    y1: 0,
+    y2: height
+  } : {
+    x1: 0,
+    x2: width,
+    y1: legendWidth,
+    y2: legendWidth
+  };
+
+  return <LineSegment {...props} {...geometryProps} style={{ strokeDasharray: "5,5" }}/>;
+};
+LegendMaxWidthIndicator.defaultProps = {
+  orientation: "vertical"
+};
+
+const LegendWidthTester = (props) => (
+  <React.Fragment>
+    <LegendMaxWidthIndicator {...props}/>
+    <VictoryLegend {...props} style={legendWidthDemonstrationStyle} />
+  </React.Fragment>
+);
+
+storiesOf("VictoryLegend.legendWidth", module)
+  .addDecorator(getBlankChartDecorator())
+  .add("vertical", () => <LegendWidthTester legendWidth={200} data={getLoremLegendData(18)}/>)
+  .add("vertical - title top", () => (
+    <LegendWidthTester
+      legendWidth={200}
+      title={'Title'}
+      data={getLoremLegendData(18)}
+    />
+  ))
+  .add("vertical - title left", () => (
+    <LegendWidthTester
+      legendWidth={200}
+      title={'Title'}
+      titleOrientation={'left'}
+      data={getLoremLegendData(18)}
+    />
+  ))
+  .add("horizontal", () => (
+    <LegendWidthTester orientation="horizontal" legendWidth={200} data={getLoremLegendData(18)}/>
+  ))
+  .add("horizontal - title top", () => (
+    <LegendWidthTester
+      orientation="horizontal"
+      legendWidth={200}
+      title={'Title'}
+      data={getLoremLegendData(18)}
+    />
+  ))
+  .add("horizontal - title left", () => (
+    <LegendWidthTester
+      orientation="horizontal"
+      legendWidth={200}
+      title={'Title'}
+      titleOrientation={'left'}
+      data={getLoremLegendData(18)}
+    />
+  ));


### PR DESCRIPTION
Fixes #1197 

`legendWidth` prop follows semantics established by `itemsPerRow`. 
  - Even though "width" and "row" are associated with "horizontal" orientation, they are used to mean "dimension that would be affected by wrapping in the direction specified by `orientation`". 
  - If there were also a `legendHeight` prop, one of the two props would be effectively meaningless depending on the orientation.

Behaves more like `legendMaxWidth`, I guess, because the `width` of `border` is not expanded to take up the full specified space. If that behavior is desired, it is theoretically possible to also hack `borderPadding`?

I tried my best to match existing code style, but it's probably not perfect...