### PR TITLE
fix onBrushDomainChangeEnd provides wrong domain

### DIFF
--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -311,7 +311,6 @@ const Helpers = {
       onBrushDomainChange,
       onBrushDomainChangeEnd,
       onBrushCleared,
-      domain,
       allowResize,
       allowDrag,
       defaultBrushArea
@@ -319,7 +318,7 @@ const Helpers = {
 
     const defaultBrushHasArea = defaultBrushArea !== undefined && defaultBrushArea !== "none";
     const cachedDomain = targetProps.cachedCurrentDomain || targetProps.currentDomain;
-    const currentDomain = this.getDefaultBrushArea(defaultBrushArea, domain, cachedDomain);
+    const currentDomain = this.getDefaultBrushArea(defaultBrushArea, targetProps.currentDomain, cachedDomain);
     const mutatedProps = { isPanning: false, isSelecting: false };
 
     // if the mouse hasn't moved since a mouseDown event, select the default brush area


### PR DESCRIPTION
Fix FormidableLabs/victory#1400

It works in the demo, but not sure if this is a proper implementation.