### PR TITLE
Task: delete unused method on addEvents HOC

### DIFF
--- a/packages/victory-area/src/victory-area.js
+++ b/packages/victory-area/src/victory-area.js
@@ -23,14 +23,6 @@ const fallbackProps = {
   interpolation: "linear"
 };
 
-const options = {
-  components: [
-    { name: "parent", index: "parent" },
-    { name: "data", index: "all" },
-    { name: "labels" }
-  ]
-};
-
 class VictoryArea extends React.Component {
   static animationWhitelist = ["data", "domain", "height", "padding", "style", "width"];
 
@@ -101,4 +93,4 @@ class VictoryArea extends React.Component {
   }
 }
 
-export default addEvents(VictoryArea, options);
+export default addEvents(VictoryArea);

--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -21,17 +21,6 @@ const fallbackProps = {
   padding: 50
 };
 
-const options = {
-  components: [
-    { name: "axis", index: 0 },
-    { name: "axisLabel", index: 0 },
-    { name: "grid" },
-    { name: "parent", index: "parent" },
-    { name: "ticks" },
-    { name: "tickLabels" }
-  ]
-};
-
 class VictoryAxis extends React.Component {
   static animationWhitelist = [
     "style",
@@ -241,4 +230,4 @@ class VictoryAxis extends React.Component {
   }
 }
 
-export default addEvents(VictoryAxis, options);
+export default addEvents(VictoryAxis);

--- a/packages/victory-box-plot/src/victory-box-plot.js
+++ b/packages/victory-box-plot/src/victory-box-plot.js
@@ -27,22 +27,6 @@ const fallbackProps = {
   }
 };
 
-const options = {
-  components: [
-    { name: "min" },
-    { name: "minLabels" },
-    { name: "max" },
-    { name: "maxLabels" },
-    { name: "median" },
-    { name: "medianLabels" },
-    { name: "q1" },
-    { name: "q1Labels" },
-    { name: "q3" },
-    { name: "q3Labels" },
-    { name: "parent", index: "parent" }
-  ]
-};
-
 const defaultData = [
   { x: 1, min: 5, q1: 7, median: 12, q3: 18, max: 20 },
   { x: 2, min: 2, q1: 5, median: 8, q3: 12, max: 15 }
@@ -237,4 +221,4 @@ class VictoryBoxPlot extends React.Component {
   }
 }
 
-export default addEvents(VictoryBoxPlot, options);
+export default addEvents(VictoryBoxPlot);

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -4,14 +4,7 @@ import Events from "./events";
 import isEqual from "react-fast-compare";
 import VictoryTransition from "../victory-transition/victory-transition";
 
-//  used for checking state changes. Expected components can be passed in via options
-const defaultComponents = [
-  { name: "parent", index: "parent" },
-  { name: "data" },
-  { name: "labels" }
-];
-
-export default (WrappedComponent, options) => {
+export default (WrappedComponent) => {
   return class addEvents extends WrappedComponent {
     constructor(props) {
       super(props);
@@ -52,40 +45,6 @@ export default (WrappedComponent, options) => {
           : undefined;
         this.setState(externalMutations, compiledCallbacks);
       }
-    }
-
-    // compile all state changes from own and parent state. Order doesn't matter, as any state
-    // state change should trigger a re-render
-    getStateChanges(props, calculatedValues) {
-      const { hasEvents, getSharedEventState } = calculatedValues;
-      if (!hasEvents) {
-        return {};
-      }
-
-      options = options || {};
-      const components = options.components || defaultComponents;
-
-      const getState = (key, type) => {
-        const baseState = defaults(
-          {},
-          this.getEventState(key, type),
-          getSharedEventState(key, type)
-        );
-        return isEmpty(baseState) ? undefined : baseState;
-      };
-
-      return components
-        .map((component) => {
-          if (!props.standalone && component.name === "parent") {
-            // don't check for changes on parent props for non-standalone components
-            return undefined;
-          } else {
-            return component.index !== undefined
-              ? getState(component.index, component.name)
-              : calculatedValues.dataKeys.map((key) => getState(key, component.name));
-          }
-        })
-        .filter(Boolean);
     }
 
     getCalculatedValues(props) {

--- a/packages/victory-line/src/victory-line.js
+++ b/packages/victory-line/src/victory-line.js
@@ -23,14 +23,6 @@ const fallbackProps = {
   interpolation: "linear"
 };
 
-const options = {
-  components: [
-    { name: "parent", index: "parent" },
-    { name: "data", index: "all" },
-    { name: "labels" }
-  ]
-};
-
 class VictoryLine extends React.Component {
   static animationWhitelist = ["data", "domain", "height", "padding", "samples", "style", "width"];
 
@@ -102,4 +94,4 @@ class VictoryLine extends React.Component {
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }
 }
-export default addEvents(VictoryLine, options);
+export default addEvents(VictoryLine);

--- a/packages/victory-polar-axis/src/victory-polar-axis.js
+++ b/packages/victory-polar-axis/src/victory-polar-axis.js
@@ -21,17 +21,6 @@ const fallbackProps = {
   padding: 50
 };
 
-const options = {
-  components: [
-    { name: "axis", index: 0 },
-    { name: "axisLabel", index: 0 },
-    { name: "grid" },
-    { name: "parent", index: "parent" },
-    { name: "ticks" },
-    { name: "tickLabels" }
-  ]
-};
-
 class VictoryPolarAxis extends React.Component {
   static animationWhitelist = [
     "style",
@@ -223,4 +212,4 @@ class VictoryPolarAxis extends React.Component {
   }
 }
 
-export default addEvents(VictoryPolarAxis, options);
+export default addEvents(VictoryPolarAxis);


### PR DESCRIPTION
I couldn't find anything that calls the `getStateChanges()` method on the `addEvents` HOC, seems like it can be deleted?