### PR TITLE
Accept object for label orientation

### DIFF
--- a/demo/components/victory-box-plot-demo.js
+++ b/demo/components/victory-box-plot-demo.js
@@ -182,6 +182,13 @@ export default class App extends React.Component {
               { type: 2, min: 4, max: 20, median: 10, q1: 7, q3: 15 },
               { type: 3, min: 3, max: 12, median: 6, q1: 5, q3: 10 }
             ]}
+            labelOrientation={{
+              q1: "top",
+              q3: "top",
+              min: "bottom",
+              max: "bottom",
+              median: "bottom"
+            }}
           />
         </VictoryChart>
         <VictoryChart animate style={chartStyle} domainPadding={50}>

--- a/packages/victory-box-plot/src/helper-methods.js
+++ b/packages/victory-box-plot/src/helper-methods.js
@@ -274,8 +274,13 @@ const getText = (props, type) => {
   return Array.isArray(labelProp) ? labelProp[index] : labelProp;
 };
 
+const getOrientation = (labelOrientation, type) =>
+  typeof labelOrientation === "object" &&
+    labelOrientation[type] || labelOrientation;
+
 const getLabelProps = (props, text, type) => {
   const { datum, positions, index, boxWidth, horizontal, labelOrientation, style } = props;
+  const orientation = getOrientation(labelOrientation, type);
   const namespace = `${type}Labels`;
   const labelStyle = style[namespace] || style.labels;
   const defaultVerticalAnchor = horizontal ? "end" : "middle";
@@ -285,8 +290,8 @@ const getLabelProps = (props, text, type) => {
 
   const getDefaultPosition = (coord) => {
     const sign = {
-      x: labelOrientation === "left" ? -1 : 1,
-      y: labelOrientation === "top" ? -1 : 1
+      x: orientation === "left" ? -1 : 1,
+      y: orientation === "top" ? -1 : 1
     };
     return positions[coord] + (sign[coord] * width) / 2 + sign[coord] * (labelStyle.padding || 0);
   };

--- a/packages/victory-box-plot/src/victory-box-plot.js
+++ b/packages/victory-box-plot/src/victory-box-plot.js
@@ -82,7 +82,16 @@ class VictoryBoxPlot extends React.Component {
       })
     ),
     horizontal: PropTypes.bool,
-    labelOrientation: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+    labelOrientation: PropTypes.oneOfType([
+      PropTypes.oneOf(["top", "bottom", "left", "right"]),
+      PropTypes.exact({
+        q1: PropTypes.oneOf(["top", "bottom", "left", "right"]).isRequired,
+        q3: PropTypes.oneOf(["top", "bottom", "left", "right"]).isRequired,
+        min: PropTypes.oneOf(["top", "bottom", "left", "right"]).isRequired,
+        max: PropTypes.oneOf(["top", "bottom", "left", "right"]).isRequired,
+        median: PropTypes.oneOf(["top", "bottom", "left", "right"]).isRequired,
+      })
+    ]),
     labels: PropTypes.bool,
     max: PropTypes.oneOfType([
       PropTypes.func,


### PR DESCRIPTION
Fixes #1234.

This is what it looks like in the demo:

![screen shot 2019-02-04 at 11 55 23 am](https://user-images.githubusercontent.com/4371429/52223513-c4d2a500-2873-11e9-8e2f-d0f8d090727b.jpg)

The labels with "bottom" also overlap with the chart when labelOrientation is just "bottom", so this isn't directly related to my changes. Dunno if that's something you want me to fix here or if you have an issue for that.

I had to extract `getLabelOrientation` cuz ESLint was complaining about function complexity. Also wondering the props types are in "style". Dunno if we should provide a default fallback if people leave out a specific label's orientation? This seemed like the least-invasive implementation though.