### PR TITLE
Improvement/reverse victory stack render

### DIFF
--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -146,7 +146,7 @@ export default class VictoryStack extends React.Component {
           events={events}
           externalEventMutations={externalEventMutations}
         >
-          {newChildren}
+          {newChildren.reverse()}
         </VictorySharedEvents>
       );
     }

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -98,7 +98,7 @@ export default class VictoryStack extends React.Component {
       are rendered behind lower children. This looks nicer for stacked bars with cornerRadius, and
       areas with strokes
     */
-    return newChildren.reverse()
+    return newChildren.reverse();
   }
 
   renderContainer(containerComponent, props) {

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -89,10 +89,16 @@ export default class VictoryStack extends React.Component {
   getNewChildren(props, childComponents, calculatedProps) {
     const children = getChildren(props, childComponents, calculatedProps);
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
-    return children.map((child, index) => {
+    const newChildren = children.map((child, index) => {
       const childProps = assign({ animate: getAnimationProps(props, child, index) }, child.props);
       return React.cloneElement(child, childProps);
     });
+    /*
+      reverse render order for children of `VictoryStack` so that higher children in the stack
+      are rendered behind lower children. This looks nicer for stacked bars with cornerRadius, and
+      areas with strokes
+    */
+    return newChildren.reverse()
   }
 
   renderContainer(containerComponent, props) {
@@ -146,7 +152,7 @@ export default class VictoryStack extends React.Component {
           events={events}
           externalEventMutations={externalEventMutations}
         >
-          {newChildren.reverse()}
+          {newChildren}
         </VictorySharedEvents>
       );
     }


### PR DESCRIPTION
This PR reverses the render order for children of `VictoryStack`. This is desirable in scenarios such as:
- Stacked `VictoryArea` or `VictoryBar` charts with `strokeWidth` styles
- Stacked charts with labels
- Stacked `VictoryBar` charts with `cornerRadius` as in https://github.com/FormidableLabs/victory/issues/1289

closes https://github.com/FormidableLabs/victory/issues/1288
closes https://github.com/FormidableLabs/victory/issues/1289