### PR TITLE
use improved delaunay-find

### DIFF
--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -56,6 +56,77 @@ class App extends React.Component {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryChart
+            height={450}
+            domain={{ y: [0, 1] }}
+            style={chartStyle}
+            containerComponent={
+              <VictoryVoronoiContainer
+                labels={(d) => d.y}
+              />
+            }
+          >
+
+            <VictoryScatter
+              data={[
+                { x: 1, y: 0 },
+                { x: 2, y: 0 },
+                { x: 3, y: 0 },
+                { x: 4, y: 0 },
+                { x: 5, y: 0 },
+                { x: 6, y: 0 },
+                { x: 7, y: 0 }
+              ]}
+              style={{
+                data: { fill: "blue" }
+              }}
+              size={(datum, active) => (active ? 8 : 3)}
+            />
+            <VictoryScatter
+              data={[
+                { x: 1, y: 0 },
+                { x: 2, y: 0 },
+                { x: 3, y: 1 },
+                { x: 4, y: 0 },
+                { x: 5, y: 0 },
+                { x: 6, y: 0 },
+                { x: 7, y: 0 }
+              ]}
+              style={{
+                data: { fill: "red" }
+              }}
+              size={(datum, active) => (active ? 5 : 3)}
+            />
+          </VictoryChart>
+
+          <VictoryChart
+            height={450}
+            domain={{ y: [0, 1] }}
+            style={chartStyle}
+            containerComponent={
+              <VictoryVoronoiContainer
+                labels={(d) => d.y}
+              />
+            }
+          >
+
+            <VictoryScatter
+              data={[
+                { x: 1, y: 0 },
+                { x: 2, y: 0 },
+                { x: 3, y: 0 },
+                { x: 4, y: 0 },
+                { x: 5, y: 0 },
+                { x: 6, y: 0 },
+                { x: 7, y: 0 }
+              ]}
+              style={{
+                data: { fill: "blue" }
+              }}
+              size={(datum, active) => (active ? 5 : 3)}
+            />
+          </VictoryChart>
+
+          <VictoryChart
             style={chartStyle}
             theme={VictoryTheme.material}
             domainPadding={{ y: 2 }}
@@ -185,7 +256,7 @@ class App extends React.Component {
                 style={{
                   data: { fill: "tomato" }
                 }}
-                size={(datum, active) => (active ? 5 : 3)}
+                size={(datum, active) => (active ? 8 : 3)}
               />
               <VictoryLine name="ignore" style={{ data: { stroke: "tomato" } }} />
             </VictoryGroup>
@@ -213,7 +284,7 @@ class App extends React.Component {
                 { x: 1, y: 5 },
                 { x: 2, y: -4 },
                 { x: 3, y: -2 },
-                { x: 4, y: -3 },
+                { x: 4, y: 0 },
                 { x: 5, y: -1 },
                 { x: 6, y: 3 },
                 { x: 7, y: -3 }
@@ -285,7 +356,7 @@ class App extends React.Component {
                   { x: 1, y: 5 },
                   { x: 2, y: -4 },
                   { x: 3, y: -2 },
-                  { x: 4, y: -3 },
+                  { x: 4, y: 0 },
                   { x: 5, y: -1 },
                   { x: 6, y: 3 },
                   { x: 7, y: -3 }

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -59,13 +59,8 @@ class App extends React.Component {
             height={450}
             domain={{ y: [0, 1] }}
             style={chartStyle}
-            containerComponent={
-              <VictoryVoronoiContainer
-                labels={(d) => d.y}
-              />
-            }
+            containerComponent={<VictoryVoronoiContainer labels={(d) => d.y} />}
           >
-
             <VictoryScatter
               data={[
                 { x: 1, y: 0 },
@@ -102,13 +97,8 @@ class App extends React.Component {
             height={450}
             domain={{ y: [0, 1] }}
             style={chartStyle}
-            containerComponent={
-              <VictoryVoronoiContainer
-                labels={(d) => d.y}
-              />
-            }
+            containerComponent={<VictoryVoronoiContainer labels={(d) => d.y} />}
           >
-
             <VictoryScatter
               data={[
                 { x: 1, y: 0 },

--- a/packages/victory-core/src/victory-util/helpers.js
+++ b/packages/victory-core/src/victory-util/helpers.js
@@ -50,13 +50,11 @@ function omit(originalObject, keys = []) {
 
 function getPoint(datum) {
   const exists = (val) => val !== undefined;
-  const { _x, _x1, _x0, _voronoiX, _y, _y1, _y0, _voronoiY } = datum;
-  const defaultX = exists(_x1) ? _x1 : _x;
-  const defaultY = exists(_y1) ? _y1 : _y;
+  const { _x, _x1, _x0, _y, _y1, _y0 } = datum;
   const point = {
-    x: exists(_voronoiX) ? _voronoiX : defaultX,
+    x: exists(_x1) ? _x1 : _x,
     x0: exists(_x0) ? _x0 : _x,
-    y: exists(_voronoiY) ? _voronoiY : defaultY,
+    y: exists(_y1) ? _y1 : _y,
     y0: exists(_y0) ? _y0 : _y
   };
   return defaults({}, point, datum);

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "d3-voronoi": "^1.1.2",
+    "delaunay-find": "0.0.3",
     "lodash": "^4.17.11",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.1",

--- a/packages/victory-voronoi-container/src/voronoi-helpers.js
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.js
@@ -1,17 +1,7 @@
 import { Selection, Data, Helpers } from "victory-core";
-import {
-  assign,
-  throttle,
-  isFunction,
-  isEmpty,
-  groupBy,
-  keys,
-  includes,
-  isString,
-  isRegExp
-} from "lodash";
+import { assign, throttle, isFunction, isEmpty, includes, isString, isRegExp } from "lodash";
 import isEqual from "react-fast-compare";
-import { voronoi as d3Voronoi } from "d3-voronoi";
+import Delaunay from "delaunay-find/lib/index.js";
 import React from "react";
 
 const VoronoiHelpers = {
@@ -39,8 +29,8 @@ const VoronoiHelpers = {
         const voronoiY = (+y + +y0) / 2;
         return assign(
           {
-            _voronoiX: props.voronoiDimension === "y" ? 0 : voronoiX,
-            _voronoiY: props.voronoiDimension === "x" ? 0 : voronoiY,
+            _voronoiX: props.voronoiDimension === "y" ? undefined : voronoiX,
+            _voronoiY: props.voronoiDimension === "x" ? undefined : voronoiY,
             eventKey: index,
             childName: name,
             continuous,
@@ -79,34 +69,39 @@ const VoronoiHelpers = {
     return Helpers.reduceChildren(children, iteratee, props);
   },
 
-  // returns an array of objects with point and data where point is an x, y coordinate, and data is
-  // an array of points belonging to that coordinate
-  mergeDatasets(props, datasets) {
-    const points = groupBy(datasets, (datum) => {
-      const { x, y } = Helpers.scalePoint(props, datum);
-      return `${x},${y}`;
-    });
-    return keys(points).map((key) => {
-      const point = key.split(",");
-      return {
-        x: +point[0],
-        y: +point[1],
-        points: points[key]
-      };
+  findPoints(datasets, point) {
+    const x = point._voronoiX;
+    const y = point._voronoiY;
+    if (x !== undefined && y !== undefined) {
+      return [point];
+    }
+    return datasets.filter((d) => {
+      const matchesX = x === undefined || x === d._voronoiX;
+      const matchesY = y === undefined || y === d._voronoiY;
+      return matchesX && matchesY;
     });
   },
 
-  getVoronoi(props, mousePosition) {
-    const { width, height, voronoiPadding } = props;
-    const padding = voronoiPadding || 0;
-    const voronoiFunction = d3Voronoi()
-      .x((d) => d.x)
-      .y((d) => d.y)
-      .extent([[padding, padding], [width - padding, height - padding]]);
+  withinRadius(point, mousePosition, radius) {
+    if (!radius) {
+      return true;
+    }
+    const { x, y } = mousePosition;
+    const distanceSquared = Math.pow(x - point[0], 2) + Math.pow(y - point[1], 2);
+    return distanceSquared < Math.pow(radius, 2);
+  },
+
+  getVoronoiPoints(props, mousePosition) {
     const datasets = this.getDatasets(props);
-    const voronoi = voronoiFunction(this.mergeDatasets(props, datasets));
-    const size = props.voronoiDimension ? undefined : props.radius;
-    return voronoi.find(mousePosition.x, mousePosition.y, size);
+    const scaledData = datasets.map((d) => {
+      const { x, y } = Helpers.scalePoint(props, d);
+      return [x, y];
+    });
+    const delaunay = Delaunay.from(scaledData);
+    const index = delaunay.find(mousePosition.x, mousePosition.y);
+    const withinRadius = this.withinRadius(scaledData[index], mousePosition, props.radius);
+    const points = withinRadius ? this.findPoints(datasets, datasets[index]) : [];
+    return { points, index };
   },
 
   getActiveMutations(props, point) {
@@ -153,12 +148,13 @@ const VoronoiHelpers = {
     });
   },
 
-  getParentMutation(activePoints, mousePosition, parentSVG) {
+  // eslint-disable-next-line max-params
+  getParentMutation(activePoints, mousePosition, parentSVG, vIndex) {
     return [
       {
         target: "parent",
         eventKey: "parent",
-        mutation: () => ({ activePoints, mousePosition, parentSVG })
+        mutation: () => ({ activePoints, mousePosition, parentSVG, vIndex })
       }
     ];
   },
@@ -196,9 +192,8 @@ const VoronoiHelpers = {
         : [];
       return this.getParentMutation([], mousePosition, parentSVG).concat(...inactiveMutations);
     }
-    const nearestVoronoi = this.getVoronoi(targetProps, mousePosition);
-    const points = nearestVoronoi ? nearestVoronoi.data.points : [];
-    const parentMutations = this.getParentMutation(points, mousePosition, parentSVG);
+    const { points = [], index } = this.getVoronoiPoints(targetProps, mousePosition);
+    const parentMutations = this.getParentMutation(points, mousePosition, parentSVG, index);
     if (activePoints.length && isEqual(points, activePoints)) {
       return parentMutations;
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4015,6 +4015,18 @@ degenerator@^1.0.4:
     escodegen "1.x.x"
     esprima "3.x.x"
 
+delaunator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.0.tgz#3630f477b4923f472f534c62a028aeca6fe22d96"
+  integrity sha512-KzVgOHix5xaIVzZSfbv3Uzw9aI7mQNDet4Yd2p+tBNkfNHMFJbjbVa3q0nC7q7TjWZLX49QbzcT+pXazXX3Qmg==
+
+delaunay-find@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/delaunay-find/-/delaunay-find-0.0.3.tgz#b9863465c4cbca963b3d75a54550e73b2fc56c30"
+  integrity sha512-Ex8DtJudrPsB0IhmJxFjHqzZnzbCOoFgw8kTGAnTlc6uU/v25nd7o2HeWhyZSaPhholsfL33PmLSEdaBi0qfug==
+  dependencies:
+    delaunator "^4.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"


### PR DESCRIPTION
This PR replaces `d3-voronoi` with an improved version of `delaunay-find` which uses an updated version of the underlying `delaunator` package (which doesn't throw errors for degenerate datasets). The updated `delaunay-find` has tracked changes with `d3-delaunay`, but diverges in how it handles datasets with several collinear points. 

related: 
https://github.com/FormidableLabs/victory/issues/1341
https://github.com/FormidableLabs/delaunay-find/pull/8