### PR TITLE
activate all matching points

### DIFF
--- a/packages/victory-voronoi-container/src/voronoi-helpers.js
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.js
@@ -72,9 +72,7 @@ const VoronoiHelpers = {
   findPoints(datasets, point) {
     const x = point._voronoiX;
     const y = point._voronoiY;
-    if (x !== undefined && y !== undefined) {
-      return [point];
-    }
+
     return datasets.filter((d) => {
       const matchesX = x === undefined || x === d._voronoiX;
       const matchesY = y === undefined || y === d._voronoiY;


### PR DESCRIPTION
This PR corrects a bug introduced when switching to `delaunay`. Prior to this fix, only the first matching point would be activated when mousing over a region that contained two identical points.

fixes https://github.com/FormidableLabs/victory/issues/1342