### PR TITLE
fix scroll wheel interaction in chrome 

### DIFF
--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -61,6 +61,12 @@ export default class VictoryContainer extends React.Component {
     this.portalUpdate = (key, el) => this.portalRef.portalUpdate(key, el);
     this.portalRegister = () => this.portalRef.portalRegister();
     this.portalDeregister = (key) => this.portalRef.portalDeregister(key);
+
+    this.containerRef = props.containerRef || React.createRef();
+    this.shouldHandleWheel = props.events && props.events.onWheel;
+    if (this.shouldHandleWheel) {
+      this.handleWheel = e => e.preventDefault();
+    }
   }
 
   getChildContext() {
@@ -72,9 +78,18 @@ export default class VictoryContainer extends React.Component {
     };
   }
 
+  componentDidMount() {
+    if (this.shouldHandleWheel && this.containerRef.current) {
+      this.containerRef.current.addEventListener("wheel", this.handleWheel);
+    }
+  }
+
   componentWillUnmount() {
     if (!this.context.getTimer) {
       this.getTimer().stop();
+    }
+    if (this.shouldHandleWheel && this.containerRef.current) {
+      this.containerRef.current.removeEventListener("wheel", this.handleWheel);
     }
   }
 
@@ -127,7 +142,7 @@ export default class VictoryContainer extends React.Component {
       style: portalSvgStyle
     };
     return (
-      <div style={defaults({}, style, divStyle)} className={className} ref={props.containerRef}>
+      <div style={defaults({}, style, divStyle)} className={className} ref={this.containerRef}>
         <svg {...svgProps} style={svgStyle}>
           {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -68,7 +68,7 @@ export default class VictoryContainer extends React.Component {
     };
     this.shouldHandleWheel = props.events && props.events.onWheel;
     if (this.shouldHandleWheel) {
-      this.handleWheel = e => e.preventDefault();
+      this.handleWheel = (e) => e.preventDefault();
     }
   }
 

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -62,7 +62,10 @@ export default class VictoryContainer extends React.Component {
     this.portalRegister = () => this.portalRef.portalRegister();
     this.portalDeregister = (key) => this.portalRef.portalDeregister(key);
 
-    this.containerRef = props.containerRef || React.createRef();
+    this.saveContainerRef = (container) => {
+      this.containerRef = props.containerRef || container;
+      return container;
+    };
     this.shouldHandleWheel = props.events && props.events.onWheel;
     if (this.shouldHandleWheel) {
       this.handleWheel = e => e.preventDefault();
@@ -79,8 +82,8 @@ export default class VictoryContainer extends React.Component {
   }
 
   componentDidMount() {
-    if (this.shouldHandleWheel && this.containerRef.current) {
-      this.containerRef.current.addEventListener("wheel", this.handleWheel);
+    if (this.shouldHandleWheel && this.containerRef) {
+      this.containerRef.addEventListener("wheel", this.handleWheel);
     }
   }
 
@@ -88,8 +91,8 @@ export default class VictoryContainer extends React.Component {
     if (!this.context.getTimer) {
       this.getTimer().stop();
     }
-    if (this.shouldHandleWheel && this.containerRef.current) {
-      this.containerRef.current.removeEventListener("wheel", this.handleWheel);
+    if (this.shouldHandleWheel && this.containerRef) {
+      this.containerRef.removeEventListener("wheel", this.handleWheel);
     }
   }
 
@@ -142,7 +145,7 @@ export default class VictoryContainer extends React.Component {
       style: portalSvgStyle
     };
     return (
-      <div style={defaults({}, style, divStyle)} className={className} ref={this.containerRef}>
+      <div style={defaults({}, style, divStyle)} className={className} ref={this.saveContainerRef}>
         <svg {...svgProps} style={svgStyle}>
           {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}

--- a/packages/victory-zoom-container/src/victory-zoom-container.js
+++ b/packages/victory-zoom-container/src/victory-zoom-container.js
@@ -82,9 +82,6 @@ export const zoomContainerMixin = (base) =>
             },
             // eslint-disable-next-line max-params
             onWheel: (evt, targetProps, eventKey, ctx) => {
-              if (targetProps.allowZoom && !props.disable) {
-                evt.preventDefault();
-              }
               return props.disable ? {} : ZoomHelpers.onWheel(evt, targetProps, eventKey, ctx);
             }
           }


### PR DESCRIPTION
This PR prevents the default wheel behavior on `VictoryContainer`'s outermost div when the events prop includes any `onWheel` events, as in `VictoryZoomContainer`. 

closes https://github.com/FormidableLabs/victory/issues/1272