### PR TITLE
Bugfix: Avoid rendering data points for null values

### DIFF
--- a/packages/victory-candlestick/src/victory-candlestick.js
+++ b/packages/victory-candlestick/src/victory-candlestick.js
@@ -113,6 +113,10 @@ class VictoryCandlestick extends React.Component {
     return !!this.props.animate;
   }
 
+  shouldRenderDatum(datum) {
+    return datum._x !== null && datum._x !== undefined;
+  }
+
   render() {
     const { animationWhitelist, role } = VictoryCandlestick;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
@@ -121,7 +125,7 @@ class VictoryCandlestick extends React.Component {
       return this.animateComponent(props, animationWhitelist);
     }
 
-    const children = this.renderData(props);
+    const children = this.renderData(props, this.shouldRenderDatum);
     return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }
 }

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -1,8 +1,12 @@
 import React from "react";
-import { defaults, assign, keys, isFunction, pick, without, isEmpty } from "lodash";
+import { defaults, assign, keys, isFunction, pick, without, isEmpty, isNil } from "lodash";
 import Events from "./events";
 import isEqual from "react-fast-compare";
 import VictoryTransition from "../victory-transition/victory-transition";
+
+const datumHasXandY = (datum) => {
+  return !isNil(datum._x) && !isNil(datum._y);
+};
 
 export default (WrappedComponent) => {
   return class addEvents extends WrappedComponent {
@@ -20,16 +24,14 @@ export default (WrappedComponent) => {
       this.externalMutations = this.getExternalMutations(props);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps) {
+      this.cacheValues(this.getCalculatedValues(prevProps));
+
       const externalMutations = this.getExternalMutations(this.props);
       if (!isEqual(this.externalMutations, externalMutations)) {
         this.externalMutations = externalMutations;
         this.applyExternalMutations(this.props, externalMutations);
       }
-    }
-
-    componentWillReceiveProps(nextProps) {
-      this.cacheValues(this.getCalculatedValues(nextProps));
     }
 
     applyExternalMutations(props, externalMutations) {
@@ -167,12 +169,16 @@ export default (WrappedComponent) => {
       return this.renderContainer(groupComponent, children);
     }
 
-    renderData(props) {
+    renderData(props, shouldRenderDatum = datumHasXandY) {
       const { dataComponent, labelComponent, groupComponent } = props;
-      const dataComponents = this.dataKeys.map((_dataKey, index) => {
+
+      const dataComponents = this.dataKeys.reduce((validDataComponents, _dataKey, index) => {
         const dataProps = this.getComponentProps(dataComponent, "data", index);
-        return React.cloneElement(dataComponent, dataProps);
-      });
+        if (shouldRenderDatum(dataProps.datum)) {
+          validDataComponents.push(React.cloneElement(dataComponent, dataProps));
+        }
+        return validDataComponents;
+      }, []);
 
       const labelComponents = this.dataKeys
         .map((_dataKey, index) => {

--- a/packages/victory-scatter/src/victory-scatter.js
+++ b/packages/victory-scatter/src/victory-scatter.js
@@ -90,7 +90,7 @@ class VictoryScatter extends React.Component {
   }
 
   render() {
-    const { animationWhitelist, role } = this.constructor;
+    const { animationWhitelist, role } = VictoryScatter;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
 
     if (this.shouldAnimate()) {

--- a/test/client/spec/victory-bar/victory-bar.spec.js
+++ b/test/client/spec/victory-bar/victory-bar.spec.js
@@ -96,6 +96,12 @@ describe("components/victory-bar", () => {
       expect(heights[1] / 2).to.be.closeTo(heights[0], 0.5);
       expect((heights[2] / 3) * 2).to.be.closeTo(heights[1], 0.5);
     });
+
+    it("does not render data with null x or y values", () => {
+      const data = [{ x: 1, y: 2 }, { x: null, y: 4 }, { x: 5, y: null }];
+      const wrapper = mount(<VictoryBar data={data} />);
+      expect(wrapper.find(Bar).length).to.equal(1);
+    });
   });
 
   describe("event handling", () => {

--- a/test/client/spec/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/victory-candlestick/victory-candlestick.spec.js
@@ -112,6 +112,15 @@ describe("components/victory-candlestick", () => {
       const points = wrapper.find(Candle);
       expect(points.length).to.equal(30);
     });
+
+    it("does not render data with null x values", () => {
+      const data = [
+        { x: 1, open: 10, close: 17, high: 19, low: 8 },
+        { x: null, open: 17, close: 17, high: 17, low: 17 }
+      ];
+      const wrapper = mount(<VictoryCandlestick data={data} />);
+      expect(wrapper.find(Candle).length).to.equal(1);
+    });
   });
 
   describe("event handling", () => {

--- a/test/client/spec/victory-errorbars/victory-errorbars.spec.js
+++ b/test/client/spec/victory-errorbars/victory-errorbars.spec.js
@@ -39,6 +39,16 @@ describe("components/victory-errorbar", () => {
     });
   });
 
+  it("does not render data with null x or y values", () => {
+    const data = [
+      { x: 15, y: 35, errorX: 1, errorY: 3 },
+      { x: null, y: 42, errorX: 3, errorY: 2 },
+      { x: 25, y: null, errorX: 5, errorY: 5 }
+    ];
+    const wrapper = mount(<VictoryErrorBar data={data} />);
+    expect(wrapper.find(ErrorBar).length).to.equal(1);
+  });
+
   const immutableRenderDataTest = {
     createData: (x) => fromJS(x),
     testLabel: "with immutable data"

--- a/test/client/spec/victory-pie/victory-pie.spec.js
+++ b/test/client/spec/victory-pie/victory-pie.spec.js
@@ -134,6 +134,12 @@ describe("components/victory-pie", () => {
 
       expect(xValues).to.eql([8, 7, 6, 5, 4, 3, 2, 1, 0]);
     });
+
+    it("does not render data with null x or y values", () => {
+      const data = [{ x: 1, y: 2 }, { x: null, y: 4 }, { x: 5, y: null }];
+      const wrapper = mount(<VictoryPie data={data} />);
+      expect(wrapper.find(Slice).length).to.equal(1);
+    });
   });
 
   describe("the `startAngle` prop", () => {

--- a/test/client/spec/victory-scatter/victory-scatter.spec.js
+++ b/test/client/spec/victory-scatter/victory-scatter.spec.js
@@ -117,6 +117,12 @@ describe("components/victory-scatter", () => {
 
       expect(coordinates).to.eql([[0, 0], [2, 3], [5, 5]]);
     });
+
+    it("does not render data with null x or y values", () => {
+      const data = [{ x: 1, y: 2 }, { x: null, y: 4 }, { x: 5, y: null }];
+      const wrapper = mount(<VictoryScatter data={data} />);
+      expect(wrapper.find(Point).length).to.equal(1);
+    });
   });
 
   describe("event handling", () => {

--- a/test/client/spec/victory-voronoi/victory-voronoi.spec.js
+++ b/test/client/spec/victory-voronoi/victory-voronoi.spec.js
@@ -64,6 +64,12 @@ describe("components/victory-voronoi", () => {
       const xValues = wrapper.find(Voronoi).map((voronoi) => voronoi.prop("datum")._x);
       expect(xValues).to.eql([4, 3, 2, 1, 0]);
     });
+
+    it("does not render data with null x or y values", () => {
+      const data = [{ x: 1, y: 2 }, { x: null, y: 4 }, { x: 5, y: null }];
+      const wrapper = mount(<VictoryVoronoi data={data} />);
+      expect(wrapper.find(Voronoi).length).to.equal(1);
+    });
   });
 
   describe("event handling", () => {


### PR DESCRIPTION
Fixes #1210 

A few components (VictoryScatter, VictoryBar, ...) will render data points with null X or Y values at the minimum of the output range rather than not rendering them at all, so this PR filters out those "invalid" data points from being rendered.

The `renderData()` method inside `add-events.js` is responsible for building the components for each data point, so I've added a predicate to that method to determine if a data component should be created. That predicate defaults to checking for `datum._x` and `datum._y` but can be overridden if necessary (as is the case for VictoryCandlestick).

Also got rid of a `componentWillReceiveProps` lifecycle method in `add-events.js`