### PR TITLE
alter reduceChildren to fix parent events regression

### DIFF
--- a/demo/components/events-demo.js
+++ b/demo/components/events-demo.js
@@ -202,7 +202,7 @@ class App extends React.Component {
                         childName: ["area-3", "area-4"],
                         target: "data",
                         mutation: (props) => {
-                          const fill = props.style.fill;
+                          const fill = props.style && props.style.fill;
                           return fill === "gold" ? null : { style: { fill: "gold" } };
                         }
                       }

--- a/packages/victory-core/src/victory-util/helpers.js
+++ b/packages/victory-core/src/victory-util/helpers.js
@@ -231,9 +231,7 @@ function reduceChildren(
         memo = combine(memo, nestedResults);
       } else {
         const result = iteratee(child, childName, parent);
-        if (Array.isArray(result)) {
-          memo = result.reduce(combine, memo);
-        } else if (result) {
+        if (result) {
           memo = combine(memo, result);
         }
       }

--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -298,11 +298,14 @@ export default {
     };
 
     const initialMemo = { x: [], y: [] };
-    const combine = (memo, datum) => ({
-      x: datum.x !== undefined ? memo.x.concat(datum.x) : memo.x,
-      y: datum.y !== undefined ? memo.y.concat(datum.y) : memo.y
-    });
-
+    const combine = (memo, datum) => {
+      const x = Array.isArray(datum) ? datum.map((d) => d.x).filter(Boolean) : datum.x;
+      const y = Array.isArray(datum) ? datum.map((d) => d.y).filter(Boolean) : datum.y;
+      return {
+        x: x !== undefined ? memo.x.concat(x) : memo.x,
+        y: y !== undefined ? memo.y.concat(y) : memo.y
+      };
+    }
     return Helpers.reduceChildren(childComponents.slice(0), iteratee, {}, initialMemo, combine);
   },
 

--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -305,7 +305,7 @@ export default {
         x: x !== undefined ? memo.x.concat(x) : memo.x,
         y: y !== undefined ? memo.y.concat(y) : memo.y
       };
-    }
+    };
     return Helpers.reduceChildren(childComponents.slice(0), iteratee, {}, initialMemo, combine);
   },
 


### PR DESCRIPTION
@mxfr
I noticed a small regression causing parent events to use the incorrect eventKey. It was caused by the additional reduce in `reduceChildren` introduced in https://github.com/FormidableLabs/victory/pull/1211

I altered `reduceChildren` and moved the additional work into the custom `combine` method used when calculating the string map.