### PR TITLE
Bugfix: Calculated domains respect custom baselines 

### DIFF
--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -44,7 +44,8 @@ export default class App extends React.Component {
   getAreaTransitionData() {
     const areas = random(6, 10);
     return range(areas).map((area) => {
-      return { x: area, y: random(2, 10) };
+      const y = random(2, 10);
+      return { x: area, y, y0: random(0, y) };
     });
   }
 

--- a/packages/victory-core/src/victory-util/domain.js
+++ b/packages/victory-core/src/victory-util/domain.js
@@ -289,23 +289,36 @@ function getDomainWithZero(props, axis) {
   if (propsDomain) {
     return propsDomain;
   }
+
+  const dataset = Data.getData(props);
+  const y0Min = dataset.reduce((min, datum) => (datum._y0 < min ? datum._y0 : min), Infinity);
+
   const ensureZero = (domain) => {
     const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
-    const minDomain = getMinFromProps(props, axis);
-    const maxDomain = getMaxFromProps(props, axis);
     if (currentAxis === "x") {
       return domain;
     }
-    const defaultMin = minDomain || 0;
-    const defaultMax = maxDomain || 0;
-    const min = minDomain !== undefined ? minDomain : Collection.getMinValue(domain, defaultMin);
-    const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(domain, defaultMax);
+
+    const defaultMin = y0Min !== Infinity ? y0Min : 0;
+    const maxDomainProp = getMaxFromProps(props, axis);
+    const minDomainProp = getMinFromProps(props, axis);
+    const max =
+      maxDomainProp !== undefined ? maxDomainProp : Collection.getMaxValue(domain, defaultMin);
+    const min =
+      minDomainProp !== undefined ? minDomainProp : Collection.getMinValue(domain, defaultMin);
+
     return getDomainFromMinMax(min, max);
   };
+
+  const getDomainFunction = () => {
+    return getDomainFromData(props, axis, dataset);
+  };
+
   const formatDomainFunction = (domain) => {
     return formatDomain(ensureZero(domain), props, axis);
   };
-  return createDomainFunction(null, formatDomainFunction)(props, axis);
+
+  return createDomainFunction(getDomainFunction, formatDomainFunction)(props, axis);
 }
 
 /**

--- a/test/client/spec/victory-core/victory-util/domain.spec.js
+++ b/test/client/spec/victory-core/victory-util/domain.spec.js
@@ -204,17 +204,47 @@ describe("victory-util/domain", () => {
   describe("getDomainWithZero", () => {
     it("ensures that the domain includes zero for the dependent axis", () => {
       const props = {
-        x: "x",
-        y: "y",
         data: [{ x: 1, y: 3 }, { x: 3, y: 5 }]
       };
       const resultDomain = Domain.getDomainWithZero(props, "y");
       expect(resultDomain).to.eql([0, 5]);
     });
+
+    it("allows minimum domain values less than zero", () => {
+      const props = {
+        data: [{ x: 1, y: -3 }, { x: 3, y: 5 }]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).to.eql([-3, 5]);
+    });
+
+    it("allows explicit y0 values in props.data to set the minimum domain", () => {
+      const props = {
+        data: [{ x: 1, y: 3, y0: 2 }, { x: 3, y: 5, y0: 3 }]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).to.eql([2, 5]);
+    });
+
+    it("handles negative y0 values", () => {
+      const props = {
+        data: [{ x: 1, y: -3, y0: -7 }, { x: 3, y: -5, y0: -7 }]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).to.eql([-7, -3]);
+    });
+
+    it("respects props.minDomain when present", () => {
+      const props = {
+        data: [{ x: 1, y: 3, y0: 2 }, { x: 3, y: 5, y0: 2 }],
+        minDomain: { y: 4 }
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).to.eql([4, 5]);
+    });
+
     it("does not force the independent domain to include zero", () => {
       const props = {
-        x: "x",
-        y: "y",
         data: [{ x: 1, y: 3 }, { x: 3, y: 5 }]
       };
       const resultDomain = Domain.getDomainWithZero(props, "x");
@@ -228,11 +258,13 @@ describe("victory-util/domain", () => {
       const maxDomain = Domain.getMaxFromProps(props, "x");
       expect(maxDomain).to.eql(props.maxDomain.x);
     });
+
     it("returns maxDomain from props as a number", () => {
       const props = { maxDomain: 3 };
       const maxDomain = Domain.getMaxFromProps(props, "x");
       expect(maxDomain).to.eql(props.maxDomain);
     });
+
     it("returns undefined when maxDomain is not defined for a given axis", () => {
       const props = { maxDomain: { y: 3 } };
       const maxDomain = Domain.getMaxFromProps(props, "x");
@@ -246,11 +278,13 @@ describe("victory-util/domain", () => {
       const minDomain = Domain.getMinFromProps(props, "x");
       expect(minDomain).to.eql(props.minDomain.x);
     });
+
     it("returns minDomain from props as a number", () => {
       const props = { minDomain: 3 };
       const minDomain = Domain.getMinFromProps(props, "x");
       expect(minDomain).to.eql(props.minDomain);
     });
+
     it("returns undefined when minDomain is not defined for a given axis", () => {
       const props = { minDomain: { y: 3 } };
       const minDomain = Domain.getMinFromProps(props, "x");


### PR DESCRIPTION
Fixes #1123 

The `<VictoryArea />` and `<VictoryBar />` components rely on the `Domain.getDomainWithZero()` function to calculate their domain ranges. There was a regression introduced in version 0.27.0 where that function stopped respecting custom baseline domains via `data.y0` values and instead always set the minimum domain to 0.