### PR TITLE
add diff labels and orientation support

### DIFF
--- a/packages/victory-box-plot/src/helper-methods.js
+++ b/packages/victory-box-plot/src/helper-methods.js
@@ -288,7 +288,7 @@ const getLabelProps = (props, text, type) => {
     text,
     datum,
     index,
-    orientation: labelOrientation,
+    orientation,
     style: labelStyle,
     y: horizontal ? getDefaultPosition("y") : positions[type],
     x: horizontal ? positions[type] : getDefaultPosition("x"),

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -2,7 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Helpers, CommonProps, Rect, Line } from "victory-core";
-import { assign, defaults } from "lodash";
+import { assign, defaults, isFunction } from "lodash";
 
 export default class Candle extends React.Component {
   static propTypes = {
@@ -28,8 +28,21 @@ export default class Candle extends React.Component {
     rectComponent: <Rect />
   };
 
+  getCandleWidth(props, style) {
+    const { active, datum, candleWidth } = props;
+    if (candleWidth) {
+      return isFunction(candleWidth)
+        ? Helpers.evaluateProp(candleWidth, datum, active)
+        : candleWidth;
+    } else if (style.width) {
+      return style.width;
+    }
+    return candleWidth;
+  }
+
   getCandleProps(props, style) {
-    const { id, x, close, open, horizontal, candleWidth } = props;
+    const { id, x, close, open, horizontal } = props;
+    const candleWidth = this.getCandleWidth(props, style);
     const candleLength = Math.abs(close - open);
     return {
       key: `${id}-candle`,

--- a/packages/victory-candlestick/src/helper-methods.js
+++ b/packages/victory-candlestick/src/helper-methods.js
@@ -224,7 +224,7 @@ const getLabelProps = (dataProps, text, style, type) => {
     scale,
     datum,
     data,
-    orientation: labelOrientation,
+    orientation,
     textAnchor: labelStyle.textAnchor || defaultTextAnchors[orientation],
     verticalAnchor: labelStyle.verticalAnchor || defaultVerticalAnchors[orientation],
     angle: labelStyle.angle,

--- a/packages/victory-candlestick/src/helper-methods.js
+++ b/packages/victory-candlestick/src/helper-methods.js
@@ -180,7 +180,7 @@ const calculatePlotValues = (props) => {
 /* eslint-enable complexity*/
 
 /* eslint-disable max-params*/
-const getLabelProps = (dataProps, text, style, type) => {
+const getLabelProps = (props, text, style, type) => {
   const {
     x,
     high,
@@ -194,7 +194,7 @@ const getLabelProps = (dataProps, text, style, type) => {
     horizontal,
     candleWidth,
     labelOrientation
-  } = dataProps;
+  } = props;
 
   const orientation = getOrientation(labelOrientation, type);
   const positions = { high, low, open, close };
@@ -281,31 +281,29 @@ const getBaseProps = (props, fallbackProps) => {
     const open = scale.y(datum._open);
     const low = scale.y(datum._low);
     const dataStyle = getDataStyles(datum, style.data, props);
-    const dataProps = defaults(
-      {
-        x,
-        high,
-        low,
-        candleWidth,
-        candleRatio,
-        scale,
-        data,
-        datum,
-        groupComponent,
-        index,
-        style: dataStyle,
-        width,
-        polar,
-        origin,
-        wickStrokeWidth,
-        open,
-        close,
-        horizontal,
-        labelOrientation
-      },
-      props
-    );
+    const dataProps = {
+      x,
+      high,
+      low,
+      candleWidth,
+      candleRatio,
+      scale,
+      data,
+      datum,
+      groupComponent,
+      index,
+      style: dataStyle,
+      width,
+      polar,
+      origin,
+      wickStrokeWidth,
+      open,
+      close,
+      horizontal,
+      labelOrientation
+    };
     dataProps.candleWidth = getCandleWidth(dataProps);
+    const extendedProps = defaults(Object.assign({}, dataProps), props);
 
     childProps[eventKey] = {
       data: dataProps
@@ -314,19 +312,19 @@ const getBaseProps = (props, fallbackProps) => {
     if (labels) {
       const text = LabelHelpers.getText(props, datum, index);
       if ((text !== undefined && text !== null) || (labels && (events || sharedEvents))) {
-        childProps[eventKey].labels = getLabelProps(dataProps, text, style);
+        childProps[eventKey].labels = getLabelProps(extendedProps, text, style);
       }
     }
 
     TYPES.forEach((type) => {
-      const labelText = getText(dataProps, type);
+      const labelText = getText(extendedProps, type);
       const labelProp = props.labels || props[`${type}Labels`];
       if (
         (labelText !== null && labelText !== undefined) ||
         (labelProp && (events || sharedEvents))
       ) {
         const target = `${type}Labels`;
-        childProps[eventKey][target] = getLabelProps(dataProps, labelText, style, type);
+        childProps[eventKey][target] = getLabelProps(extendedProps, labelText, style, type);
       }
     });
 

--- a/packages/victory-candlestick/src/helper-methods.js
+++ b/packages/victory-candlestick/src/helper-methods.js
@@ -127,9 +127,9 @@ const getText = (props, type) => {
 };
 
 const getCandleWidth = (props, style) => {
-  const { active, datum, data, candleWidth, scale, defaultCandleWidth } = props;
+  const { datum, data, candleWidth, scale, defaultCandleWidth } = props;
   if (candleWidth) {
-    return isFunction(candleWidth) ? Helpers.evaluateProp(candleWidth, datum, active) : candleWidth;
+    return isFunction(candleWidth) ? Helpers.evaluateProp(candleWidth, datum) : candleWidth;
   } else if (style && style.width) {
     return style.width;
   }
@@ -145,7 +145,7 @@ const getOrientation = (labelOrientation, type) =>
   (typeof labelOrientation === "object" && labelOrientation[type]) || labelOrientation;
 
 /* eslint-disable complexity*/
-const calculateAxisValues = (props) => {
+const calculatePlotValues = (props) => {
   const { positions, labelStyle, x, horizontal, computedType, candleWidth, orientation } = props;
   positions.labels = (positions.open + positions.close) / 2;
 
@@ -204,7 +204,7 @@ const getLabelProps = (dataProps, text, style, type) => {
   const defaultTextAnchors = { left: "end", right: "start", top: "middle", bottom: "middle" };
   const computedType = type ? type : "labels";
 
-  const axisProps = {
+  const plotProps = {
     positions,
     labelStyle,
     x,
@@ -213,7 +213,7 @@ const getLabelProps = (dataProps, text, style, type) => {
     candleWidth,
     orientation
   };
-  const { yValue, xValue } = calculateAxisValues(axisProps);
+  const { yValue, xValue } = calculatePlotValues(plotProps);
 
   return {
     style: labelStyle,

--- a/packages/victory-candlestick/src/victory-candlestick.js
+++ b/packages/victory-candlestick/src/victory-candlestick.js
@@ -138,7 +138,7 @@ class VictoryCandlestick extends React.Component {
     openLabelComponent: PropTypes.element,
     openLabels: PropTypes.oneOfType([PropTypes.func, PropTypes.array, PropTypes.bool]),
     style: PropTypes.shape({
-      data: PropTypes.obeject,
+      data: PropTypes.object,
       labels: PropTypes.object,
       close: PropTypes.object,
       closeLabels: PropTypes.object,

--- a/stories/victory-candlestick.js
+++ b/stories/victory-candlestick.js
@@ -128,10 +128,36 @@ storiesOf("VictoryCandlestick.labels", module)
   .add("function labels", () => (
     <VictoryCandlestick data={getData(7)} labels={(d) => `x: ${d.x}`} />
   ))
+  .add("openLabels and closeLabels", () => (
+    <VictoryCandlestick
+      data={[
+        { x: 1, open: 9, close: 30, high: 56, low: 7 },
+        { x: 2, open: 80, close: 40, high: 120, low: 10 },
+        { x: 3, open: 50, close: 80, high: 90, low: 20 },
+        { x: 4, open: 70, close: 22, high: 70, low: 5 },
+        { x: 5, open: 20, close: 35, high: 50, low: 10 }
+      ]}
+      openLabels={(d) => d.open}
+      closeLabels={(d) => d.close}
+    />
+  ))
+  .add("highLabels and lowLabels", () => (
+    <VictoryCandlestick
+      data={[
+        { x: 1, open: 9, close: 30, high: 56, low: 7 },
+        { x: 2, open: 80, close: 40, high: 120, low: 10 },
+        { x: 3, open: 50, close: 80, high: 90, low: 20 },
+        { x: 4, open: 70, close: 22, high: 70, low: 5 },
+        { x: 5, open: 20, close: 35, high: 50, low: 10 }
+      ]}
+      highLabels={(d) => d.high}
+      lowLabels={(d) => d.low}
+    />
+  ))
   .add("array labels", () => (
     <VictoryCandlestick data={getData(7)} labels={["", "", "three", "four", 5, "six"]} />
   ))
-  .add("function labels with orientation", () => (
+  .add("labels with orientation", () => (
     <VictoryCandlestick
       data={[
         { x: 1, open: 9, close: 30, high: 56, low: 7 },
@@ -154,6 +180,7 @@ storiesOf("VictoryCandlestick.labels", module)
         { x: 4, open: 70, close: 22, high: 70, low: 5 },
         { x: 5, open: 20, close: 35, high: 50, low: 10, label: ["last", "label"] }
       ]}
+      labels={(d) => d.label}
     />
   ));
 
@@ -172,6 +199,24 @@ storiesOf("VictoryCandlestick.tooltips", module)
       data={getData(5)}
       labels={(d) => `x: ${d.x}`}
       labelComponent={<VictoryTooltip active />}
+    />
+  ))
+
+  .add("tooltips different labels", () => (
+    <VictoryCandlestick
+      horizontal
+      data={[
+        { x: 1, open: 9, close: 30, high: 56, low: 7 },
+        { x: 2, open: 80, close: 40, high: 120, low: 10 },
+        { x: 3, open: 50, close: 80, high: 90, low: 20 },
+        { x: 4, open: 70, close: 22, high: 70, low: 5 },
+        { x: 5, open: 20, close: 35, high: 50, low: 10 }
+      ]}
+      openLabels={(d) => `o: ${d.open}`}
+      openLabelComponent={<VictoryTooltip active />}
+      closeLabels={(d) => `c: ${d.close}`}
+      closeLabelComponent={<VictoryTooltip active />}
+      labelOrientation="top"
     />
   ))
   .add("tooltips with long and short strings", () => (

--- a/stories/victory-candlestick.js
+++ b/stories/victory-candlestick.js
@@ -9,6 +9,13 @@ import seedrandom from "seedrandom";
 import { getChartDecorator } from "./decorators";
 import { fromJS } from "immutable";
 
+const sampleData = [
+  { x: 1, open: 9, close: 30, high: 56, low: 7 },
+  { x: 2, open: 80, close: 40, high: 120, low: 10 },
+  { x: 3, open: 50, close: 80, high: 90, low: 20 },
+  { x: 4, open: 70, close: 22, high: 70, low: 5 },
+  { x: 5, open: 20, close: 35, high: 50, low: 10 }
+];
 const getTimeData = (num, seed) => {
   seed = seed || "getTimeData";
   const baseSeed = seedrandom(seed);
@@ -83,31 +90,10 @@ storiesOf("VictoryCandlestick.wickStrokeWidth", module)
 storiesOf("VictoryCandlestick.data", module)
   .addDecorator(getChartDecorator({ domainPadding: 25 }))
   .add("with data accessors", () => (
-    <VictoryCandlestick
-      data={[
-        { series: 1, open: 9, close: 30, big: 560, low: 7 },
-        { series: 2, open: 80, close: 40, big: 1200, low: 10 },
-        { series: 3, open: 50, close: 80, big: 900, low: 20 },
-        { series: 4, open: 70, close: 22, big: 700, low: 5 },
-        { series: 5, open: 20, close: 35, big: 500, low: 10 }
-      ]}
-      x={"series"}
-      high={(data) => data.big / 10}
-    />
+    <VictoryCandlestick data={sampleData} x={"series"} high={(data) => data.big / 10} />
   ))
   .add("with data accessors (horizontal)", () => (
-    <VictoryCandlestick
-      horizontal
-      data={[
-        { series: 1, open: 9, close: 30, big: 560, low: 7 },
-        { series: 2, open: 80, close: 40, big: 1200, low: 10 },
-        { series: 3, open: 50, close: 80, big: 900, low: 20 },
-        { series: 4, open: 70, close: 22, big: 700, low: 5 },
-        { series: 5, open: 20, close: 35, big: 500, low: 10 }
-      ]}
-      x={"series"}
-      high={(data) => data.big / 10}
-    />
+    <VictoryCandlestick horizontal data={sampleData} x={"series"} high={(data) => data.big / 10} />
   ))
   .add("with immutable data", () => {
     return (
@@ -129,43 +115,17 @@ storiesOf("VictoryCandlestick.labels", module)
     <VictoryCandlestick data={getData(7)} labels={(d) => `x: ${d.x}`} />
   ))
   .add("openLabels and closeLabels", () => (
-    <VictoryCandlestick
-      data={[
-        { x: 1, open: 9, close: 30, high: 56, low: 7 },
-        { x: 2, open: 80, close: 40, high: 120, low: 10 },
-        { x: 3, open: 50, close: 80, high: 90, low: 20 },
-        { x: 4, open: 70, close: 22, high: 70, low: 5 },
-        { x: 5, open: 20, close: 35, high: 50, low: 10 }
-      ]}
-      openLabels={(d) => d.open}
-      closeLabels={(d) => d.close}
-    />
+    <VictoryCandlestick data={sampleData} openLabels={(d) => d.open} closeLabels={(d) => d.close} />
   ))
   .add("highLabels and lowLabels", () => (
-    <VictoryCandlestick
-      data={[
-        { x: 1, open: 9, close: 30, high: 56, low: 7 },
-        { x: 2, open: 80, close: 40, high: 120, low: 10 },
-        { x: 3, open: 50, close: 80, high: 90, low: 20 },
-        { x: 4, open: 70, close: 22, high: 70, low: 5 },
-        { x: 5, open: 20, close: 35, high: 50, low: 10 }
-      ]}
-      highLabels={(d) => d.high}
-      lowLabels={(d) => d.low}
-    />
+    <VictoryCandlestick data={sampleData} highLabels={(d) => d.high} lowLabels={(d) => d.low} />
   ))
   .add("array labels", () => (
     <VictoryCandlestick data={getData(7)} labels={["", "", "three", "four", 5, "six"]} />
   ))
   .add("labels with orientation", () => (
     <VictoryCandlestick
-      data={[
-        { x: 1, open: 9, close: 30, high: 56, low: 7 },
-        { x: 2, open: 80, close: 40, high: 120, low: 10 },
-        { x: 3, open: 50, close: 80, high: 90, low: 20 },
-        { x: 4, open: 70, close: 22, high: 70, low: 5 },
-        { x: 5, open: 20, close: 35, high: 50, low: 10 }
-      ]}
+      data={sampleData}
       openLabels={(d) => d.open}
       labelOrientation={{ open: "top" }}
     />
@@ -201,22 +161,32 @@ storiesOf("VictoryCandlestick.tooltips", module)
       labelComponent={<VictoryTooltip active />}
     />
   ))
-
-  .add("tooltips different labels", () => (
+  .add("openLabels tooltips", () => (
     <VictoryCandlestick
-      horizontal
-      data={[
-        { x: 1, open: 9, close: 30, high: 56, low: 7 },
-        { x: 2, open: 80, close: 40, high: 120, low: 10 },
-        { x: 3, open: 50, close: 80, high: 90, low: 20 },
-        { x: 4, open: 70, close: 22, high: 70, low: 5 },
-        { x: 5, open: 20, close: 35, high: 50, low: 10 }
-      ]}
-      openLabels={(d) => `o: ${d.open}`}
+      data={sampleData}
+      openLabels={(d) => d.open}
       openLabelComponent={<VictoryTooltip active />}
-      closeLabels={(d) => `c: ${d.close}`}
+    />
+  ))
+  .add("closeLabels tooltips", () => (
+    <VictoryCandlestick
+      data={sampleData}
+      closeLabels={(d) => d.close}
       closeLabelComponent={<VictoryTooltip active />}
-      labelOrientation="top"
+    />
+  ))
+  .add("lowLabels tooltips", () => (
+    <VictoryCandlestick
+      data={sampleData}
+      lowLabels={(d) => d.low}
+      lowLabelComponent={<VictoryTooltip active />}
+    />
+  ))
+  .add("highLabels tooltips", () => (
+    <VictoryCandlestick
+      data={sampleData}
+      highLabels={(d) => d.high}
+      highLabelComponent={<VictoryTooltip active />}
     />
   ))
   .add("tooltips with long and short strings", () => (

--- a/stories/victory-candlestick.js
+++ b/stories/victory-candlestick.js
@@ -90,10 +90,31 @@ storiesOf("VictoryCandlestick.wickStrokeWidth", module)
 storiesOf("VictoryCandlestick.data", module)
   .addDecorator(getChartDecorator({ domainPadding: 25 }))
   .add("with data accessors", () => (
-    <VictoryCandlestick data={sampleData} x={"series"} high={(data) => data.big / 10} />
+    <VictoryCandlestick
+      data={[
+        { series: 1, open: 9, close: 30, big: 560, low: 7 },
+        { series: 2, open: 80, close: 40, big: 1200, low: 10 },
+        { series: 3, open: 50, close: 80, big: 900, low: 20 },
+        { series: 4, open: 70, close: 22, big: 700, low: 5 },
+        { series: 5, open: 20, close: 35, big: 500, low: 10 }
+      ]}
+      x={"series"}
+      high={(data) => data.big / 10}
+    />
   ))
   .add("with data accessors (horizontal)", () => (
-    <VictoryCandlestick horizontal data={sampleData} x={"series"} high={(data) => data.big / 10} />
+    <VictoryCandlestick
+      horizontal
+      data={[
+        { series: 1, open: 9, close: 30, big: 560, low: 7 },
+        { series: 2, open: 80, close: 40, big: 1200, low: 10 },
+        { series: 3, open: 50, close: 80, big: 900, low: 20 },
+        { series: 4, open: 70, close: 22, big: 700, low: 5 },
+        { series: 5, open: 20, close: 35, big: 500, low: 10 }
+      ]}
+      x={"series"}
+      high={(data) => data.big / 10}
+    />
   ))
   .add("with immutable data", () => {
     return (
@@ -166,6 +187,7 @@ storiesOf("VictoryCandlestick.tooltips", module)
       data={sampleData}
       openLabels={(d) => d.open}
       openLabelComponent={<VictoryTooltip active />}
+      labelOrientation="top"
     />
   ))
   .add("closeLabels tooltips", () => (
@@ -173,6 +195,7 @@ storiesOf("VictoryCandlestick.tooltips", module)
       data={sampleData}
       closeLabels={(d) => d.close}
       closeLabelComponent={<VictoryTooltip active />}
+      labelOrientation={{ close: "left" }}
     />
   ))
   .add("lowLabels tooltips", () => (


### PR DESCRIPTION
Fixes: #1286 

Improvements on label support for `victory-candlestick`. This PR includes following label support for candlestick 

- lowLabels
- lowLabelComponent
- highLabels
- highLabelComponent
- openLabels
- openLabelComponent
- closeLabels
- closeLabelComponent

There is also continued support for `labels` and `labelComponent`.  `style` can be applied on all the different labels.

Also support `top`,` bottom`, `left`, `right` label orientation support for all the labels

TODO:
- [x] regression testing
- [x] demo update