### PR TITLE
Feature request: defaultBrushArea="move"

### DIFF
--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -204,7 +204,7 @@ class App extends React.Component {
             y={(d) => d.x * d.x}
           />
 
-          <VictoryGroup style={chartStyle} containerComponent={<VictoryBrushContainer />}>
+          <VictoryGroup style={chartStyle} containerComponent={<VictoryBrushContainer defaultBrushArea="move" />}>
             <VictoryScatter
               style={{
                 data: { fill: "tomato" }

--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -204,7 +204,10 @@ class App extends React.Component {
             y={(d) => d.x * d.x}
           />
 
-          <VictoryGroup style={chartStyle} containerComponent={<VictoryBrushContainer defaultBrushArea="move" />}>
+          <VictoryGroup
+            style={chartStyle}
+            containerComponent={<VictoryBrushContainer defaultBrushArea="move" />}
+          >
             <VictoryScatter
               style={{
                 data: { fill: "tomato" }

--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -82,11 +82,29 @@ const Helpers = {
     };
   },
 
-  getDefaultBrushArea(defaultBrushArea, domain, cachedDomain) {
+  getDefaultBrushArea(targetProps, cachedDomain, evt) {
+    const { defaultBrushArea, domain, fullDomain, scale, horizontal } = targetProps;
     if (defaultBrushArea === "none") {
       return this.getMinimumDomain();
     } else if (defaultBrushArea === "disable") {
       return cachedDomain;
+    } else if (defaultBrushArea === "move") {
+      // eslint-disable-next-line no-unused-vars
+      const { x1, x2, y1, y2, ...restProps } = targetProps;
+      const brushBox = this.getDomainBox(restProps, fullDomain, cachedDomain);
+      const parentSVG = restProps.parentSVG || Selection.getParentSVG(evt);
+      const pannedBox = this.panBox(
+        {
+          ...restProps,
+          brushDomain: cachedDomain,
+          startX: (brushBox.x1 + brushBox.x2) / 2,
+          startY: (brushBox.y1 + brushBox.y2) / 2
+        },
+        Selection.getSVGEventCoordinates(evt, parentSVG)
+      );
+      const fullDomainBox = restProps.fullDomainBox || this.getDomainBox(restProps, fullDomain);
+      const constrainedBox = this.constrainBox(pannedBox, fullDomainBox);
+      return Selection.getBounds({ ...constrainedBox, scale, horizontal });
     } else {
       return domain;
     }
@@ -311,7 +329,6 @@ const Helpers = {
       onBrushDomainChange,
       onBrushDomainChangeEnd,
       onBrushCleared,
-      domain,
       currentDomain,
       allowResize,
       allowDrag,
@@ -324,7 +341,7 @@ const Helpers = {
     // if the mouse hasn't moved since a mouseDown event, select the default brush area
     if ((allowResize || defaultBrushHasArea) && (x1 === x2 || y1 === y2)) {
       const cachedDomain = targetProps.cachedCurrentDomain || currentDomain;
-      const defaultDomain = this.getDefaultBrushArea(defaultBrushArea, domain, cachedDomain);
+      const defaultDomain = this.getDefaultBrushArea(targetProps, cachedDomain, evt);
       mutatedProps.currentDomain = defaultDomain;
       if (isFunction(onBrushDomainChange)) {
         onBrushDomainChange(defaultDomain, defaults({}, mutatedProps, targetProps));

--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -89,20 +89,19 @@ const Helpers = {
     } else if (defaultBrushArea === "disable") {
       return cachedDomain;
     } else if (defaultBrushArea === "move") {
-      // eslint-disable-next-line no-unused-vars
-      const { x1, x2, y1, y2, ...restProps } = targetProps;
-      const brushBox = this.getDomainBox(restProps, fullDomain, cachedDomain);
-      const parentSVG = restProps.parentSVG || Selection.getParentSVG(evt);
+      const brushBox = this.getDomainBox(targetProps, fullDomain, cachedDomain);
+      const parentSVG = targetProps.parentSVG || Selection.getParentSVG(evt);
       const pannedBox = this.panBox(
         {
-          ...restProps,
+          ...targetProps,
+          ...brushBox,
           brushDomain: cachedDomain,
           startX: (brushBox.x1 + brushBox.x2) / 2,
           startY: (brushBox.y1 + brushBox.y2) / 2
         },
         Selection.getSVGEventCoordinates(evt, parentSVG)
       );
-      const fullDomainBox = restProps.fullDomainBox || this.getDomainBox(restProps, fullDomain);
+      const fullDomainBox = targetProps.fullDomainBox || this.getDomainBox(targetProps, fullDomain);
       const constrainedBox = this.constrainBox(pannedBox, fullDomainBox);
       return Selection.getBounds({ ...constrainedBox, scale, horizontal });
     } else {

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -20,7 +20,7 @@ export const brushContainerMixin = (base) =>
         y: PropTypes.array
       }),
       brushStyle: PropTypes.object,
-      defaultBrushArea: PropTypes.oneOf(["all", "disable", "none"]),
+      defaultBrushArea: PropTypes.oneOf(["all", "disable", "none", "move"]),
       disable: PropTypes.bool,
       handleComponent: PropTypes.element,
       handleStyle: PropTypes.object,


### PR DESCRIPTION
I find it quite convenient to move the selected area without changing the zoom by just clicking at the desired location, like with scrollbars

![Kapture 2019-11-06 at 16 52 56](https://user-images.githubusercontent.com/6651625/68314129-f94ee800-00b5-11ea-8e22-c1c3c2438b9a.gif)

