### PR TITLE
fix area stroke on polar charts

### DIFF
--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -51,7 +51,7 @@ export default class Area extends React.Component {
           .defined(defined)
           .curve(d3Shape[`${interpolation}Closed`])
           .angle(getAngleAccessor(scale))
-          .radius(getY0Accessor(scale))
+          .radius(getYAccessor(scale))
       : d3Shape
           .line()
           .defined(defined)


### PR DESCRIPTION
Fixes #1265 

I run `yarn nps test` and result was `Executed 650 of 651 (skipped 1) SUCCESS`. Not sure how to better test it.