### PR TITLE
Improvements for native

### DIFF
--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { assign } from "lodash";
+import { assign, isEmpty } from "lodash";
 import {
   PropTypes as CustomPropTypes,
   Helpers,
@@ -154,13 +154,25 @@ class VictoryAxis extends React.Component {
     return React.cloneElement(axisLabelComponent, axisLabelProps);
   }
 
+
+
   renderGridAndTicks(props) {
     const { tickComponent, tickLabelComponent, gridComponent, name } = props;
+    const shouldRender = (componentProps) => {
+      const { style = {}, events = {} } = componentProps;
+      const visible = style.stroke !== "transparent"
+        && style.stroke !== "none"
+        && style.strokeWidth !== 0;
+      return visible || !isEmpty(events);
+    };
+
     return this.dataKeys.map((key, index) => {
       const tickProps = this.getComponentProps(tickComponent, "ticks", index);
-      const TickComponent = React.cloneElement(tickComponent, tickProps);
+      const BaseTickComponent = React.cloneElement(tickComponent, tickProps);
+      const TickComponent = shouldRender(BaseTickComponent.props) ? BaseTickComponent : undefined;
       const gridProps = this.getComponentProps(gridComponent, "grid", index);
-      const GridComponent = React.cloneElement(gridComponent, gridProps);
+      const BaseGridComponent = React.cloneElement(gridComponent, gridProps);
+      const GridComponent = shouldRender(BaseGridComponent.props) ? BaseGridComponent : undefined;
       const tickLabelProps = this.getComponentProps(tickLabelComponent, "tickLabels", index);
       const TickLabel = React.cloneElement(tickLabelComponent, tickLabelProps);
       return React.cloneElement(

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -165,7 +165,9 @@ const getChildComponents = (props, defaultAxes) => {
   };
 
   if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
-    return childComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
+    return props.prependDefaultAxes
+      ? [defaultAxes.independent, defaultAxes.dependent].concat(childComponents)
+      : childComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
   }
   return childComponents;
 };

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -37,6 +37,7 @@ export default class VictoryChart extends React.Component {
     }),
     endAngle: PropTypes.number,
     innerRadius: CustomPropTypes.nonNegative,
+    prependDefaultAxes: PropTypes.bool,
     startAngle: PropTypes.number
   };
 

--- a/packages/victory-core/src/victory-primitives/circle.js
+++ b/packages/victory-core/src/victory-primitives/circle.js
@@ -1,6 +1,5 @@
 import React from "react";
-import isEqual from "react-fast-compare";
 
 const Circle = (props) => <circle vectorEffect="non-scaling-stroke" {...props} />;
 
-export default React.memo(Circle, isEqual);
+export default Circle;

--- a/packages/victory-core/src/victory-primitives/line.js
+++ b/packages/victory-core/src/victory-primitives/line.js
@@ -1,6 +1,5 @@
 import React from "react";
-import isEqual from "react-fast-compare";
 
 const Line = (props) => <line vectorEffect="non-scaling-stroke" {...props} />;
 
-export default React.memo(Line, isEqual);
+export default Line;

--- a/packages/victory-core/src/victory-primitives/path.js
+++ b/packages/victory-core/src/victory-primitives/path.js
@@ -1,6 +1,5 @@
 import React from "react";
-import isEqual from "react-fast-compare";
 
-const Path = (props) => <path {...props} />;
+const Path = (props) => <path vectorEffect="non-scaling-stroke" {...props} />;
 
-export default React.memo(Path, isEqual);
+export default Path;

--- a/packages/victory-core/src/victory-primitives/rect.js
+++ b/packages/victory-core/src/victory-primitives/rect.js
@@ -1,6 +1,5 @@
 import React from "react";
-import isEqual from "react-fast-compare";
 
 const Rect = (props) => <rect vectorEffect="non-scaling-stroke" {...props} />;
 
-export default React.memo(Rect, isEqual);
+export default Rect;

--- a/packages/victory-core/src/victory-primitives/text.js
+++ b/packages/victory-core/src/victory-primitives/text.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import isEqual from "react-fast-compare";
 
 const Text = (props) => {
   const { children, title, desc, ...rest } = props;
@@ -19,4 +18,4 @@ Text.propTypes = {
   title: PropTypes.string
 };
 
-export default React.memo(Text, isEqual);
+export default Text;

--- a/packages/victory-core/src/victory-primitives/tspan.js
+++ b/packages/victory-core/src/victory-primitives/tspan.js
@@ -1,6 +1,5 @@
 import React from "react";
-import isEqual from "react-fast-compare";
 
 const TSpan = (props) => <tspan {...props} />;
 
-export default React.memo(TSpan, isEqual);
+export default TSpan;

--- a/packages/victory-polar-axis/src/victory-polar-axis.js
+++ b/packages/victory-polar-axis/src/victory-polar-axis.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { assign } from "lodash";
+import { assign, isEmpty } from "lodash";
 import {
   PropTypes as CustomPropTypes,
   Helpers,
@@ -160,6 +160,13 @@ class VictoryPolarAxis extends React.Component {
 
   renderAxis(props) {
     const { tickComponent, tickLabelComponent, name } = props;
+    const shouldRender = (componentProps) => {
+      const { style = {}, events = {} } = componentProps;
+      const visible = style.stroke !== "transparent"
+        && style.stroke !== "none"
+        && style.strokeWidth !== 0;
+      return visible || !isEmpty(events);
+    };
     const axisType = props.dependentAxis ? "radial" : "angular";
     const gridComponent = axisType === "radial" ? props.circularGridComponent : props.gridComponent;
     const tickComponents = this.dataKeys.map((key, index) => {
@@ -167,16 +174,18 @@ class VictoryPolarAxis extends React.Component {
         { key: `${name}-tick-${key}` },
         this.getComponentProps(tickComponent, "ticks", index)
       );
-      return React.cloneElement(tickComponent, tickProps);
-    });
+      const TickComponent = React.cloneElement(tickComponent, tickProps);
+      return shouldRender(TickComponent.props) ? TickComponent : undefined;
+    }).filter(Boolean);
 
     const gridComponents = this.dataKeys.map((key, index) => {
       const gridProps = assign(
         { key: `${name}-grid-${key}` },
         this.getComponentProps(gridComponent, "grid", index)
       );
-      return React.cloneElement(gridComponent, gridProps);
-    });
+      const GridComponent = React.cloneElement(gridComponent, gridProps);
+      return shouldRender(GridComponent.props) ? GridComponent : undefined;
+    }).filter(Boolean);
 
     const tickLabelComponents = this.dataKeys.map((key, index) => {
       const tickLabelProps = assign(


### PR DESCRIPTION
- filter invisible / non-evented grid lines and ticks
- adds option to prepend default axes, which VictoryChart will use in native to prevent event blocking
- more consistent primitives 