### PR TITLE
Improvement/a11y

### DIFF
--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -123,7 +123,9 @@ const Area = (props) => {
       {
         key: `${id}-area`,
         style: assign({}, style, { stroke: areaStroke }),
-        d: areaFunction(data)
+        d: areaFunction(data),
+        desc: Helpers.evaluateProp(props.desc, props),
+        tabIndex: Helpers.evaluateProp(props.tabIndex, props)
       },
       sharedProps
     )
@@ -157,7 +159,8 @@ Area.defaultProps = {
   groupComponent: <g />,
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default Area;

--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -159,8 +159,7 @@ Area.defaultProps = {
   groupComponent: <g />,
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default Area;

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -99,7 +99,9 @@ const Bar = (props) => {
     className: props.className,
     role: props.role,
     shapeRendering: props.shapeRendering,
-    clipPath: props.clipPath
+    clipPath: props.clipPath,
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props)
   });
 };
 
@@ -134,7 +136,8 @@ Bar.defaultProps = {
   defaultBarWidth: 8,
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default Bar;

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -136,8 +136,7 @@ Bar.defaultProps = {
   defaultBarWidth: 8,
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default Bar;

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -117,8 +117,7 @@ Candle.defaultProps = {
   lineComponent: <Line />,
   rectComponent: <Rect />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default Candle;

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -74,7 +74,16 @@ const Candle = (props) => {
     style
   } = props;
   const wickStyle = defaults({ strokeWidth: wickStrokeWidth }, style);
-  const sharedProps = { role, shapeRendering, className, transform, clipPath, ...events };
+  const sharedProps = {
+    ...events,
+    role,
+    shapeRendering,
+    className,
+    transform,
+    clipPath,
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props)
+  };
   const candleProps = assign(getCandleProps(props, style), sharedProps);
   const highWickProps = assign(getHighWickProps(props, wickStyle), sharedProps);
   const lowWickProps = assign(getLowWickProps(props, wickStyle), sharedProps);
@@ -108,7 +117,8 @@ Candle.defaultProps = {
   lineComponent: <Line />,
   rectComponent: <Rect />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default Candle;

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -24,6 +24,7 @@ export default class VictoryContainer extends React.Component {
     portalZIndex: CustomPropTypes.integer,
     responsive: PropTypes.bool,
     style: PropTypes.object,
+    tabIndex: PropTypes.number,
     theme: PropTypes.object,
     title: PropTypes.string,
     width: CustomPropTypes.nonNegative
@@ -163,7 +164,7 @@ export default class VictoryContainer extends React.Component {
   }
 
   render() {
-    const { width, height, responsive, events, title, desc } = this.props;
+    const { width, height, responsive, events, title, desc, tabIndex } = this.props;
     const style = responsive
       ? this.props.style
       : Helpers.omit(this.props.style, ["height", "width"]);
@@ -171,6 +172,7 @@ export default class VictoryContainer extends React.Component {
       {
         width,
         height,
+        tabIndex,
         role: "img",
         "aria-labelledby": title ? this.getIdForElement("title") : undefined,
         "aria-describedby": desc ? this.getIdForElement("desc") : undefined,

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -162,17 +162,24 @@ export default class VictoryContainer extends React.Component {
     );
   }
 
+  getAriaLabel(props) {
+    const title = props.title ? this.getIdForElement("title") : "";
+    const desc = props.desc ? this.getIdForElement("desc") : "";
+    return !title && !desc ? undefined : `${title} ${desc}`.trim();
+  }
+
   render() {
     const { width, height, responsive, events } = this.props;
     const style = responsive
       ? this.props.style
       : Helpers.omit(this.props.style, ["height", "width"]);
+    const ariaLabel = this.getAriaLabel(this.props);
     const svgProps = assign(
       {
         width,
         height,
         role: "img",
-        "aria-labelledby": `${this.getIdForElement("title")} ${this.getIdForElement("desc")}`,
+        "aria-labelledby": ariaLabel,
         viewBox: responsive ? `0 0 ${width} ${height}` : undefined
       },
       events

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -162,24 +162,18 @@ export default class VictoryContainer extends React.Component {
     );
   }
 
-  getAriaLabel(props) {
-    const title = props.title ? this.getIdForElement("title") : "";
-    const desc = props.desc ? this.getIdForElement("desc") : "";
-    return !title && !desc ? undefined : `${title} ${desc}`.trim();
-  }
-
   render() {
-    const { width, height, responsive, events } = this.props;
+    const { width, height, responsive, events, title, desc } = this.props;
     const style = responsive
       ? this.props.style
       : Helpers.omit(this.props.style, ["height", "width"]);
-    const ariaLabel = this.getAriaLabel(this.props);
     const svgProps = assign(
       {
         width,
         height,
         role: "img",
-        "aria-labelledby": ariaLabel,
+        "aria-labelledby": title ? this.getIdForElement("title") : undefined,
+        "aria-describedby": desc ? this.getIdForElement("desc") : undefined,
         viewBox: responsive ? `0 0 ${width} ${height}` : undefined
       },
       events

--- a/packages/victory-core/src/victory-label/victory-label.js
+++ b/packages/victory-core/src/victory-label/victory-label.js
@@ -111,7 +111,7 @@ const getTransform = (props) => {
 };
 
 const renderElements = (props) => {
-  const { inline, className, title, desc, events, direction, text, style } = props;
+  const { inline, className, title, events, direction, text, style } = props;
   const lineHeight = getHeight(props, "lineHeight");
   const textAnchor = props.textAnchor ? Helpers.evaluateProp(props.textAnchor, props) : "start";
   const dx = props.dx ? Helpers.evaluateProp(props.dx, props) : 0;
@@ -152,7 +152,8 @@ const renderElements = (props) => {
       transform,
       className,
       title,
-      desc,
+      desc: Helpers.evaluateProp(props.desc, props),
+      tabIndex: Helpers.evaluateProp(props.tabIndex, props),
       id: props.id
     },
     textChildren
@@ -189,7 +190,7 @@ VictoryLabel.propTypes = {
   className: PropTypes.string,
   data: PropTypes.array,
   datum: PropTypes.any,
-  desc: PropTypes.string,
+  desc: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   direction: PropTypes.oneOf(["rtl", "ltr", "inherit"]),
   dx: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.func]),
   dy: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.func]),
@@ -215,6 +216,7 @@ VictoryLabel.propTypes = {
     y: CustomPropTypes.scale
   }),
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func, PropTypes.array]),
   textAnchor: PropTypes.oneOfType([
     PropTypes.oneOf(["start", "middle", "end", "inherit"]),

--- a/packages/victory-core/src/victory-primitives/arc.js
+++ b/packages/victory-core/src/victory-primitives/arc.js
@@ -30,6 +30,8 @@ const Arc = (props) =>
     ...props.events,
     d: getArcPath(props),
     style: Helpers.evaluateStyle(assign({ stroke: "black", fill: "none" }, props.style), props),
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
     className: props.className,
     role: props.role,
     shapeRendering: props.shapeRendering,
@@ -52,7 +54,8 @@ Arc.propTypes = {
 Arc.defaultProps = {
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default Arc;

--- a/packages/victory-core/src/victory-primitives/arc.js
+++ b/packages/victory-core/src/victory-primitives/arc.js
@@ -54,8 +54,7 @@ Arc.propTypes = {
 Arc.defaultProps = {
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default Arc;

--- a/packages/victory-core/src/victory-primitives/border.js
+++ b/packages/victory-core/src/victory-primitives/border.js
@@ -9,6 +9,8 @@ const Border = (props) =>
   React.cloneElement(props.rectComponent, {
     ...props.events,
     style: Helpers.evaluateStyle(assign({ fill: "none" }, props.style), props),
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
     transform: props.transform,
     className: props.className,
     role: props.role,
@@ -32,7 +34,8 @@ Border.propTypes = {
 Border.defaultProps = {
   rectComponent: <Rect />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default Border;

--- a/packages/victory-core/src/victory-primitives/border.js
+++ b/packages/victory-core/src/victory-primitives/border.js
@@ -34,8 +34,7 @@ Border.propTypes = {
 Border.defaultProps = {
   rectComponent: <Rect />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default Border;

--- a/packages/victory-core/src/victory-primitives/circle.js
+++ b/packages/victory-core/src/victory-primitives/circle.js
@@ -4,8 +4,8 @@ const Circle = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
   return desc
-    ? <circle vectorEffect="non-scaling-stroke" {...rest} />
-    : <circle vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></circle>;
+    ? <circle vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></circle>
+    : <circle vectorEffect="non-scaling-stroke" {...rest} />;
 }
 
 export default Circle;

--- a/packages/victory-core/src/victory-primitives/circle.js
+++ b/packages/victory-core/src/victory-primitives/circle.js
@@ -3,9 +3,13 @@ import React from "react";
 const Circle = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
-  return desc
-    ? <circle vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></circle>
-    : <circle vectorEffect="non-scaling-stroke" {...rest} />;
-}
+  return desc ? (
+    <circle vectorEffect="non-scaling-stroke" {...rest}>
+      <desc>{desc}</desc>
+    </circle>
+  ) : (
+    <circle vectorEffect="non-scaling-stroke" {...rest} />
+  );
+};
 
 export default Circle;

--- a/packages/victory-core/src/victory-primitives/circle.js
+++ b/packages/victory-core/src/victory-primitives/circle.js
@@ -1,5 +1,11 @@
 import React from "react";
 
-const Circle = (props) => <circle vectorEffect="non-scaling-stroke" {...props} />;
+const Circle = (props) => {
+  // eslint-disable-next-line react/prop-types
+  const { desc, ...rest } = props;
+  return desc
+    ? <circle vectorEffect="non-scaling-stroke" {...rest} />
+    : <circle vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></circle>;
+}
 
 export default Circle;

--- a/packages/victory-core/src/victory-primitives/line-segment.js
+++ b/packages/victory-core/src/victory-primitives/line-segment.js
@@ -35,8 +35,7 @@ LineSegment.propTypes = {
 LineSegment.defaultProps = {
   lineComponent: <Line />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default LineSegment;

--- a/packages/victory-core/src/victory-primitives/line-segment.js
+++ b/packages/victory-core/src/victory-primitives/line-segment.js
@@ -9,6 +9,8 @@ const LineSegment = (props) =>
   React.cloneElement(props.lineComponent, {
     ...props.events,
     style: Helpers.evaluateStyle(assign({ stroke: "black" }, props.style), props),
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
     className: props.className,
     role: props.role,
     shapeRendering: props.shapeRendering,
@@ -33,7 +35,8 @@ LineSegment.propTypes = {
 LineSegment.defaultProps = {
   lineComponent: <Line />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default LineSegment;

--- a/packages/victory-core/src/victory-primitives/line.js
+++ b/packages/victory-core/src/victory-primitives/line.js
@@ -1,12 +1,15 @@
 import React from "react";
 
-
 const Line = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
-  return desc
-    ? <line vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></line>
-    : <line vectorEffect="non-scaling-stroke" {...rest} />;
-}
+  return desc ? (
+    <line vectorEffect="non-scaling-stroke" {...rest}>
+      <desc>{desc}</desc>
+    </line>
+  ) : (
+    <line vectorEffect="non-scaling-stroke" {...rest} />
+  );
+};
 
 export default Line;

--- a/packages/victory-core/src/victory-primitives/line.js
+++ b/packages/victory-core/src/victory-primitives/line.js
@@ -5,8 +5,8 @@ const Line = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
   return desc
-    ? <line vectorEffect="non-scaling-stroke" {...rest} />
-    : <line vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></line>;
+    ? <line vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></line>
+    : <line vectorEffect="non-scaling-stroke" {...rest} />;
 }
 
 export default Line;

--- a/packages/victory-core/src/victory-primitives/line.js
+++ b/packages/victory-core/src/victory-primitives/line.js
@@ -1,5 +1,12 @@
 import React from "react";
 
-const Line = (props) => <line vectorEffect="non-scaling-stroke" {...props} />;
+
+const Line = (props) => {
+  // eslint-disable-next-line react/prop-types
+  const { desc, ...rest } = props;
+  return desc
+    ? <line vectorEffect="non-scaling-stroke" {...rest} />
+    : <line vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></line>;
+}
 
 export default Line;

--- a/packages/victory-core/src/victory-primitives/path.js
+++ b/packages/victory-core/src/victory-primitives/path.js
@@ -4,11 +4,11 @@ const Path = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
   return desc ? (
-    <path vectorEffect="non-scaling-stroke" {...rest}>
+    <path {...rest}>
       <desc>{desc}</desc>
     </path>
   ) : (
-    <path vectorEffect="non-scaling-stroke" {...rest} />
+    <path {...rest} />
   );
 };
 

--- a/packages/victory-core/src/victory-primitives/path.js
+++ b/packages/victory-core/src/victory-primitives/path.js
@@ -1,5 +1,11 @@
 import React from "react";
 
-const Path = (props) => <path {...props} />;
+const Path = (props) => {
+  // eslint-disable-next-line react/prop-types
+  const { desc, ...rest } = props;
+  return desc
+    ? <path vectorEffect="non-scaling-stroke" {...rest} />
+    : <path vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></path>;
+}
 
 export default Path;

--- a/packages/victory-core/src/victory-primitives/path.js
+++ b/packages/victory-core/src/victory-primitives/path.js
@@ -3,9 +3,13 @@ import React from "react";
 const Path = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
-  return desc
-    ? <path vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></path>
-    : <path vectorEffect="non-scaling-stroke" {...rest} />;
-}
+  return desc ? (
+    <path vectorEffect="non-scaling-stroke" {...rest}>
+      <desc>{desc}</desc>
+    </path>
+  ) : (
+    <path vectorEffect="non-scaling-stroke" {...rest} />
+  );
+};
 
 export default Path;

--- a/packages/victory-core/src/victory-primitives/path.js
+++ b/packages/victory-core/src/victory-primitives/path.js
@@ -4,8 +4,8 @@ const Path = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
   return desc
-    ? <path vectorEffect="non-scaling-stroke" {...rest} />
-    : <path vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></path>;
+    ? <path vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></path>
+    : <path vectorEffect="non-scaling-stroke" {...rest} />;
 }
 
 export default Path;

--- a/packages/victory-core/src/victory-primitives/point.js
+++ b/packages/victory-core/src/victory-primitives/point.js
@@ -32,6 +32,8 @@ const Point = (props) =>
     ...props.events,
     d: getPath(props),
     style: Helpers.evaluateStyle(props.style, props),
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
     role: props.role,
     shapeRendering: props.shapeRendering,
     className: props.className,
@@ -65,7 +67,8 @@ Point.propTypes = {
 Point.defaultProps = {
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default Point;

--- a/packages/victory-core/src/victory-primitives/point.js
+++ b/packages/victory-core/src/victory-primitives/point.js
@@ -67,8 +67,7 @@ Point.propTypes = {
 Point.defaultProps = {
   pathComponent: <Path />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default Point;

--- a/packages/victory-core/src/victory-primitives/rect.js
+++ b/packages/victory-core/src/victory-primitives/rect.js
@@ -4,7 +4,7 @@ const Rect = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
   return desc
-    ? <rect vectorEffect="non-scaling-stroke" {...rest} />
-    : <rect vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></rect>;
+    ? <rect vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></rect>
+    : <rect vectorEffect="non-scaling-stroke" {...rest} />;
 }
 export default Rect;

--- a/packages/victory-core/src/victory-primitives/rect.js
+++ b/packages/victory-core/src/victory-primitives/rect.js
@@ -3,8 +3,12 @@ import React from "react";
 const Rect = (props) => {
   // eslint-disable-next-line react/prop-types
   const { desc, ...rest } = props;
-  return desc
-    ? <rect vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></rect>
-    : <rect vectorEffect="non-scaling-stroke" {...rest} />;
-}
+  return desc ? (
+    <rect vectorEffect="non-scaling-stroke" {...rest}>
+      <desc>{desc}</desc>
+    </rect>
+  ) : (
+    <rect vectorEffect="non-scaling-stroke" {...rest} />
+  );
+};
 export default Rect;

--- a/packages/victory-core/src/victory-primitives/rect.js
+++ b/packages/victory-core/src/victory-primitives/rect.js
@@ -1,5 +1,10 @@
 import React from "react";
 
-const Rect = (props) => <rect vectorEffect="non-scaling-stroke" {...props} />;
-
+const Rect = (props) => {
+  // eslint-disable-next-line react/prop-types
+  const { desc, ...rest } = props;
+  return desc
+    ? <rect vectorEffect="non-scaling-stroke" {...rest} />
+    : <rect vectorEffect="non-scaling-stroke" {...rest}><desc>{desc}</desc></rect>;
+}
 export default Rect;

--- a/packages/victory-core/src/victory-primitives/whisker.js
+++ b/packages/victory-core/src/victory-primitives/whisker.js
@@ -57,8 +57,7 @@ Whisker.defaultProps = {
   groupComponent: <g />,
   lineComponent: <Line />,
   role: "presentation",
-  shapeRendering: "auto",
-  tabIndex: 0
+  shapeRendering: "auto"
 };
 
 export default Whisker;

--- a/packages/victory-core/src/victory-primitives/whisker.js
+++ b/packages/victory-core/src/victory-primitives/whisker.js
@@ -18,8 +18,17 @@ const Whisker = (props) => {
     role,
     shapeRendering
   } = props;
-  const style = Helpers.evaluateStyle(props.style, props);
-  const baseProps = { ...events, style, className, transform, clipPath, role, shapeRendering };
+  const baseProps = {
+    ...events,
+    style: Helpers.evaluateStyle(props.style, props),
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
+    className,
+    transform,
+    clipPath,
+    role,
+    shapeRendering
+  };
   return React.cloneElement(groupComponent, {}, [
     React.cloneElement(lineComponent, assign({ key: "major-whisker" }, baseProps, majorWhisker)),
     React.cloneElement(lineComponent, assign({ key: "minor-whisker" }, baseProps, minorWhisker))
@@ -48,7 +57,8 @@ Whisker.defaultProps = {
   groupComponent: <g />,
   lineComponent: <Line />,
   role: "presentation",
-  shapeRendering: "auto"
+  shapeRendering: "auto",
+  tabIndex: 0
 };
 
 export default Whisker;

--- a/packages/victory-core/src/victory-util/common-props.js
+++ b/packages/victory-core/src/victory-util/common-props.js
@@ -149,6 +149,7 @@ const primitiveProps = {
   className: PropTypes.string,
   clipPath: PropTypes.string,
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  desc: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   events: PropTypes.object,
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -161,6 +162,7 @@ const primitiveProps = {
   ]),
   shapeRendering: PropTypes.string,
   style: PropTypes.object,
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   transform: PropTypes.string
 };
 


### PR DESCRIPTION
This PR addresses aria improvements suggested in https://github.com/FormidableLabs/victory/issues/1392

- corrects behavior of `VictoryContainer` so that it only adds `aria-labelledby` and `aria-describedby` attributes when there are actually `title` and / or `desc` elements that are rendered (controlled by the `title` and `desc` props on `VictoryContainer` 
- adds a `tabIndex` prop to all primitive components that Victory renders (_i.e._ `VictoryLabel`, `Bar` etc). This prop may be given as a number or a function of other props
- adds a `desc` prop to all primitive components. This prop may be given as a number or a function of other props
