### PR TITLE
Lifecycle updates: VictoryAnimation updates. componentWillMount updates.

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -1,6 +1,6 @@
 /*global document:false window:false */
 /*eslint-disable react/no-multi-comp */
-import React from "react";
+import React, { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import { keys } from "lodash";
 
@@ -50,17 +50,38 @@ const MAP = {
   "/group": { component: GroupDemo, name: "GroupDemo" },
   "/voronoi": { component: VoronoiDemo, name: "VoronoiDemo" },
   "/tooltip": { component: TooltipDemo, name: "TooltipDemo" },
-  "/zoom-container": { component: ZoomContainerDemo, name: "ZoomContainerDemo" },
-  "/voronoi-container": { component: VoronoiContainerDemo, name: "VoronoiContainerDemo" },
-  "/cursor-container": { component: CursorContainerDemo, name: "CursorContainerDemo" },
-  "/brush-container": { component: BrushContainerDemo, name: "BrushContainerDemo" },
+  "/zoom-container": {
+    component: ZoomContainerDemo,
+    name: "ZoomContainerDemo"
+  },
+  "/voronoi-container": {
+    component: VoronoiContainerDemo,
+    name: "VoronoiContainerDemo"
+  },
+  "/cursor-container": {
+    component: CursorContainerDemo,
+    name: "CursorContainerDemo"
+  },
+  "/brush-container": {
+    component: BrushContainerDemo,
+    name: "BrushContainerDemo"
+  },
   "/animation": { component: AnimationDemo, name: "AnimationDemo" },
   "/selection-container": { component: SelectionDemo, name: "SelectionDemo" },
-  "/create-container": { component: CreateContainerDemo, name: "CreateContainerDemo" },
+  "/create-container": {
+    component: CreateContainerDemo,
+    name: "CreateContainerDemo"
+  },
   "/polar": { component: PolarDemo, name: "PolarDemo" },
   "/immutable": { component: ImmutableDemo, name: "ImmutableDemo" },
-  "/external-events": { component: ExternalEventsDemo, name: "ExternalEventsDemo" },
-  "/victory-brush-line": { component: VictoryBrushLineDemo, name: "BrushLineDemo" },
+  "/external-events": {
+    component: ExternalEventsDemo,
+    name: "ExternalEventsDemo"
+  },
+  "/victory-brush-line": {
+    component: VictoryBrushLineDemo,
+    name: "BrushLineDemo"
+  },
   "/performance": { component: PerformanceDemo, name: "PerformanceDemo" },
   "/debug": { component: DebugDemo, name: "DebugDemo" },
   "/label": { component: VictoryLabelDemo, name: "LabelDemo" },
@@ -84,7 +105,7 @@ class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.addEventListener("hashchange", () => {
       this.setState({
         route: window.location.hash.substr(1)
@@ -119,4 +140,9 @@ class App extends React.Component {
   }
 }
 
-ReactDOM.render(<App />, document.getElementById("content"));
+ReactDOM.render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+  document.getElementById("content")
+);

--- a/demo/components/animation-demo.js
+++ b/demo/components/animation-demo.js
@@ -20,7 +20,7 @@ export default class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.setInterval(() => {
       this.setState({
         data: this.getData(),

--- a/demo/components/external-events-demo.js
+++ b/demo/components/external-events-demo.js
@@ -19,7 +19,7 @@ class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.setInterval(() => {
       this.setState({
         data: this.getData()

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -20,7 +20,7 @@ export default class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.setInterval(() => {
       this.setState({
         data: this.getData(),

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -1,4 +1,5 @@
-import { defaults, assign } from "lodash";
+import { assign, defaults } from "lodash";
+import isEqual from "react-fast-compare";
 import PropTypes from "prop-types";
 import React from "react";
 import {
@@ -74,11 +75,11 @@ export default class VictoryChart extends React.Component {
     this.events = Wrapper.getAllEvents(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.animate) {
-      this.setAnimationState(this.props, nextProps);
+  componentDidUpdate(prevProps) {
+    if (!isEqual(this.props, prevProps)) {
+      this.setAnimationState(prevProps, this.props);
     }
-    this.events = Wrapper.getAllEvents(nextProps);
+    this.events = Wrapper.getAllEvents(this.props);
   }
 
   // the old ones were bad

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -70,7 +70,7 @@ export default class VictoryChart extends React.Component {
     this.events = Wrapper.getAllEvents(props);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.events = Wrapper.getAllEvents(this.props);
   }
 

--- a/packages/victory-core/src/victory-animation/victory-animation.js
+++ b/packages/victory-core/src/victory-animation/victory-animation.js
@@ -98,21 +98,24 @@ export default class VictoryAnimation extends React.Component {
     }
   }
 
-  /* lifecycle */
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(_props, _state, snapshot) {
+    if (snapshot.shouldRestartTraversal === false) {
+      return;
+    }
+
     /* cancel existing loop if it exists */
     this.getTimer().unsubscribe(this.loopID);
 
     /* If an object was supplied */
-    if (!Array.isArray(nextProps.data)) {
+    if (!Array.isArray(this.props.data)) {
       // Replace the tween queue. Could set `this.queue = [nextProps.data]`,
       // but let's reuse the same array.
       this.queue.length = 0;
-      this.queue.push(nextProps.data);
+      this.queue.push(this.props.data);
       /* If an array was supplied */
     } else {
       /* Extend the tween queue */
-      this.queue.push(...nextProps.data);
+      this.queue.push(...this.props.data);
     }
     /* Start traversing the tween queue */
     this.traverseQueue();
@@ -124,6 +127,16 @@ export default class VictoryAnimation extends React.Component {
     } else {
       this.getTimer().stop();
     }
+  }
+
+  getSnapshotBeforeUpdate(prevProps) {
+    const snapshot = { shouldRestartTraversal: false };
+
+    if (prevProps.data !== this.props.data) {
+      snapshot.shouldRestartTraversal = true;
+    }
+
+    return snapshot;
   }
 
   getTimer() {

--- a/packages/victory-core/src/victory-animation/victory-animation.js
+++ b/packages/victory-core/src/victory-animation/victory-animation.js
@@ -1,5 +1,6 @@
 /*global setTimeout:false */
 import React from "react";
+import isEqual from "react-fast-compare";
 import PropTypes from "prop-types";
 import * as d3Ease from "d3-ease";
 import { victoryInterpolator } from "./util";
@@ -98,8 +99,8 @@ export default class VictoryAnimation extends React.Component {
     }
   }
 
-  componentDidUpdate(_props, _state, snapshot) {
-    if (snapshot.shouldRestartTraversal === false) {
+  componentDidUpdate(prevProps) {
+    if (isEqual(this.props, prevProps)) {
       return;
     }
 
@@ -127,16 +128,6 @@ export default class VictoryAnimation extends React.Component {
     } else {
       this.getTimer().stop();
     }
-  }
-
-  getSnapshotBeforeUpdate(prevProps) {
-    const snapshot = { shouldRestartTraversal: false };
-
-    if (prevProps.data !== this.props.data) {
-      snapshot.shouldRestartTraversal = true;
-    }
-
-    return snapshot;
   }
 
   getTimer() {

--- a/packages/victory-core/src/victory-transition/victory-transition.js
+++ b/packages/victory-core/src/victory-transition/victory-transition.js
@@ -5,7 +5,8 @@ import Collection from "../victory-util/collection";
 import Helpers from "../victory-util/helpers";
 import Timer from "../victory-util/timer";
 import Transitions from "../victory-util/transitions";
-import { defaults, isFunction, pick, isObject } from "lodash";
+import { defaults, isFunction, isObject, pick } from "lodash";
+import isEqual from "react-fast-compare";
 
 export default class VictoryTransition extends React.Component {
   static displayName = "VictoryTransition";
@@ -33,11 +34,14 @@ export default class VictoryTransition extends React.Component {
     this.setState({ nodesShouldLoad: true }); //eslint-disable-line react/no-did-mount-set-state
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.getTimer().bypassAnimation();
-    this.setState(this.getTransitionState(this.props, nextProps), () =>
-      this.getTimer().resumeAnimation()
-    );
+  componentDidUpdate(prevProps) {
+    if (!isEqual(this.props, prevProps)) {
+      this.getTimer().bypassAnimation();
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState(this.getTransitionState(prevProps, this.props), () =>
+        this.getTimer().resumeAnimation()
+      );
+    }
   }
 
   componentWillUnmount() {

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -22,21 +22,17 @@ export default (WrappedComponent, options) => {
         return boundGetEvents(p, target, eventKey, getScopedEvents);
       };
       this.getEventState = Events.getEventState.bind(this);
-      const calculatedValues = this.getCalculatedValues(props);
-      this.cacheValues(calculatedValues);
+      this.cacheCalculatedValues(props);
       this.externalMutations = this.getExternalMutations(props);
     }
 
     componentDidUpdate() {
       const externalMutations = this.getExternalMutations(this.props);
+      this.cacheCalculatedValues(this.props);
       if (!isEqual(this.externalMutations, externalMutations)) {
         this.externalMutations = externalMutations;
         this.applyExternalMutations(this.props, externalMutations);
       }
-    }
-
-    componentWillReceiveProps(nextProps) {
-      this.cacheValues(this.getCalculatedValues(nextProps));
     }
 
     applyExternalMutations(props, externalMutations) {
@@ -88,7 +84,7 @@ export default (WrappedComponent, options) => {
         .filter(Boolean);
     }
 
-    getCalculatedValues(props) {
+    cacheCalculatedValues(props) {
       const { sharedEvents } = props;
       const components = WrappedComponent.expectedComponents;
       const componentEvents = Events.getComponentEvents(props, components);
@@ -100,14 +96,13 @@ export default (WrappedComponent, options) => {
       const dataKeys = keys(baseProps).filter((key) => key !== "parent");
       const hasEvents = props.events || props.sharedEvents || componentEvents;
       const events = this.getAllEvents(props);
-      return {
-        componentEvents,
-        getSharedEventState,
-        baseProps,
-        dataKeys,
-        hasEvents,
-        events
-      };
+
+      this.componentEvents = componentEvents;
+      this.getSharedEventState = getSharedEventState;
+      this.baseProps = baseProps;
+      this.dataKeys = dataKeys;
+      this.hasEvents = hasEvents;
+      this.events = events;
     }
 
     getExternalMutations(props) {
@@ -115,12 +110,6 @@ export default (WrappedComponent, options) => {
       return isEmpty(externalEventMutations) || sharedEvents
         ? undefined
         : Events.getExternalMutations(externalEventMutations, this.baseProps, this.state);
-    }
-
-    cacheValues(obj) {
-      keys(obj).forEach((key) => {
-        this[key] = obj[key];
-      });
     }
 
     getBaseProps(props, getSharedEventState) {

--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -66,7 +66,7 @@ export default class VictoryGroup extends React.Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.events = Wrapper.getAllEvents(this.props);
   }
 

--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -1,4 +1,5 @@
 import { assign, defaults } from "lodash";
+import isEqual from "react-fast-compare";
 import PropTypes from "prop-types";
 import React from "react";
 import { Helpers, VictoryContainer, VictoryTheme, CommonProps, Wrapper } from "victory-core";
@@ -70,11 +71,13 @@ export default class VictoryGroup extends React.Component {
     this.events = Wrapper.getAllEvents(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.animate) {
-      this.setAnimationState(this.props, nextProps);
+  componentDidUpdate(prevProps) {
+    if (!isEqual(this.props, prevProps)) {
+      if (this.props.animate) {
+        this.setAnimationState(prevProps, this.props);
+      }
+      this.events = Wrapper.getAllEvents(this.props);
     }
-    this.events = Wrapper.getAllEvents(nextProps);
   }
 
   // the old ones were bad

--- a/packages/victory-shared-events/src/victory-shared-events.js
+++ b/packages/victory-shared-events/src/victory-shared-events.js
@@ -1,4 +1,5 @@
 import { assign, isFunction, defaults, isEmpty, fromPairs } from "lodash";
+import isEqual from "react-fast-compare";
 import React from "react";
 import PropTypes from "prop-types";
 import { PropTypes as CustomPropTypes, Events, Helpers, Timer } from "victory-core";
@@ -73,10 +74,12 @@ export default class VictorySharedEvents extends React.Component {
     };
   }
 
-  componentWillReceiveProps(newProps) {
-    this.baseProps = this.getBaseProps(newProps);
-    const externalMutations = this.getExternalMutations(newProps, this.baseProps);
-    this.applyExternalMutations(newProps, externalMutations);
+  componentDidUpdate(prevProps) {
+    if (!isEqual(this.props, prevProps)) {
+      this.baseProps = this.getBaseProps(this.props);
+      const externalMutations = this.getExternalMutations(this.props, this.baseProps);
+      this.applyExternalMutations(this.props, externalMutations);
+    }
   }
 
   getTimer() {
@@ -231,6 +234,8 @@ export default class VictorySharedEvents extends React.Component {
     if (events) {
       return this.getContainer(this.props, this.baseProps, events);
     }
-    return React.cloneElement(this.props.container, { children: this.props.children });
+    return React.cloneElement(this.props.container, {
+      children: this.props.children
+    });
   }
 }

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -77,7 +77,7 @@ export default class VictoryStack extends React.Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.events = Wrapper.getAllEvents(this.props);
   }
 

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -1,4 +1,5 @@
 import { assign, defaults } from "lodash";
+import isEqual from "react-fast-compare";
 import PropTypes from "prop-types";
 import React from "react";
 import { Helpers, VictoryContainer, VictoryTheme, CommonProps, Wrapper } from "victory-core";
@@ -81,11 +82,13 @@ export default class VictoryStack extends React.Component {
     this.events = Wrapper.getAllEvents(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.animate) {
-      this.setAnimationState(this.props, nextProps);
+  componentDidUpdate(prevProps) {
+    if (!isEqual(this.props, prevProps)) {
+      if (this.props.animate) {
+        this.setAnimationState(prevProps, this.props);
+      }
+      this.events = Wrapper.getAllEvents(this.props);
     }
-    this.events = Wrapper.getAllEvents(nextProps);
   }
 
   // the old ones were bad


### PR DESCRIPTION
This is part of the effort for #969. My goal is to migrate in small PRs to make the diffs more manageable and understandable.

This PR does the following:

- Adds `<StrictMode>` to the example app to help us find migration points.
- Change uses of `componentWillMount` to `componentDidMount` (I believe this is a safe swap given whats happening in each case)
- a very naive swap from `cDRP` to `cDU`. The basic approach was to use lodash `isEqual` to compare props and prevProps to know if we should run some code on update. It's basically the same logic as `cDRP` but potentially runs the `isEqual` check a lot more than if React compared props behind the scenes. Curious on feedback here. 