### PR TITLE
Fix handles disappearing with `invertedAxis`

### DIFF
--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -114,6 +114,7 @@ class App extends React.Component {
               <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowDraw={false} />
             }
           >
+            <VictoryAxis dependentAxis invertAxis />
             <VictoryLegend
               x={120}
               y={20}

--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -39,6 +39,7 @@ const Helpers = {
   },
 
   getHandles(props, domainBox) {
+    const brushDimension = this.getDimension(props);
     const { x1, x2, y1, y2 } = domainBox;
     const minX = Math.min(x1, x2);
     const maxX = Math.max(x1, x2);
@@ -46,17 +47,17 @@ const Helpers = {
     const maxY = Math.max(y1, y2);
     const handleWidth = props.handleWidth / 2;
     return {
-      left: { x1: minX - handleWidth, x2: minX + handleWidth, y1, y2 },
-      right: { x1: maxX - handleWidth, x2: maxX + handleWidth, y1, y2 },
-      top: { x1, x2, y1: minY + handleWidth, y2: minY - handleWidth },
-      bottom: { x1, x2, y1: maxY + handleWidth, y2: maxY - handleWidth }
+      left: brushDimension !== "y" && { x1: minX - handleWidth, x2: minX + handleWidth, y1, y2 },
+      right: brushDimension !== "y" && { x1: maxX - handleWidth, x2: maxX + handleWidth, y1, y2 },
+      top: brushDimension !== "x" && { x1, x2, y1: minY + handleWidth, y2: minY - handleWidth },
+      bottom: brushDimension !== "x" && { x1, x2, y1: maxY + handleWidth, y2: maxY - handleWidth }
     };
   },
 
   getActiveHandles(point, props, domainBox) {
     const handles = this.getHandles(props, domainBox);
     const activeHandles = ["top", "bottom", "left", "right"].reduce((memo, opt) => {
-      memo = this.withinBounds(point, handles[opt]) ? memo.concat(opt) : memo;
+      memo = handles[opt] && this.withinBounds(point, handles[opt]) ? memo.concat(opt) : memo;
       return memo;
     }, []);
     return activeHandles.length && activeHandles;

--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -49,8 +49,8 @@ const Helpers = {
     return {
       left: brushDimension !== "y" && { x1: minX - handleWidth, x2: minX + handleWidth, y1, y2 },
       right: brushDimension !== "y" && { x1: maxX - handleWidth, x2: maxX + handleWidth, y1, y2 },
-      top: brushDimension !== "x" && { x1, x2, y1: minY + handleWidth, y2: minY - handleWidth },
-      bottom: brushDimension !== "x" && { x1, x2, y1: maxY + handleWidth, y2: maxY - handleWidth }
+      top: brushDimension !== "x" && { x1, x2, y1: minY - handleWidth, y2: minY + handleWidth },
+      bottom: brushDimension !== "x" && { x1, x2, y1: maxY - handleWidth, y2: maxY + handleWidth }
     };
   },
 

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -127,12 +127,16 @@ export const brushContainerMixin = (base) =>
       const cursors = this.getCursorPointers(props);
       const yProps = { style, width, height: handleWidth, cursor: cursors.yProps };
       const xProps = { style, width: handleWidth, height, cursor: cursors.xProps };
+      const minX = Math.min(x[0], x[1]);
+      const maxX = Math.max(x[0], x[1]);
+      const minY = Math.min(y[0], y[1]);
+      const maxY = Math.max(y[0], y[1]);
 
       const handleProps = {
-        top: brushDimension !== "x" && assign({ x: x[0], y: y[1] - handleWidth / 2 }, yProps),
-        bottom: brushDimension !== "x" && assign({ x: x[0], y: y[0] - handleWidth / 2 }, yProps),
-        left: brushDimension !== "y" && assign({ y: y[1], x: x[0] - handleWidth / 2 }, xProps),
-        right: brushDimension !== "y" && assign({ y: y[1], x: x[1] - handleWidth / 2 }, xProps)
+        top: brushDimension !== "x" && assign({ x: minX, y: minY - handleWidth / 2 }, yProps),
+        bottom: brushDimension !== "x" && assign({ x: minX, y: maxY - handleWidth / 2 }, yProps),
+        left: brushDimension !== "y" && assign({ y: minY, x: minX - handleWidth / 2 }, xProps),
+        right: brushDimension !== "y" && assign({ y: minY, x: maxX - handleWidth / 2 }, xProps)
       };
       const handles = ["top", "bottom", "left", "right"].reduce((memo, curr) => {
         memo = handleProps[curr]

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -115,28 +115,25 @@ export const brushContainerMixin = (base) =>
       return cursors;
     }
 
-    getHandles(props, coordinates) {
+    getHandles(props, domain) {
       const { handleWidth, handleStyle, handleComponent, name } = props;
-      const brushDimension = BrushHelpers.getDimension(props);
-      const { x, y } = coordinates;
-      const width = Math.abs(x[1] - x[0]) || 1;
-      const height = Math.abs(y[1] - y[0]) || 1;
+      const domainBox = BrushHelpers.getDomainBox(props, domain);
+      const { x1, x2, y1, y2 } = domainBox;
+      const { top, bottom, left, right } = BrushHelpers.getHandles(props, domainBox);
+      const width = Math.abs(x2 - x1) || 1;
+      const height = Math.abs(y2 - y1) || 1;
       const handleComponentStyle = (handleComponent.props && handleComponent.props.style) || {};
       const style = defaults({}, handleComponentStyle, handleStyle);
 
       const cursors = this.getCursorPointers(props);
       const yProps = { style, width, height: handleWidth, cursor: cursors.yProps };
       const xProps = { style, width: handleWidth, height, cursor: cursors.xProps };
-      const minX = Math.min(x[0], x[1]);
-      const maxX = Math.max(x[0], x[1]);
-      const minY = Math.min(y[0], y[1]);
-      const maxY = Math.max(y[0], y[1]);
 
       const handleProps = {
-        top: brushDimension !== "x" && assign({ x: minX, y: minY - handleWidth / 2 }, yProps),
-        bottom: brushDimension !== "x" && assign({ x: minX, y: maxY - handleWidth / 2 }, yProps),
-        left: brushDimension !== "y" && assign({ y: minY, x: minX - handleWidth / 2 }, xProps),
-        right: brushDimension !== "y" && assign({ y: minY, x: maxX - handleWidth / 2 }, xProps)
+        top: top && assign({ x: top.x1, y: top.y1 }, yProps),
+        bottom: bottom && assign({ x: bottom.x1, y: bottom.y1 }, yProps),
+        left: left && assign({ y: left.y1, x: left.x1 }, xProps),
+        right: right && assign({ y: right.y1, x: right.x1 }, xProps)
       };
       const handles = ["top", "bottom", "left", "right"].reduce((memo, curr) => {
         memo = handleProps[curr]
@@ -160,7 +157,7 @@ export const brushContainerMixin = (base) =>
         : brushDomain;
       const coordinates = Selection.getDomainCoordinates(props, domain);
       const selectBox = this.getSelectBox(props, coordinates);
-      return selectBox ? [selectBox, this.getHandles(props, coordinates)] : [];
+      return selectBox ? [selectBox, this.getHandles(props, domain)] : [];
     }
 
     // Overrides method in VictoryContainer


### PR DESCRIPTION
This fixes #1432 by reusing `BrushHelpers.getHandles`

This also moves `brushDimension` checks to `BrushHelpers.getHandles`, to ensure that behaviour is consistent with cursors