### PR TITLE
fix error on createContainer with zoom and vonoroi

### DIFF
--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -66,7 +66,7 @@ export default class VictoryContainer extends React.Component {
       this.containerRef = props.containerRef || container;
       return container;
     };
-    this.shouldHandleWheel = props.events && props.events.onWheel;
+    this.shouldHandleWheel = props && props.events && props.events.onWheel;
     if (this.shouldHandleWheel) {
       this.handleWheel = (e) => e.preventDefault();
     }


### PR DESCRIPTION
createContainer throws and error "can't get events of undefined - props.events"