### PR TITLE
Handle tooltip text when using custom flyoutComponent

### DIFF
--- a/packages/victory-core/src/victory-util/textsize.js
+++ b/packages/victory-core/src/victory-util/textsize.js
@@ -108,7 +108,7 @@ const _prepareParams = (inputStyle, index) => {
 };
 
 const _approximateTextWidthInternal = (text, style) => {
-  if (text === undefined || text === "") {
+  if (text === undefined || text === "" || text === null) {
     return 0;
   }
   const widths = _splitToLines(text).map((line, index) => {
@@ -120,7 +120,7 @@ const _approximateTextWidthInternal = (text, style) => {
 };
 
 const _approximateTextHeightInternal = (text, style) => {
-  if (text === undefined || text === "") {
+  if (text === undefined || text === "" || text === null) {
     return 0;
   }
   return _splitToLines(text).reduce((total, line, index) => {


### PR DESCRIPTION
When using the `flyoutComponent` prop, and letting the rendered
component render any blank text, the `text` prop comes through as
`null`. This means that we try to stringify null.

This is a followup to #1425 which added this check in case the height
was the number value 0, but broke `null`.

Specifically, our code looks like:
```tsx
                <VictoryBar
                  labelComponent={
                    <VictoryTooltip
                      renderInPortal={false}
                      dx={horizontal ? this.centerY(key) : 0}
                      dy={horizontal ? 0 : BAR_TOOLTIP_DISTANCE}
                      flyoutComponent={
                        <BarChartTooltip
                          position={Position.TOP}
                          getDatumLabel={this.formatDatum}
                          seriesKey={key}
                        />
                      }
                    />
                  }
...
```

Note that I also tried adding an explicit `text={undefined}` and `text=""` to trigger the existing null/etc but that ended up overriding the flyoutComponent prop.

