### PR TITLE
Feature/blacklist with regex

### DIFF
--- a/packages/victory-core/src/victory-util/prop-types.js
+++ b/packages/victory-core/src/victory-util/prop-types.js
@@ -216,7 +216,7 @@ export default {
    */
   regExp: makeChainable((props, propName, componentName) => {
     if (props[propName] && !isRegExp(props[propName])) {
-      return new Error(`\`${propName}\` in \`${componentName}\` must be a regular expression.`);      
+      return new Error(`\`${propName}\` in \`${componentName}\` must be a regular expression.`);
     }
     return undefined;
   })

--- a/packages/victory-core/src/victory-util/prop-types.js
+++ b/packages/victory-core/src/victory-util/prop-types.js
@@ -1,5 +1,5 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
-import { isFunction, find } from "lodash";
+import { isFunction, find, isRegExp } from "lodash";
 import Log from "./log";
 import PropTypes from "prop-types";
 
@@ -207,6 +207,16 @@ export default {
       props[propName].length !== props.data.length
     ) {
       return new Error(`Length of data and ${propName} arrays must match.`);
+    }
+    return undefined;
+  }),
+
+  /**
+   * Check that the value is a regular expression
+   */
+  regExp: makeChainable((props, propName, componentName) => {
+    if (props[propName] && !isRegExp(props[propName])) {
+      return new Error(`\`${propName}\` in \`${componentName}\` must be a regular expression.`);      
     }
     return undefined;
   })

--- a/packages/victory-voronoi-container/README.md
+++ b/packages/victory-voronoi-container/README.md
@@ -105,7 +105,7 @@ _example:_ `radius={25}`
 
 ### voronoiBlacklist
 
-`type: array[string]`
+`type: array[string || regex]`
 
 The `voronoiBlacklist` prop is used to specify a list of components to ignore when calculating a shared voronoi diagram. Components with a `name` prop matching an element in the `voronoiBlacklist` array will be ignored by `VictoryVoronoiContainer`. Ignored components will never be flagged as active, and will not contribute date to shared tooltips or labels.
 

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -18,7 +18,9 @@ export const voronoiContainerMixin = (base) =>
       onActivated: PropTypes.func,
       onDeactivated: PropTypes.func,
       radius: PropTypes.number,
-      voronoiBlacklist: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, CustomPropTypes.regExp])),
+      voronoiBlacklist: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, CustomPropTypes.regExp])
+      ),
       voronoiDimension: PropTypes.oneOf(["x", "y"]),
       voronoiPadding: PropTypes.number
     };

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { defaults, isFunction, pick } from "lodash";
 import { VictoryTooltip } from "victory-tooltip";
-import { VictoryContainer, Helpers, TextSize } from "victory-core";
+import { VictoryContainer, Helpers, TextSize, PropTypes as CustomPropTypes } from "victory-core";
 import VoronoiHelpers from "./voronoi-helpers";
 
 export const voronoiContainerMixin = (base) =>
@@ -18,7 +18,7 @@ export const voronoiContainerMixin = (base) =>
       onActivated: PropTypes.func,
       onDeactivated: PropTypes.func,
       radius: PropTypes.number,
-      voronoiBlacklist: PropTypes.arrayOf(PropTypes.string),
+      voronoiBlacklist: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, CustomPropTypes.regExp])),
       voronoiDimension: PropTypes.oneOf(["x", "y"]),
       voronoiPadding: PropTypes.number
     };

--- a/packages/victory-voronoi-container/src/voronoi-helpers.js
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.js
@@ -1,5 +1,15 @@
 import { Selection, Data, Helpers } from "victory-core";
-import { assign, throttle, isFunction, isEmpty, groupBy, keys, includes, isString, isRegExp } from "lodash";
+import {
+  assign,
+  throttle,
+  isFunction,
+  isEmpty,
+  groupBy,
+  keys,
+  includes,
+  isString,
+  isRegExp
+} from "lodash";
 import isEqual from "react-fast-compare";
 import { voronoi as d3Voronoi } from "d3-voronoi";
 import React from "react";
@@ -56,7 +66,7 @@ const VoronoiHelpers = {
       const blacklist = props.voronoiBlacklist || [];
       const blacklistStr = blacklist.filter(isString);
       const blacklistRegExp = blacklist.filter(isRegExp);
-      const isRegExpMatch = blacklistRegExp.some(regExp => regExp.test(name));
+      const isRegExpMatch = blacklistRegExp.some((regExp) => regExp.test(name));
       if (!Data.isDataComponent(child) || includes(blacklistStr, name) || isRegExpMatch) {
         return null;
       }

--- a/packages/victory-voronoi-container/src/voronoi-helpers.js
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.js
@@ -1,5 +1,5 @@
 import { Selection, Data, Helpers } from "victory-core";
-import { assign, throttle, isFunction, isEmpty, groupBy, keys, includes } from "lodash";
+import { assign, throttle, isFunction, isEmpty, groupBy, keys, includes, isString, isRegExp } from "lodash";
 import isEqual from "react-fast-compare";
 import { voronoi as d3Voronoi } from "d3-voronoi";
 import React from "react";
@@ -54,7 +54,10 @@ const VoronoiHelpers = {
       const childProps = child.props || {};
       const name = childProps.name || childName;
       const blacklist = props.voronoiBlacklist || [];
-      if (!Data.isDataComponent(child) || includes(blacklist, name)) {
+      const blacklistStr = blacklist.filter(isString);
+      const blacklistRegExp = blacklist.filter(isRegExp);
+      const isRegExpMatch = blacklistRegExp.some(regExp => regExp.test(name));
+      if (!Data.isDataComponent(child) || includes(blacklistStr, name) || isRegExpMatch) {
         return null;
       }
       const getChildData =


### PR DESCRIPTION
Implements feature #1275

Allows you to define the voronoiBlacklist prop using strings or regular expressions. I decided to use lodash's isRegExp function instead of `x instanceof RegExp` because it seemed more robust. 