### PR TITLE
chore(lodash): Update to version 4.17.15 (npm advisory 1065)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^2.0.4",
     "lerna": "^2.11.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "lodash-webpack-plugin": "^0.11.4",
     "mocha": "^5.0.0",
     "nps": "^5.9.0",

--- a/packages/victory-area/package.json
+++ b/packages/victory-area/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "d3-shape": "^1.2.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-axis/package.json
+++ b/packages/victory-axis/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "d3-shape": "^1.2.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-box-plot/package.json
+++ b/packages/victory-box-plot/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "d3-array": "^1.2.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-candlestick/package.json
+++ b/packages/victory-candlestick/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-chart/package.json
+++ b/packages/victory-chart/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0",
     "victory-axis": "^32.3.2",

--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -24,7 +24,7 @@
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.2.0",
     "d3-timer": "^1.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0"
   },

--- a/packages/victory-create-container/package.json
+++ b/packages/victory-create-container/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "victory-brush-container": "^32.3.2",
     "victory-core": "^32.3.2",
     "victory-cursor-container": "^32.3.2",

--- a/packages/victory-cursor-container/package.json
+++ b/packages/victory-cursor-container/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-errorbar/package.json
+++ b/packages/victory-errorbar/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -19,7 +19,7 @@
   "author": "Lauren Eastridge",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0",
     "victory-core": "^32.3.2"

--- a/packages/victory-legend/package.json
+++ b/packages/victory-legend/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "d3-shape": "^1.2.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-pie/package.json
+++ b/packages/victory-pie/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "d3-shape": "^1.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-polar-axis/package.json
+++ b/packages/victory-polar-axis/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-scatter/package.json
+++ b/packages/victory-scatter/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-selection-container/package.json
+++ b/packages/victory-selection-container/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-shared-events/package.json
+++ b/packages/victory-shared-events/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0",
     "victory-core": "^32.3.2"

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0",
     "victory-core": "^32.3.2"

--- a/packages/victory-tooltip/package.json
+++ b/packages/victory-tooltip/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "delaunay-find": "0.0.3",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2",
     "victory-tooltip": "^32.3.2"

--- a/packages/victory-voronoi/package.json
+++ b/packages/victory-voronoi/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "d3-voronoi": "^1.1.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/packages/victory-zoom-container/package.json
+++ b/packages/victory-zoom-container/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^32.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7051,6 +7051,11 @@ lodash@4.17.11, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.6, l
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log4js@^2.5.3:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/log4js/-/log4js-2.11.0.tgz#bf3902eff65c6923d9ce9cfbd2db54160e34005a"


### PR DESCRIPTION
@boygirl This update is due to versions of lodash <= 4.17.11 being vulnerable to prototype pollution. 

https://www.npmjs.com/advisories/1065