### PR TITLE
VictoryBrushContainer: add a threshold for mouseMove events to avoid accidental minimal draws

### DIFF
--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -275,7 +275,8 @@ const Helpers = {
       onBrushDomainChange,
       allowResize,
       allowDrag,
-      horizontal
+      horizontal,
+      mouseMoveThreshold
     } = targetProps;
     const brushDimension = this.getDimension(targetProps);
     const parentSVG = targetProps.parentSVG || Selection.getParentSVG(evt);
@@ -284,7 +285,7 @@ const Helpers = {
     if (
       (!allowResize && !allowDrag) ||
       !this.withinBounds({ x, y }, fullDomainBox) ||
-      !this.hasMoved({ ...targetProps, x2: x, y2: y })
+      (mouseMoveThreshold > 0 && !this.hasMoved({ ...targetProps, x2: x, y2: y }))
     ) {
       return {};
     }

--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -151,6 +151,21 @@ const Helpers = {
     };
   },
 
+  hasMoved(props) {
+    const { x1, x2, y1, y2, mouseMoveThreshold } = props;
+    const brushDimension = this.getDimension(props);
+    const xMoved = Math.abs(x1 - x2) >= mouseMoveThreshold;
+    const yMoved = Math.abs(y1 - y2) >= mouseMoveThreshold;
+    switch (brushDimension) {
+      case "x":
+        return xMoved;
+      case "y":
+        return yMoved;
+      default:
+        return xMoved || yMoved;
+    }
+  },
+
   // eslint-disable-next-line max-statements, complexity
   onMouseDown(evt, targetProps) {
     evt.preventDefault();
@@ -266,7 +281,11 @@ const Helpers = {
     const parentSVG = targetProps.parentSVG || Selection.getParentSVG(evt);
     const { x, y } = Selection.getSVGEventCoordinates(evt, parentSVG);
     // Ignore events that occur outside of the maximum domain region
-    if ((!allowResize && !allowDrag) || !this.withinBounds({ x, y }, fullDomainBox)) {
+    if (
+      (!allowResize && !allowDrag) ||
+      !this.withinBounds({ x, y }, fullDomainBox) ||
+      !this.hasMoved({ ...targetProps, x2: x, y2: y })
+    ) {
       return {};
     }
     if (allowDrag && isPanning) {

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -46,7 +46,7 @@ export const brushContainerMixin = (base) =>
         fill: "transparent"
       },
       handleWidth: 8,
-      mouseMoveThreshold: 2
+      mouseMoveThreshold: 0
     };
 
     static defaultEvents = (props) => {

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -45,7 +45,8 @@ export const brushContainerMixin = (base) =>
         stroke: "transparent",
         fill: "transparent"
       },
-      handleWidth: 8
+      handleWidth: 8,
+      mouseMoveThreshold: 2
     };
 
     static defaultEvents = (props) => {


### PR DESCRIPTION
When using `defaultBrushArea: 'move'`, it's too easy to accidentally draw a minimal selection when in fact you just click the empty area. I've added a customisable threshold for handling mouseMove with default of 2px

Probably related: https://github.com/FormidableLabs/victory/issues/1058