### PR TITLE
Accept custom interpolation functions

### DIFF
--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -38,7 +38,8 @@ const toNewName = (interpolation) => {
 const getLineFunction = (props) => {
   const { polar, scale, horizontal } = props;
   const interpolationFunction = typeof props.interpolation === "function" && props.interpolation;
-  const interpolationName = typeof props.interpolation === "string" && toNewName(props.interpolation);
+  const interpolationName =
+    typeof props.interpolation === "string" && toNewName(props.interpolation);
   return polar
     ? d3Shape
         .lineRadial()
@@ -78,7 +79,8 @@ const getCartesianArea = (props, interpolation) => {
 const getAreaFunction = (props) => {
   const { polar, scale } = props;
   const interpolationFunction = typeof props.interpolation === "function" && props.interpolation;
-  const interpolationName = typeof props.interpolation === "string" && toNewName(props.interpolation);
+  const interpolationName =
+    typeof props.interpolation === "string" && toNewName(props.interpolation);
   const interpolation = interpolationFunction || interpolationName;
   return polar
     ? d3Shape
@@ -147,10 +149,7 @@ const Area = (props) => {
 Area.propTypes = {
   ...CommonProps.primitiveProps,
   groupComponent: PropTypes.element,
-  interpolation: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func
-  ]),
+  interpolation: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   pathComponent: PropTypes.element
 };
 

--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -37,36 +37,39 @@ const toNewName = (interpolation) => {
 
 const getLineFunction = (props) => {
   const { polar, scale, horizontal } = props;
-  const interpolation = toNewName(props.interpolation);
+  const interpolationFunction = typeof props.interpolation === "function" && props.interpolation;
+  const interpolationName = typeof props.interpolation === "string" && toNewName(props.interpolation);
   return polar
     ? d3Shape
         .lineRadial()
         .defined(defined)
-        .curve(d3Shape[`${interpolation}Closed`])
+        .curve(interpolationFunction || d3Shape[`${interpolationName}Closed`])
         .angle(getAngleAccessor(scale))
         .radius(getYAccessor(scale))
     : d3Shape
         .line()
         .defined(defined)
-        .curve(d3Shape[interpolation])
+        .curve(interpolationFunction || d3Shape[interpolationName])
         .x(horizontal ? getYAccessor(scale) : getXAccessor(scale))
         .y(horizontal ? getXAccessor(scale) : getYAccessor(scale));
 };
 
 const getCartesianArea = (props, interpolation) => {
   const { horizontal, scale } = props;
+  const interpolationFunction = typeof interpolation === "function" && interpolation;
+  const interpolationName = typeof interpolation === "string" && interpolation;
   return horizontal
     ? d3Shape
         .area()
         .defined(defined)
-        .curve(d3Shape[interpolation])
+        .curve(interpolationFunction || d3Shape[interpolationName])
         .x0(getY0Accessor(scale))
         .x1(getYAccessor(scale))
         .y(getXAccessor(scale))
     : d3Shape
         .area()
         .defined(defined)
-        .curve(d3Shape[interpolation])
+        .curve(interpolationFunction || d3Shape[interpolationName])
         .x(getXAccessor(scale))
         .y1(getYAccessor(scale))
         .y0(getY0Accessor(scale));
@@ -74,12 +77,14 @@ const getCartesianArea = (props, interpolation) => {
 
 const getAreaFunction = (props) => {
   const { polar, scale } = props;
-  const interpolation = toNewName(props.interpolation);
+  const interpolationFunction = typeof props.interpolation === "function" && props.interpolation;
+  const interpolationName = typeof props.interpolation === "string" && toNewName(props.interpolation);
+  const interpolation = interpolationFunction || interpolationName;
   return polar
     ? d3Shape
         .radialArea()
         .defined(defined)
-        .curve(d3Shape[`${interpolation}Closed`])
+        .curve(interpolationFunction || d3Shape[`${interpolationName}Closed`])
         .angle(getAngleAccessor(scale))
         .outerRadius(getYAccessor(scale))
         .innerRadius(getY0Accessor(scale))
@@ -142,7 +147,10 @@ const Area = (props) => {
 Area.propTypes = {
   ...CommonProps.primitiveProps,
   groupComponent: PropTypes.element,
-  interpolation: PropTypes.string,
+  interpolation: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
   pathComponent: PropTypes.element
 };
 

--- a/packages/victory-area/src/victory-area.js
+++ b/packages/victory-area/src/victory-area.js
@@ -37,17 +37,20 @@ class VictoryArea extends React.Component {
   static propTypes = {
     ...CommonProps.baseProps,
     ...CommonProps.dataProps,
-    interpolation: PropTypes.oneOf([
-      "basis",
-      "cardinal",
-      "catmullRom",
-      "linear",
-      "monotoneX",
-      "monotoneY",
-      "natural",
-      "step",
-      "stepAfter",
-      "stepBefore"
+    interpolation: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        "basis",
+        "cardinal",
+        "catmullRom",
+        "linear",
+        "monotoneX",
+        "monotoneY",
+        "natural",
+        "step",
+        "stepAfter",
+        "stepBefore"
+      ]),
+      PropTypes.func
     ]),
     label: CustomPropTypes.deprecated(
       PropTypes.string,

--- a/packages/victory-line/src/curve.js
+++ b/packages/victory-line/src/curve.js
@@ -36,11 +36,9 @@ const getLineFunction = (props) => {
   const defaultOpenCurve = polar ? false : true;
   const openCurve = props.openCurve === undefined ? defaultOpenCurve : props.openCurve;
   const interpolationFunction = typeof props.interpolation === "function" && props.interpolation;
-  const interpolationName = typeof props.interpolation === "string" && (
-    !openCurve
-      ? `${toNewName(props.interpolation)}Closed`
-      : toNewName(props.interpolation)
-  );
+  const interpolationName =
+    typeof props.interpolation === "string" &&
+    (!openCurve ? `${toNewName(props.interpolation)}Closed` : toNewName(props.interpolation));
   return polar
     ? d3Shape
         .lineRadial()
@@ -74,10 +72,7 @@ const Curve = (props) => {
 
 Curve.propTypes = {
   ...CommonProps.primitiveProps,
-  interpolation: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func
-  ]),
+  interpolation: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   openCurve: PropTypes.bool,
   origin: PropTypes.object,
   pathComponent: PropTypes.element,

--- a/packages/victory-line/src/curve.js
+++ b/packages/victory-line/src/curve.js
@@ -35,20 +35,23 @@ const getLineFunction = (props) => {
   const { polar, scale, horizontal } = props;
   const defaultOpenCurve = polar ? false : true;
   const openCurve = props.openCurve === undefined ? defaultOpenCurve : props.openCurve;
-  const interpolation = !openCurve
-    ? `${toNewName(props.interpolation)}Closed`
-    : toNewName(props.interpolation);
+  const interpolationFunction = typeof props.interpolation === "function" && props.interpolation;
+  const interpolationName = typeof props.interpolation === "string" && (
+    !openCurve
+      ? `${toNewName(props.interpolation)}Closed`
+      : toNewName(props.interpolation)
+  );
   return polar
     ? d3Shape
         .lineRadial()
         .defined(defined)
-        .curve(d3Shape[interpolation])
+        .curve(interpolationFunction || d3Shape[interpolationName])
         .angle(getAngleAccessor(scale))
         .radius(getYAccessor(scale))
     : d3Shape
         .line()
         .defined(defined)
-        .curve(d3Shape[interpolation])
+        .curve(interpolationFunction || d3Shape[interpolationName])
         .x(horizontal ? getYAccessor(scale) : getXAccessor(scale))
         .y(horizontal ? getXAccessor(scale) : getYAccessor(scale));
 };
@@ -71,7 +74,10 @@ const Curve = (props) => {
 
 Curve.propTypes = {
   ...CommonProps.primitiveProps,
-  interpolation: PropTypes.string,
+  interpolation: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
   openCurve: PropTypes.bool,
   origin: PropTypes.object,
   pathComponent: PropTypes.element,

--- a/packages/victory-line/src/victory-line.js
+++ b/packages/victory-line/src/victory-line.js
@@ -43,18 +43,21 @@ class VictoryLine extends React.Component {
   static propTypes = {
     ...CommonProps.baseProps,
     ...CommonProps.dataProps,
-    interpolation: PropTypes.oneOf([
-      "basis",
-      "bundle",
-      "cardinal",
-      "catmullRom",
-      "linear",
-      "monotoneX",
-      "monotoneY",
-      "natural",
-      "step",
-      "stepAfter",
-      "stepBefore"
+    interpolation: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        "basis",
+        "bundle",
+        "cardinal",
+        "catmullRom",
+        "linear",
+        "monotoneX",
+        "monotoneY",
+        "natural",
+        "step",
+        "stepAfter",
+        "stepBefore"
+      ]),
+      PropTypes.func
     ]),
     label: CustomPropTypes.deprecated(
       PropTypes.string,

--- a/test/client/spec/svg-test-helper.js
+++ b/test/client/spec/svg-test-helper.js
@@ -43,8 +43,10 @@ const calculateD3Path = (props, pathType, index) => {
   // eslint-disable-line max-statements
   const { width, height, padding, scale, interpolation, data, domain } = props;
   const scaleType = scale ? `scale${scale[0].toUpperCase() + scale.slice(1)}` : "scaleLinear";
-  const curveType =
-    interpolation && `curve${interpolation[0].toUpperCase() + interpolation.slice(1)}`;
+  const curveType = typeof interpolation === "string"
+    ? `curve${interpolation[0].toUpperCase() + interpolation.slice(1)}`
+    : undefined;
+  const curveFunction = typeof interpolation === "function" ? interpolation : d3Shape[curveType];
 
   const dataDomain = data.reduce(
     (prev, datum) => {
@@ -81,7 +83,7 @@ const calculateD3Path = (props, pathType, index) => {
     case "line": {
       return d3Shape
         .line()
-        .curve(d3Shape[curveType])
+        .curve(curveFunction)
         .x((d) => scaleX(d.x))
         .y((d) => scaleY(d.y))(data);
     }
@@ -91,7 +93,7 @@ const calculateD3Path = (props, pathType, index) => {
       });
       return d3Shape
         .area()
-        .curve(d3Shape[curveType])
+        .curve(curveFunction)
         .x((d) => scaleX(d.x))
         .y1((d) => scaleY(d.y1))
         .y0((d) => scaleY(d.y0))(modifiedData);

--- a/test/client/spec/svg-test-helper.js
+++ b/test/client/spec/svg-test-helper.js
@@ -43,9 +43,10 @@ const calculateD3Path = (props, pathType, index) => {
   // eslint-disable-line max-statements
   const { width, height, padding, scale, interpolation, data, domain } = props;
   const scaleType = scale ? `scale${scale[0].toUpperCase() + scale.slice(1)}` : "scaleLinear";
-  const curveType = typeof interpolation === "string"
-    ? `curve${interpolation[0].toUpperCase() + interpolation.slice(1)}`
-    : undefined;
+  const curveType =
+    typeof interpolation === "string"
+      ? `curve${interpolation[0].toUpperCase() + interpolation.slice(1)}`
+      : undefined;
   const curveFunction = typeof interpolation === "function" ? interpolation : d3Shape[curveType];
 
   const dataDomain = data.reduce(

--- a/test/client/spec/victory-area/victory-area.spec.js
+++ b/test/client/spec/victory-area/victory-area.spec.js
@@ -55,12 +55,20 @@ describe("components/victory-area", () => {
       const stringWrapper = mount(<VictoryArea {...props} interpolation="catmullRom" />);
       const stringArea = stringWrapper.find(Area);
       const stringPath = stringArea.find("path").prop("d");
-      SvgTestHelper.expectCorrectD3Path(stringArea, { ...props, interpolation: "catmullRom" }, "area");
+      SvgTestHelper.expectCorrectD3Path(
+        stringArea,
+        { ...props, interpolation: "catmullRom" },
+        "area"
+      );
 
       const functionWrapper = mount(<VictoryArea {...props} interpolation={curveCatmullRom} />);
       const functionArea = functionWrapper.find(Area);
       const functionPath = functionArea.find("path").prop("d");
-      SvgTestHelper.expectCorrectD3Path(functionArea, { ...props, interpolation: curveCatmullRom }, "area");
+      SvgTestHelper.expectCorrectD3Path(
+        functionArea,
+        { ...props, interpolation: curveCatmullRom },
+        "area"
+      );
 
       expect(functionPath).to.equal(stringPath);
     });

--- a/test/client/spec/victory-area/victory-area.spec.js
+++ b/test/client/spec/victory-area/victory-area.spec.js
@@ -7,6 +7,7 @@
 import React from "react";
 import { range, omit } from "lodash";
 import { shallow, mount } from "enzyme";
+import { curveCatmullRom } from "d3-shape";
 import SvgTestHelper from "../svg-test-helper";
 import { VictoryArea, Area } from "packages/victory-area/src/index";
 import { VictoryLabel } from "packages/victory-core";
@@ -41,6 +42,27 @@ describe("components/victory-area", () => {
       const wrapper = mount(<VictoryArea {...props} />);
       const area = wrapper.find(Area);
       SvgTestHelper.expectCorrectD3Path(area, props, "area");
+    });
+
+    it("renders the correct d3 path with custom interpolation", () => {
+      const props = {
+        width: 400,
+        height: 300,
+        padding: 50,
+        scale: "linear",
+        data: [{ x: 0, y: 0, y0: 0 }, { x: 2, y: 3, y0: 0 }, { x: 4, y: 1, y0: 0 }]
+      };
+      const stringWrapper = mount(<VictoryArea {...props} interpolation="catmullRom" />);
+      const stringArea = stringWrapper.find(Area);
+      const stringPath = stringArea.find("path").prop("d");
+      SvgTestHelper.expectCorrectD3Path(stringArea, { ...props, interpolation: "catmullRom" }, "area");
+
+      const functionWrapper = mount(<VictoryArea {...props} interpolation={curveCatmullRom} />);
+      const functionArea = functionWrapper.find(Area);
+      const functionPath = functionArea.find("path").prop("d");
+      SvgTestHelper.expectCorrectD3Path(functionArea, { ...props, interpolation: curveCatmullRom }, "area");
+
+      expect(functionPath).to.equal(stringPath);
     });
 
     it("sorts data according to sortKey prop", () => {

--- a/test/client/spec/victory-line/victory-line.spec.js
+++ b/test/client/spec/victory-line/victory-line.spec.js
@@ -91,12 +91,20 @@ describe("components/victory-line", () => {
       const stringWrapper = mount(<VictoryLine {...props} interpolation="catmullRom" />);
       const stringLine = stringWrapper.find(Curve);
       const stringPath = stringLine.find("path").prop("d");
-      SvgTestHelper.expectCorrectD3Path(stringLine, { ...props, interpolation: "catmullRom" }, "line");
+      SvgTestHelper.expectCorrectD3Path(
+        stringLine,
+        { ...props, interpolation: "catmullRom" },
+        "line"
+      );
 
       const functionWrapper = mount(<VictoryLine {...props} interpolation={curveCatmullRom} />);
       const functionLine = functionWrapper.find(Curve);
       const functionPath = functionLine.find("path").prop("d");
-      SvgTestHelper.expectCorrectD3Path(functionLine, { ...props, interpolation: curveCatmullRom }, "line");
+      SvgTestHelper.expectCorrectD3Path(
+        functionLine,
+        { ...props, interpolation: curveCatmullRom },
+        "line"
+      );
 
       expect(functionPath).to.equal(stringPath);
     });

--- a/test/client/spec/victory-line/victory-line.spec.js
+++ b/test/client/spec/victory-line/victory-line.spec.js
@@ -8,6 +8,7 @@
 import React from "react";
 import { omit } from "lodash";
 import { shallow, mount } from "enzyme";
+import { curveCatmullRom } from "d3-shape";
 import SvgTestHelper from "../svg-test-helper";
 import { VictoryLine, Curve } from "packages/victory-line/src/index";
 import { VictoryLabel } from "packages/victory-core";
@@ -77,6 +78,27 @@ describe("components/victory-line", () => {
       const wrapper = mount(<VictoryLine {...props} />);
       const line = wrapper.find(Curve);
       SvgTestHelper.expectCorrectD3Path(line, props, "line");
+    });
+
+    it("renders the correct d3Shape path with custom interpolation", () => {
+      const props = {
+        scale: "linear",
+        padding: 50,
+        width: 400,
+        height: 300,
+        data: [{ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }]
+      };
+      const stringWrapper = mount(<VictoryLine {...props} interpolation="catmullRom" />);
+      const stringLine = stringWrapper.find(Curve);
+      const stringPath = stringLine.find("path").prop("d");
+      SvgTestHelper.expectCorrectD3Path(stringLine, { ...props, interpolation: "catmullRom" }, "line");
+
+      const functionWrapper = mount(<VictoryLine {...props} interpolation={curveCatmullRom} />);
+      const functionLine = functionWrapper.find(Curve);
+      const functionPath = functionLine.find("path").prop("d");
+      SvgTestHelper.expectCorrectD3Path(functionLine, { ...props, interpolation: curveCatmullRom }, "line");
+
+      expect(functionPath).to.equal(stringPath);
     });
   });
 


### PR DESCRIPTION
This PR extends `interpolation` property in `VictoryLine` and `VictoryArea` by allowing to pass functions instead of interpolation names. This gives more control over curves from d3-shape (such as specifying [tension for cardinal curves](https://github.com/d3/d3-shape#curveCardinal_tension)) and also allows to use custom curves.

I think it fixes #561, though the proposed solution was different.