### PR TITLE
chore(build): Specify required react version

### DIFF
--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -45,6 +45,9 @@
     "victory-voronoi-container": "^32.2.0",
     "victory-zoom-container": "^32.2.0"
   },
+  "peerDependencies": {
+    "react": "^16.6.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },


### PR DESCRIPTION
Couldn't find the required react version. Should probably be mentioned in the docs as well.

This is the version that is currently specified in the lockfile. I want to work on switching to the new context API and this is the perfect version for it (16.6 has the static `contextType` which is a lot better for classes than `Context.Consumer`)