### PR TITLE
remove componentWillMount

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -84,7 +84,7 @@ class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.addEventListener("hashchange", () => {
       this.setState({
         route: window.location.hash.substr(1)

--- a/demo/components/animation-demo.js
+++ b/demo/components/animation-demo.js
@@ -20,7 +20,7 @@ export default class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.setInterval(() => {
       this.setState({
         data: this.getData(),

--- a/demo/components/external-events-demo.js
+++ b/demo/components/external-events-demo.js
@@ -19,7 +19,7 @@ class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.setInterval(() => {
       this.setState({
         data: this.getData()

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -20,7 +20,7 @@ export default class App extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     window.setInterval(() => {
       this.setState({
         data: this.getData(),

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -1,4 +1,4 @@
-import { defaults, assign } from "lodash";
+import { defaults, assign, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import {
@@ -67,11 +67,6 @@ export default class VictoryChart extends React.Component {
       };
     }
     this.setAnimationState = Wrapper.setAnimationState.bind(this);
-    this.events = Wrapper.getAllEvents(props);
-  }
-
-  componentWillMount() {
-    this.events = Wrapper.getAllEvents(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -134,7 +129,8 @@ export default class VictoryChart extends React.Component {
     const container = standalone
       ? this.renderContainer(containerComponent, containerProps)
       : groupComponent;
-    if (this.events) {
+    this.events = this.events || Wrapper.getAllEvents(props);
+    if (!isEmpty(this.events)) {
       return (
         <VictorySharedEvents
           container={container}

--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -116,12 +116,13 @@ export default {
   getAllEvents(props) {
     const components = ["groupComponent", "containerComponent", "labelComponent"];
     this.componentEvents = Events.getComponentEvents(props, components);
+    let events = props.events;
     if (Array.isArray(this.componentEvents)) {
-      return Array.isArray(props.events)
+      events = Array.isArray(props.events)
         ? this.componentEvents.concat(...props.events)
         : this.componentEvents;
     }
-    return props.events;
+    return events || [];
   },
 
   getAnimationProps(props, child, index) {

--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -1,4 +1,4 @@
-import { assign, defaults } from "lodash";
+import { assign, defaults, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import { Helpers, VictoryContainer, VictoryTheme, CommonProps, Wrapper } from "victory-core";
@@ -62,12 +62,7 @@ export default class VictoryGroup extends React.Component {
         animating: true
       };
       this.setAnimationState = Wrapper.setAnimationState.bind(this);
-      this.events = Wrapper.getAllEvents(props);
     }
-  }
-
-  componentWillMount() {
-    this.events = Wrapper.getAllEvents(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -129,7 +124,8 @@ export default class VictoryGroup extends React.Component {
     const container = standalone
       ? this.renderContainer(containerComponent, containerProps)
       : groupComponent;
-    if (this.events) {
+    this.events = this.events || Wrapper.getAllEvents(props);
+    if (!isEmpty(this.events)) {
       return (
         <VictorySharedEvents
           container={container}

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -1,4 +1,4 @@
-import { assign, defaults } from "lodash";
+import { assign, defaults, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import { Helpers, VictoryContainer, VictoryTheme, CommonProps, Wrapper } from "victory-core";
@@ -73,12 +73,7 @@ export default class VictoryStack extends React.Component {
         animating: true
       };
       this.setAnimationState = Wrapper.setAnimationState.bind(this);
-      this.events = Wrapper.getAllEvents(props);
     }
-  }
-
-  componentWillMount() {
-    this.events = Wrapper.getAllEvents(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -140,7 +135,8 @@ export default class VictoryStack extends React.Component {
     const container = standalone
       ? this.renderContainer(containerComponent, containerProps)
       : groupComponent;
-    if (this.events) {
+    this.events = this.events || Wrapper.getAllEvents(props);
+    if (!isEmpty(this.events)) {
       return (
         <VictorySharedEvents
           container={container}


### PR DESCRIPTION
Some odd behavior was happening when switching from `componentWillMount` to `componentDidMount`, so instead, `render` will set up events if they have not already been set up. This ensures that the first render has the correct events. Events are subsequently updated when props update.