### PR TITLE
Fix contributing document code block format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ When running a development server, tests will be served automatically at http://
 
 Tests my also be run in the terminal with:
 
-``console
+```console
 $ yarn nps test
 ```
 


### PR DESCRIPTION
There was a third tilde missing in one of `CONTRIBUTING.md`'s code blocks, resulting in some improper formatting.  I've added it back in to correct that formatting issue.