### PR TITLE
Improvement/axis value

### DIFF
--- a/packages/victory-axis/src/helper-methods.js
+++ b/packages/victory-axis/src/helper-methods.js
@@ -225,12 +225,38 @@ const getOffset = (props, calculatedValues) => {
 };
 
 const getTransform = (props, calculatedValues, offset) => {
-  const { orientation } = calculatedValues;
+  const { stringMap } = props;
+  const { orientation, axis } = calculatedValues;
+  const otherAxis = axis === "x" ? "y" : "x";
+  const scale = props.scale && isFunction(props.scale[otherAxis]) ? props.scale[otherAxis] : false;
+  const useAxisScale = props.axisValue && scale;
+  let axisValue = props.axisValue;
+  if (stringMap && stringMap[otherAxis] && typeof props.axisValue === "string") {
+    axisValue = stringMap[otherAxis][props.axisValue];
+  }
+  const fallback = {
+    top: offset.y,
+    bottom: props.height - offset.y,
+    left: offset.x,
+    right: props.width - offset.x
+  };
   return {
-    top: { x: 0, y: offset.y },
-    bottom: { x: 0, y: props.height - offset.y },
-    left: { x: offset.x, y: 0 },
-    right: { x: props.width - offset.x, y: 0 }
+    top: {
+      x: 0,
+      y: useAxisScale ? scale(axisValue) || fallback.top : fallback.top
+    },
+    bottom: {
+      x: 0,
+      y: useAxisScale ? scale(axisValue) || fallback.bottom : fallback.bottom
+    },
+    left: {
+      x: useAxisScale ? scale(axisValue) || fallback.left : fallback.left,
+      y: 0
+    },
+    right: {
+      x: useAxisScale ? scale(axisValue) || fallback.right : fallback.right,
+      y: 0
+    }
   }[orientation];
 };
 

--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -63,6 +63,7 @@ class VictoryAxis extends React.Component {
     ...CommonProps.baseProps,
     axisComponent: PropTypes.element,
     axisLabelComponent: PropTypes.element,
+    axisValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object]),
     categories: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.shape({
@@ -211,8 +212,8 @@ class VictoryAxis extends React.Component {
     const sorted = gridAndTicks.sort(
       (a, b) =>
         isVertical
-          ? getLabelCoord(b) - getLabelCoord(a) //ordinat axis has top-bottom orientation
-          : getLabelCoord(a) - getLabelCoord(b) //ordinat axis has left-right orientation
+          ? getLabelCoord(b) - getLabelCoord(a) //ordinary axis has top-bottom orientation
+          : getLabelCoord(a) - getLabelCoord(b) //ordinary axis has left-right orientation
     );
     return sorted.filter((gridAndTick, index) => index % divider === 0);
   }

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -17,7 +17,7 @@ function getAxisProps(child, props, calculatedProps) {
   const crossAxis = childProps.crossAxis === false ? false : true;
   const orientation = Axis.getOrientation(child, axis, originSign[otherAxis]);
   return {
-    stringMap: stringMap[currentAxis],
+    stringMap,
     categories: categories[currentAxis],
     startAngle: props.startAngle,
     endAngle: props.endAngle,

--- a/packages/victory-core/src/victory-util/axis.js
+++ b/packages/victory-core/src/victory-util/axis.js
@@ -171,7 +171,9 @@ function stringTicks(props) {
 }
 
 function getDefaultTickFormat(props) {
-  const { tickValues, stringMap } = props;
+  const { tickValues } = props;
+  const axis = getAxis(props);
+  const stringMap = props.stringMap && props.stringMap[axis];
   const fallbackFormat = tickValues && !Collection.containsDates(tickValues) ? (x) => x : undefined;
   if (!stringMap) {
     return stringTicks(props) ? (x, index) => tickValues[index] : fallbackFormat;
@@ -186,7 +188,9 @@ function getDefaultTickFormat(props) {
 }
 
 function getTickFormat(props, scale) {
-  const { tickFormat, stringMap } = props;
+  const { tickFormat } = props;
+  const axis = getAxis(props);
+  const stringMap = props.stringMap && props.stringMap[axis];
   if (!tickFormat) {
     const defaultTickFormat = getDefaultTickFormat(props);
     const scaleTickFormat =
@@ -207,8 +211,8 @@ function getTickFormat(props, scale) {
 }
 
 function getStringTicks(props) {
-  const { stringMap } = props;
   const axis = getAxis(props);
+  const stringMap = props.stringMap && props.stringMap[axis];
   const categories = Array.isArray(props.categories)
     ? props.categories
     : props.categories && props.categories[axis];
@@ -223,7 +227,9 @@ function getStringTicks(props) {
 }
 
 function getTickArray(props) {
-  const { tickValues, tickFormat, stringMap } = props;
+  const { tickValues, tickFormat } = props;
+  const axis = getAxis(props);
+  const stringMap = props.stringMap && props.stringMap[axis];
   const getTicksFromFormat = () => {
     if (!tickFormat || !Array.isArray(tickFormat)) {
       return undefined;
@@ -240,7 +246,6 @@ function getTickArray(props) {
   }
   const tickArray = ticks ? uniq(ticks) : getTicksFromFormat(props);
   const filterArray = (arr) => {
-    const axis = getAxis(props);
     const domain = (props.domain && props.domain[axis]) || props.domain;
     return Array.isArray(domain)
       ? arr.filter((t) => t >= Math.min(...domain) && t <= Math.max(...domain))

--- a/packages/victory-polar-axis/src/helper-methods.js
+++ b/packages/victory-polar-axis/src/helper-methods.js
@@ -106,12 +106,16 @@ const getStyles = (props, styleObject) => {
 };
 
 const getAxisAngle = (props) => {
-  const { axisAngle, startAngle, axisValue, dependentAxis, scale } = props;
+  const { axisAngle, startAngle, dependentAxis, scale, stringMap } = props;
   const otherAxis = Axis.getAxis(props) === "y" ? "x" : "y";
+  let axisValue = props.axisValue;
+  if (stringMap && stringMap[otherAxis] && typeof props.axisValue === "string") {
+    axisValue = stringMap[otherAxis][props.axisValue];
+  }
   if (axisValue === undefined || !dependentAxis || scale[otherAxis] === undefined) {
     return axisAngle === undefined ? startAngle : axisAngle;
   }
-  return Helpers.radiansToDegrees(scale.x(axisValue));
+  return Helpers.radiansToDegrees(scale[otherAxis](axisValue));
 };
 
 //eslint-disable-next-line max-params

--- a/packages/victory-polar-axis/src/victory-polar-axis.js
+++ b/packages/victory-polar-axis/src/victory-polar-axis.js
@@ -62,7 +62,7 @@ class VictoryPolarAxis extends React.Component {
     axisAngle: PropTypes.number,
     axisComponent: PropTypes.element,
     axisLabelComponent: PropTypes.element,
-    axisValue: PropTypes.number,
+    axisValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object]),
     categories: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.shape({

--- a/stories/victory-axis.js
+++ b/stories/victory-axis.js
@@ -30,6 +30,39 @@ const getRandomValues = (num, seed) => {
 
 storiesOf("VictoryAxis", module).add("default rendering", () => <VictoryAxis />);
 
+storiesOf("VictoryAxis.axisValue", module)
+  .add("works with numeric axisValue", () => (
+    <VictoryChart>
+      <VictoryAxis
+        tickValues={[1, 2, 3, 4, 5]}
+      />
+      <VictoryAxis dependentAxis axisValue={3}/>
+    </VictoryChart>
+  ))
+  .add("works with string axisValue", () => (
+    <VictoryChart>
+      <VictoryAxis axisValue={"zero"}/>
+      <VictoryAxis dependentAxis
+        tickValues={["-", "zero", "+"]}
+      />
+
+    </VictoryChart>
+  ))
+  .add("works with date axisValue", () => (
+    <VictoryChart scale={{ x: "time "}}>
+      <VictoryAxis
+        tickValues={[
+          new Date(1985, 1, 1),
+          new Date(1995, 1, 1),
+          new Date(2005, 1, 1),
+          new Date(2015, 1, 1)
+        ]}
+        tickFormat={(t) => t.getFullYear()}
+      />
+      <VictoryAxis dependentAxis axisValue={new Date(2000, 1, 1)}/>
+    </VictoryChart>
+  ));
+
 storiesOf("VictoryAxis.theme", module)
   .add("material theme", () => <VictoryAxis theme={VictoryTheme.material} />)
   .add("chart axes material theme", () => <VictoryChart theme={VictoryTheme.material} />)


### PR DESCRIPTION
This PR adds support for setting `axisValue` on polar and cartesian axes. This prop may be used to set the position of an axis relative to the opposite axis when it is used on an axis component that is nested within `VictoryChart`. This prop can take numeric, date, and string values. If this prop is set on an axis component that is not nested within `VictoryChart` it will not have an effect. 