### PR TITLE
Apply axis orientation from theme in getOrientation

### DIFF
--- a/packages/victory-axis/src/helper-methods.js
+++ b/packages/victory-axis/src/helper-methods.js
@@ -299,6 +299,14 @@ const getLayoutProps = (modifiedProps, calculatedValues) => {
 };
 
 const getOrientation = (props) => {
+  if (props.theme) {
+    if (props.dependentAxis && props.theme.dependentAxis && props.theme.dependentAxis.orientation) {
+      return props.theme.dependentAxis.orientation;
+    }
+    if (props.theme.independentAxis && props.theme.independentAxis.orientation) {
+      return props.theme.independentAxis.orientation;
+    }
+  }
   if (props.orientation) {
     return props.orientation;
   }

--- a/packages/victory-core/src/victory-util/helpers.js
+++ b/packages/victory-core/src/victory-util/helpers.js
@@ -248,7 +248,7 @@ function reduceChildren(
 /**
  * @param {Object} props: the props object
  * @returns {Boolean} returns true if the props object contains `horizontal: true` of if any
- * children or nested children are hoizontal
+ * children or nested children are horizontal
  */
 function isHorizontal(props) {
   if (props.horizontal !== undefined || !props.children) {


### PR DESCRIPTION
I applied a fix that addresses #1413 for applying alternative axis orientations for customized themes.  However, I'm not certain that this solution adequately resembles the intended behavior for setting axis orientations via customized themes.  That said, I would really like to try and resolve this issue properly, so please feel free to point me in the right direction so I can apply a proper fix if need be.  Thank you!

Upon reviewing the docs and comments specified in #1413, it was specified that themes and props should be "merged".  I'm unsure as to the meaning of this since `theme` and its properties are attached to props from the start.  I noticed that `Helpers.modifyProps` in the `VictoryAxis`'s render method does appear to be doing some sort of combining and flattening of props values, but this occurs after the call to `getOrientation` where axis orientations are obtained.  I couldn't see anywhere else where it would be suitable for `props.orientation` to apply an orientation supplied by a theme, assuming that is the intent.

I am brand new to this library/codebase and to making pull requests generally, so I apologize if I am overlooking something obvious or failed to adequately review the information available to me.