### PR TITLE
Last frame of animation should not be skipped

### DIFF
--- a/packages/victory-core/src/victory-animation/victory-animation.js
+++ b/packages/victory-core/src/victory-animation/victory-animation.js
@@ -119,7 +119,7 @@ export default class VictoryAnimation extends React.Component {
       /* Start traversing the tween queue */
       this.traverseQueue();
     }
-    return nextState.animationInfo.animating || !equalProps;
+    return nextState.animationInfo.animating || nextState.animationInfo.terminating || !equalProps;
   }
 
   componentWillUnmount() {
@@ -181,7 +181,8 @@ export default class VictoryAnimation extends React.Component {
         data: this.interpolator(1),
         animationInfo: {
           progress: 1,
-          animating: false
+          animating: false,
+          terminating: true
         }
       });
       if (this.loopID) {


### PR DESCRIPTION
Spectacle transitions skip the last render causing incomplete effects and partially loaded slides. 

To reproduce it just inspect the DOM after the slide transitions and confirm that the final CSS _transform_ values such as _scale_ or _translate3d_ do not reach final values (i.e. scale=1 or translate3d=0).  

See https://codesandbox.io/s/simple-spectacle-example-e96d2 as an example. In this specific case, scale does not reach 1 but a number close to it such as 0.993772. In this case maybe it is not noticeable at a first look, but if the slide has many more components or the hardware is stressed, it could stop at lower values causing a very noticeable glitch in the layout.

Forcing the render on the terminating case should fix the issue.

Once this is fixed and released, Spectacle dependency on victory should be updated.

By the way, I am fixing this bug since I am implementing a cover letter using Spectacle to find a new job. Do you want to hire me? :D Please see [https://fernandobarbat.com](https://fernandobarbat.com) Thanks!