### PR TITLE
Feature: add an `animationWhitelist` array to the `animate` prop

### DIFF
--- a/demo/components/animation-demo.js
+++ b/demo/components/animation-demo.js
@@ -2,6 +2,7 @@
 /*eslint-disable no-magic-numbers */
 import React from "react";
 import { random, range } from "lodash";
+import { VictoryBar } from "../../packages/victory-bar/src/index";
 import { VictoryChart } from "../../packages/victory-chart/src/index";
 import { VictoryStack } from "../../packages/victory-stack/src/index";
 import { VictoryArea } from "../../packages/victory-area/src/index";
@@ -48,7 +49,7 @@ export default class App extends React.Component {
   }
 
   getData() {
-    return range(100).map((i) => {
+    return range(20).map((i) => {
       return {
         x: i,
         y: Math.random()
@@ -161,6 +162,30 @@ export default class App extends React.Component {
               );
             })}
           </VictoryStack>
+        </VictoryChart>
+
+        <VictoryChart style={style}>
+          <VictoryBar
+            animate={{
+              animationWhitelist: ["style"]
+            }}
+            data={this.state.data}
+            style={{
+              data: this.state.style
+            }}
+          />
+        </VictoryChart>
+
+        <VictoryChart style={style}>
+          <VictoryBar
+            animate={{
+              animationWhitelist: ["data"]
+            }}
+            data={this.state.data}
+            style={{
+              data: this.state.style
+            }}
+          />
         </VictoryChart>
       </div>
     );

--- a/packages/victory-area/src/victory-area.js
+++ b/packages/victory-area/src/victory-area.js
@@ -20,9 +20,15 @@ const options = {
   ]
 };
 
-const animationWhitelist = ["data", "domain", "height", "padding", "style", "width"];
-
 class VictoryArea extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "padding",
+    "style",
+    "width"
+  ];
 
   static propTypes = {
     ...CommonProps.baseProps,
@@ -68,12 +74,13 @@ class VictoryArea extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryArea;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
 
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderContinuousData(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -7,17 +7,11 @@ import {
 } from "victory-core";
 import { getBaseProps, getScale, getStyles } from "./helper-methods";
 
-
 const fallbackProps = {
   width: 450,
   height: 300,
   padding: 50
 };
-
-const animationWhitelist = [
-  "style", "domain", "range", "tickCount", "tickValues",
-  "offsetX", "offsetY", "padding", "width", "height"
-];
 
 const options = {
   components: [
@@ -31,6 +25,19 @@ const options = {
 };
 
 class VictoryAxis extends React.Component {
+  static animationWhitelist = [
+    "style",
+    "domain",
+    "range",
+    "tickCount",
+    "tickValues",
+    "offsetX",
+    "offsetY",
+    "padding",
+    "width",
+    "height"
+  ];
+
   static displayName = "VictoryAxis";
 
   static role = "axis";
@@ -186,7 +193,9 @@ class VictoryAxis extends React.Component {
   }
 
   render() {
-    const props = Helpers.modifyProps(this.props, fallbackProps, "axis");
+    const { animationWhitelist, role } = VictoryAxis;
+    const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }

--- a/packages/victory-bar/src/victory-bar.js
+++ b/packages/victory-bar/src/victory-bar.js
@@ -19,9 +19,16 @@ const defaultData = [
   { x: 4, y: 4 }
 ];
 
-const animationWhitelist = ["data", "domain", "height", "padding", "style", "width"];
-
 class VictoryBar extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "padding",
+    "style",
+    "width"
+  ];
+
   static displayName = "VictoryBar";
 
   static role = "bar";
@@ -94,11 +101,13 @@ class VictoryBar extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryBar;
     const props = Helpers.modifyProps((this.props), fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderData(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/packages/victory-box-plot/src/victory-box-plot.js
+++ b/packages/victory-box-plot/src/victory-box-plot.js
@@ -31,11 +31,16 @@ const defaultData = [
   { x: 2, min: 2, q1: 5, median: 8, q3: 12, max: 15 }
 ];
 
-const animationWhitelist = [
-  "data", "domain", "height", "padding", "style", "width"
-];
 
 class VictoryBoxPlot extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "padding",
+    "style",
+    "width"
+  ];
 
   static displayName = "VictoryBoxPlot";
   static role = "boxplot";
@@ -187,11 +192,13 @@ class VictoryBoxPlot extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryBoxPlot;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderBoxPlot(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/packages/victory-candlestick/src/victory-candlestick.js
+++ b/packages/victory-candlestick/src/victory-candlestick.js
@@ -30,11 +30,18 @@ const defaultData = [
 ];
 /*eslint-enable no-magic-numbers */
 
-const animationWhitelist = [
-  "data", "domain", "height", "padding", "samples", "size", "style", "width"
-];
-
 class VictoryCandlestick extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "padding",
+    "samples",
+    "size",
+    "style",
+    "width"
+  ];
+
   static displayName = "VictoryCandlestick";
   static role = "candlestick";
   static defaultTransitions = DefaultTransitions.discreteTransitions();
@@ -101,11 +108,13 @@ class VictoryCandlestick extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryCandlestick;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderData(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -167,7 +167,12 @@ export default (WrappedComponent, options) => {
       return React.cloneElement(component, parentProps, children);
     }
 
-    animateComponent(props, animationWhitelist) {
+    animateComponent(props, defaultAnimationWhitelist) {
+      const animationWhitelist =
+        props.animate && props.animate.animationWhitelist
+          ? props.animate.animationWhitelist
+          : defaultAnimationWhitelist;
+
       return (
         <VictoryTransition animate={props.animate} animationWhitelist={animationWhitelist}>
           {React.createElement(this.constructor, props)}

--- a/packages/victory-errorbar/src/victory-errorbar.js
+++ b/packages/victory-errorbar/src/victory-errorbar.js
@@ -20,12 +20,20 @@ const defaultData = [
   { x: 4, y: 4, errorX: 0.4, errorY: 0.4 }
 ];
 
-const animationWhitelist = [
-  "data", "domain", "height", "padding", "samples",
-  "style", "width", "errorX", "errorY", "borderWidth"
-];
-
 class VictoryErrorBar extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "padding",
+    "samples",
+    "style",
+    "width",
+    "errorX",
+    "errorY",
+    "borderWidth"
+  ];
+
   static displayName = "VictoryErrorBar";
   static role = "errorbar";
   static defaultTransitions = DefaultTransitions.discreteTransitions();
@@ -75,11 +83,13 @@ class VictoryErrorBar extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryErrorBar;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderData(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/packages/victory-line/src/victory-line.js
+++ b/packages/victory-line/src/victory-line.js
@@ -20,9 +20,17 @@ const options = {
   ]
 };
 
-const animationWhitelist = ["data", "domain", "height", "padding", "samples", "style", "width"];
-
 class VictoryLine extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "padding",
+    "samples",
+    "style",
+    "width"
+  ];
+
   static displayName = "VictoryLine";
   static role = "line";
   static defaultTransitions = DefaultTransitions.continuousTransitions();
@@ -68,11 +76,13 @@ class VictoryLine extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryLine;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderContinuousData(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/packages/victory-pie/src/victory-pie.js
+++ b/packages/victory-pie/src/victory-pie.js
@@ -31,12 +31,21 @@ const fallbackProps = {
   labelPosition: "centroid"
 };
 
-const animationWhitelist = [
-  "data", "endAngle", "height", "innerRadius", "cornerRadius", "padAngle", "padding",
-  "colorScale", "startAngle", "style", "width"
-];
-
 class VictoryPie extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "endAngle",
+    "height",
+    "innerRadius",
+    "cornerRadius",
+    "padAngle",
+    "padding",
+    "colorScale",
+    "startAngle",
+    "style",
+    "width"
+  ];
+
   static displayName = "VictoryPie";
 
   static role = "pie";
@@ -181,8 +190,9 @@ class VictoryPie extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryPie;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }

--- a/packages/victory-polar-axis/src/victory-polar-axis.js
+++ b/packages/victory-polar-axis/src/victory-polar-axis.js
@@ -13,10 +13,6 @@ const fallbackProps = {
   padding: 50
 };
 
-const animationWhitelist = [
-  "style", "domain", "range", "tickCount", "tickValues", "padding", "width", "height"
-];
-
 const options = {
   components: [
     { name: "axis", index: 0 },
@@ -29,6 +25,17 @@ const options = {
 };
 
 class VictoryPolarAxis extends React.Component {
+  static animationWhitelist = [
+    "style",
+    "domain",
+    "range",
+    "tickCount",
+    "tickValues",
+    "padding",
+    "width",
+    "height"
+  ];
+
   static displayName = "VictoryAxis";
 
   static role = "axis";
@@ -177,7 +184,9 @@ class VictoryPolarAxis extends React.Component {
   }
 
   render() {
-    const props = Helpers.modifyProps(this.props, fallbackProps, "axis");
+    const { animationWhitelist, role } = VictoryPolarAxis;
+    const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }

--- a/packages/victory-scatter/src/victory-scatter.js
+++ b/packages/victory-scatter/src/victory-scatter.js
@@ -14,11 +14,19 @@ const fallbackProps = {
   symbol: "circle"
 };
 
-const animationWhitelist = [
-  "data", "domain", "height", "maxBubbleSize", "padding", "samples", "size", "style", "width"
-];
-
 class VictoryScatter extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "maxBubbleSize",
+    "padding",
+    "samples",
+    "size",
+    "style",
+    "width"
+  ];
+
   static displayName = "VictoryScatter";
   static role = "scatter";
   static defaultTransitions = DefaultTransitions.discreteTransitions();
@@ -63,11 +71,13 @@ class VictoryScatter extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = this.constructor;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderData(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/packages/victory-voronoi/src/victory-voronoi.js
+++ b/packages/victory-voronoi/src/victory-voronoi.js
@@ -12,11 +12,18 @@ const fallbackProps = {
   padding: 50
 };
 
-const animationWhitelist = [
-  "data", "domain", "height", "padding", "samples", "size", "style", "width"
-];
-
 class VictoryVoronoi extends React.Component {
+  static animationWhitelist = [
+    "data",
+    "domain",
+    "height",
+    "padding",
+    "samples",
+    "size",
+    "style",
+    "width"
+  ];
+
   static displayName = "VictoryVoronoi";
   static role = "voronoi";
   static defaultTransitions = DefaultTransitions.discreteTransitions();
@@ -52,11 +59,13 @@ class VictoryVoronoi extends React.Component {
   }
 
   render() {
-    const { role } = this.constructor;
+    const { animationWhitelist, role } = VictoryVoronoi;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
+
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
+
     const children = this.renderData(props);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }

--- a/test/client/spec/mock-components.js
+++ b/test/client/spec/mock-components.js
@@ -42,6 +42,7 @@ class MockLabel extends React.Component {
 }
 
 class MockVictoryComponent extends React.Component {
+  static animationWhitelist = ["data", "style"]
   static displayName = "MockVictoryComponent";
   static role = "chart";
 
@@ -75,8 +76,13 @@ class MockVictoryComponent extends React.Component {
   };
 
   render() {
+    const { animationWhitelist } = MockVictoryComponent;
     const props = defaults({}, this.props, this.defaultProps);
-    const { dataComponent, labelComponent, groupComponent } = props;
+    const { animate, dataComponent, labelComponent, groupComponent } = props;
+
+    if (animate) {
+      return this.animateComponent(props, animationWhitelist);
+    }
 
     const dataComponents = map(this.dataKeys, (_key, index) => {
       const dataProps = this.getComponentProps(dataComponent, "data", index);

--- a/test/client/spec/victory-core/victory-util/add-events.spec.js
+++ b/test/client/spec/victory-core/victory-util/add-events.spec.js
@@ -87,4 +87,36 @@ describe("victory-util/add-events", () => {
     getDataComponents(wrapper).at(1).simulate("click");
     expectEventsTriggered(getLabelComponents, labelComponentIsAltered, [true, true], wrapper);
   });
+
+  describe("when adding animations to the component", () => {
+    describe("and props.animate.animationWhitelist is not present", () => {
+      it("passes the default animation whitelist to the <VictoryTransition /> component", () => {
+        const wrapper = mount(
+          <EventedMockVictoryComponent animate />
+        );
+
+        const victoryTransitionWrapper = wrapper.find("VictoryTransition");
+
+        expect(victoryTransitionWrapper.prop("animationWhitelist"))
+          .to.equal(MockVictoryComponent.animationWhitelist);
+      });
+    });
+
+    describe("and props.animate.animationWhitelist is passed in", () => {
+      it("passes props.animate.animationWhitelist to the <VictoryTransition /> component", () => {
+        const wrapper = mount(
+          <EventedMockVictoryComponent
+            animate={{
+              animationWhitelist: ["allTheThings"]
+            }}
+          />
+        );
+
+        const victoryTransitionWrapper = wrapper.find("VictoryTransition");
+
+        expect(victoryTransitionWrapper.prop("animationWhitelist"))
+          .to.deep.equal(["allTheThings"]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Addresses #1186 

This PR allows users to override the default `animationWhitelist` for components that accept an `animate` prop.

When a component has an `animate` prop it will render itself within a `<VictoryTransition />` wrapper, which then renders a `<VictoryAnimation />` component with a subset of data to "tween". Initially, that subset was determined by pulling data keys that were included in a module-scoped array of strings (`["data", "style", "domain", ...]`). These changes allow an `animate.animationWhitelist` prop to override that array and also moves the default array to a static property on the component so users can reference it if necessary.

There's still room for improvement by allowing users to specify sub-properties they want to animate. For example, instead of enabling/disabling all animations for `style` it would be great to enable/disable animation for `style.fill` or `style.opacity`, etc. That gets a little more difficult when dealing with the `data` animations though.