### PR TITLE
clear up logic around resetting to default domain

### DIFF
--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -312,27 +312,28 @@ const Helpers = {
       onBrushDomainChangeEnd,
       onBrushCleared,
       domain,
+      currentDomain,
       allowResize,
       allowDrag,
       defaultBrushArea
     } = targetProps;
 
     const defaultBrushHasArea = defaultBrushArea !== undefined && defaultBrushArea !== "none";
-    const cachedDomain = targetProps.cachedCurrentDomain || targetProps.currentDomain;
-    const currentDomain = this.getDefaultBrushArea(defaultBrushArea, domain, cachedDomain);
     const mutatedProps = { isPanning: false, isSelecting: false };
 
     // if the mouse hasn't moved since a mouseDown event, select the default brush area
     if ((allowResize || defaultBrushHasArea) && (x1 === x2 || y1 === y2)) {
-      mutatedProps.currentDomain = currentDomain;
+      const cachedDomain = targetProps.cachedCurrentDomain || currentDomain;
+      const defaultDomain = this.getDefaultBrushArea(defaultBrushArea, domain, cachedDomain);
+      mutatedProps.currentDomain = defaultDomain;
       if (isFunction(onBrushDomainChange)) {
-        onBrushDomainChange(currentDomain, defaults({}, mutatedProps, targetProps));
+        onBrushDomainChange(defaultDomain, defaults({}, mutatedProps, targetProps));
       }
       if (isFunction(onBrushDomainChangeEnd)) {
-        onBrushDomainChangeEnd(currentDomain, defaults({}, mutatedProps, targetProps));
+        onBrushDomainChangeEnd(defaultDomain, defaults({}, mutatedProps, targetProps));
       }
       if (isFunction(onBrushCleared)) {
-        onBrushCleared(currentDomain, defaults({}, mutatedProps, targetProps));
+        onBrushCleared(defaultDomain, defaults({}, mutatedProps, targetProps));
       }
     } else if ((allowDrag && isPanning) || (allowResize && isSelecting)) {
       if (isFunction(onBrushDomainChangeEnd)) {


### PR DESCRIPTION
This PR fixes a bug where the incorrect domain was used in `onBrushEnd` callbacks. It also renames a couple variables and cleans up some code to make it clearer that a default domain is being used when the user clicks on the chart area without dragging.

Fixes #1400 
Related to https://github.com/FormidableLabs/victory/pull/1412

