### PR TITLE
Bug/chart overrides axis orientation from theme

### DIFF
--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -42,6 +42,11 @@ class Wrapper extends React.Component {
   }
 }
 
+const dependentAxisTheme = {
+  ...VictoryTheme.material,
+  ...{ dependentAxis: { orientation: "right" } }
+};
+
 class App extends React.Component {
   constructor(props) {
     super(props);
@@ -192,6 +197,10 @@ class App extends React.Component {
         <div style={containerStyle}>
           <VictoryChart style={chartStyle}>
             <VictoryScatter data={[{ x: -3, y: -3 }]} />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle} theme={dependentAxisTheme}>
+            <VictoryScatter />
           </VictoryChart>
 
           <VictoryChart style={chartStyle} domainPadding={{ x: [0, 20] }}>

--- a/packages/victory-axis/src/helper-methods.js
+++ b/packages/victory-axis/src/helper-methods.js
@@ -123,26 +123,6 @@ const getEvaluatedStyles = (style, props) => {
   };
 };
 
-const getRole = (props) => {
-  if (props.dependentAxis) {
-    return props.theme && props.theme.dependentAxis ? "dependentAxis" : "axis";
-  }
-
-  return props.theme && props.theme.independentAxis ? "independentAxis" : "axis";
-};
-
-const getShallowMergedThemeProps = (props, role) => {
-  const axisTheme = props.theme.axis || {};
-  return defaults({}, props.theme[role], axisTheme);
-};
-
-const modifyProps = (props, fallbackProps, role) => {
-  if (role !== "axis") {
-    props.theme[role] = getShallowMergedThemeProps(props, role);
-  }
-  return Helpers.modifyProps(props, fallbackProps, role);
-};
-
 const getAxisLabelProps = (props, calculatedValues, globalTransform) => {
   const { style, orientation, padding, labelPadding, isVertical } = calculatedValues;
   const sign = orientationSign[orientation];
@@ -341,8 +321,7 @@ const getCalculatedValues = (props) => {
 };
 
 const getBaseProps = (props, fallbackProps) => {
-  const role = getRole(props);
-  props = modifyProps(props, fallbackProps, role);
+  props = Axis.modifyProps(props, fallbackProps);
   const calculatedValues = getCalculatedValues(props);
   const {
     axis,

--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -3,7 +3,6 @@ import React from "react";
 import { assign, isEmpty } from "lodash";
 import {
   PropTypes as CustomPropTypes,
-  Helpers,
   VictoryLabel,
   CommonProps,
   VictoryContainer,

--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -230,8 +230,8 @@ class VictoryAxis extends React.Component {
   }
 
   render() {
-    const { animationWhitelist, role } = VictoryAxis;
-    const props = Helpers.modifyProps(this.props, fallbackProps, role);
+    const { animationWhitelist } = VictoryAxis;
+    const props = Axis.modifyProps(this.props, fallbackProps);
 
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -13,8 +13,8 @@ const fallbackProps = {
 
 function getAxisProps(child, props, calculatedProps) {
   const { domain, scale, stringMap, categories, horizontal, orientations } = calculatedProps;
-  const childProps = child.props || {};
-  const axis = child.type.getAxis(assign({ horizontal }, childProps));
+  const childProps = Axis.modifyProps(defaults({ horizontal, theme: props.theme }, child.props));
+  const axis = child.type.getAxis(childProps);
   const axisOffset = horizontal
     ? getHorizontalAxisOffset(props, calculatedProps)
     : getAxisOffset(props, calculatedProps);

--- a/packages/victory-core/src/victory-util/axis.js
+++ b/packages/victory-core/src/victory-util/axis.js
@@ -1,6 +1,8 @@
 /* eslint-disable func-style */
 import React from "react";
 import {
+  assign,
+  defaults,
   identity,
   isFunction,
   isObject,
@@ -14,6 +16,7 @@ import {
 } from "lodash";
 import Collection from "./collection";
 import Domain from "./domain";
+import Helpers from "./helpers";
 
 /**
  * Returns the axis (x or y) of a particular axis component
@@ -303,17 +306,36 @@ function getAxisValue(props, axis) {
   return scale(axisValue);
 }
 
+function modifyProps(props, fallbackProps) {
+  if (!isObject(props.theme)) {
+    return Helpers.modifyProps(props, fallbackProps, "axis");
+  }
+  let role = "axis";
+  if (props.dependentAxis && props.theme.dependentAxis) {
+    role = "dependentAxis";
+  } else if (!props.dependentAxis && props.theme.independentAxis) {
+    role = "independentAxis";
+  }
+  if (role === "axis") {
+    return Helpers.modifyProps(props, fallbackProps, "axis");
+  }
+  const axisTheme = defaults({}, props.theme[role], props.theme.axis);
+  const theme = assign({}, props.theme, { axis: axisTheme });
+  return Helpers.modifyProps(assign({}, props, { theme }), fallbackProps, "axis");
+};
+
 export default {
   getTicks,
   getTickFormat,
   getAxis,
   getAxisComponent,
   getAxisComponentsWithParent,
+  getAxisValue,
   findAxisComponents,
   getOrigin,
   getOriginSign,
   getDomain,
   isVertical,
-  stringTicks,
-  getAxisValue
+  modifyProps,
+  stringTicks
 };

--- a/packages/victory-core/src/victory-util/axis.js
+++ b/packages/victory-core/src/victory-util/axis.js
@@ -322,7 +322,7 @@ function modifyProps(props, fallbackProps) {
   const axisTheme = defaults({}, props.theme[role], props.theme.axis);
   const theme = assign({}, props.theme, { axis: axisTheme });
   return Helpers.modifyProps(assign({}, props, { theme }), fallbackProps, "axis");
-};
+}
 
 export default {
   getTicks,

--- a/packages/victory-polar-axis/src/helper-methods.js
+++ b/packages/victory-polar-axis/src/helper-methods.js
@@ -288,26 +288,6 @@ const getAxisProps = (modifiedProps, calculatedValues) => {
       };
 };
 
-const getRole = (props) => {
-  if (props.dependentAxis) {
-    return props.theme && props.theme.dependentAxis ? "dependentAxis" : "axis";
-  }
-
-  return props.theme && props.theme.independentAxis ? "independentAxis" : "axis";
-};
-
-const getShallowMergedThemeProps = (props, role) => {
-  const axisTheme = props.theme.axis || {};
-  return defaults({}, props.theme[role], axisTheme);
-};
-
-const modifyProps = (props, fallbackProps, role) => {
-  if (role !== "axis") {
-    props.theme[role] = getShallowMergedThemeProps(props, role);
-  }
-  return Helpers.modifyProps(props, fallbackProps, role);
-};
-
 const getCalculatedValues = (props) => {
   props = assign({ polar: true }, props);
   const defaultStyles = getStyleObject(props);
@@ -339,8 +319,7 @@ const getCalculatedValues = (props) => {
 };
 
 const getBaseProps = (props, fallbackProps) => {
-  const role = getRole(props);
-  props = modifyProps(props, fallbackProps, role);
+  props = Axis.modifyProps(props, fallbackProps);
   const calculatedValues = getCalculatedValues(props);
   const { style, scale, ticks, domain } = calculatedValues;
   const { width, height, standalone, theme, name } = props;

--- a/packages/victory-polar-axis/src/victory-polar-axis.js
+++ b/packages/victory-polar-axis/src/victory-polar-axis.js
@@ -223,8 +223,8 @@ class VictoryPolarAxis extends React.Component {
   }
 
   render() {
-    const { animationWhitelist, role } = VictoryPolarAxis;
-    const props = Helpers.modifyProps(this.props, fallbackProps, role);
+    const { animationWhitelist } = VictoryPolarAxis;
+    const props = Axis.modifyProps(this.props, fallbackProps);
 
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);

--- a/stories/victory-chart.js
+++ b/stories/victory-chart.js
@@ -10,6 +10,11 @@ import { VictoryBoxPlot } from "../packages/victory-box-plot/src/index";
 import { VictoryTheme } from "../packages/victory-core/src/index";
 import { getData, getFourQuadrantData, getArrayData } from "./data";
 
+const dependentAxisTheme = {
+  ...VictoryTheme.material,
+  ...{ dependentAxis: { orientation: "right" } }
+};
+
 storiesOf("VictoryChart", module).add("default rendering", () => <VictoryChart />);
 
 storiesOf("VictoryChart.theme", module)
@@ -30,6 +35,11 @@ storiesOf("VictoryChart.axes", module)
   ))
   .add("with a single dependent axis", () => (
     <VictoryChart>
+      <VictoryAxis dependentAxis />
+    </VictoryChart>
+  ))
+  .add("with orientation set by a theme", () => (
+    <VictoryChart theme={dependentAxisTheme}>
       <VictoryAxis dependentAxis />
     </VictoryChart>
   ));


### PR DESCRIPTION
This PR ensures that axis props set via a theme (such as `orientation`) are used instead of default values set by `VictoryChart`.

Fixes #1413 
related to https://github.com/FormidableLabs/victory/pull/1415