### PR TITLE
Migrate to new context API

### DIFF
--- a/packages/victory-core/src/index.js
+++ b/packages/victory-core/src/index.js
@@ -28,6 +28,7 @@ export { default as Selection } from "./victory-util/selection";
 export { default as Style } from "./victory-util/style";
 export { default as TextSize } from "./victory-util/textsize";
 export { default as Timer } from "./victory-util/timer";
+export { default as TimerContext } from "./victory-util/timer-context";
 export { default as Transitions } from "./victory-util/transitions";
 export { default as Rect } from "./victory-primitives/rect";
 export { default as Path } from "./victory-primitives/path";

--- a/packages/victory-core/src/victory-animation/victory-animation.js
+++ b/packages/victory-core/src/victory-animation/victory-animation.js
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import * as d3Ease from "d3-ease";
 import { victoryInterpolator } from "./util";
-import Timer from "../victory-util/timer";
+import TimerContext from "../victory-util/timer-context";
 import isEqual from "react-fast-compare";
 
 export default class VictoryAnimation extends React.Component {
@@ -66,12 +66,10 @@ export default class VictoryAnimation extends React.Component {
     easing: "quadInOut"
   };
 
-  static contextTypes = {
-    getTimer: PropTypes.func
-  };
+  static contextType = TimerContext;
 
-  constructor(props) {
-    super(props);
+  constructor(props, context) {
+    super(props, context);
     /* defaults */
     this.state = {
       data: Array.isArray(this.props.data) ? this.props.data[0] : this.props.data,
@@ -84,12 +82,13 @@ export default class VictoryAnimation extends React.Component {
     this.queue = Array.isArray(this.props.data) ? this.props.data.slice(1) : [];
     /* build easing function */
     this.ease = d3Ease[this.toNewName(this.props.easing)];
+    this.timer = context;
+
     /*
       There is no autobinding of this in ES6 classes
       so we bind functionToBeRunEachFrame to current instance of victory animation class
     */
     this.functionToBeRunEachFrame = this.functionToBeRunEachFrame.bind(this);
-    this.getTimer = this.getTimer.bind(this);
   }
 
   componentDidMount() {
@@ -103,7 +102,7 @@ export default class VictoryAnimation extends React.Component {
     const equalProps = isEqual(this.props, nextProps);
     if (!equalProps) {
       /* cancel existing loop if it exists */
-      this.getTimer().unsubscribe(this.loopID);
+      this.timer.unsubscribe(this.loopID);
 
       /* If an object was supplied */
       if (!Array.isArray(nextProps.data)) {
@@ -124,20 +123,10 @@ export default class VictoryAnimation extends React.Component {
 
   componentWillUnmount() {
     if (this.loopID) {
-      this.getTimer().unsubscribe(this.loopID);
+      this.timer.unsubscribe(this.loopID);
     } else {
-      this.getTimer().stop();
+      this.timer.stop();
     }
-  }
-
-  getTimer() {
-    if (this.context.getTimer) {
-      return this.context.getTimer();
-    }
-    if (!this.timer) {
-      this.timer = new Timer();
-    }
-    return this.timer;
   }
 
   toNewName(ease) {
@@ -156,13 +145,10 @@ export default class VictoryAnimation extends React.Component {
       /* reset step to zero */
       if (this.props.delay) {
         setTimeout(() => {
-          this.loopID = this.getTimer().subscribe(
-            this.functionToBeRunEachFrame,
-            this.props.duration
-          );
+          this.loopID = this.timer.subscribe(this.functionToBeRunEachFrame, this.props.duration);
         }, this.props.delay);
       } else {
-        this.loopID = this.getTimer().subscribe(this.functionToBeRunEachFrame, this.props.duration);
+        this.loopID = this.timer.subscribe(this.functionToBeRunEachFrame, this.props.duration);
       }
     } else if (this.props.onEnd) {
       this.props.onEnd();
@@ -186,7 +172,7 @@ export default class VictoryAnimation extends React.Component {
         }
       });
       if (this.loopID) {
-        this.getTimer().unsubscribe(this.loopID);
+        this.timer.unsubscribe(this.loopID);
       }
       this.queue.shift();
       this.traverseQueue();

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "../victory-util/prop-types";
 import { assign, defaults, uniqueId, isObject, isFunction } from "lodash";
 import Portal from "../victory-portal/portal";
-import Timer from "../victory-util/timer";
+import TimerContext from "../victory-util/timer-context";
 import Helpers from "../victory-util/helpers";
 
 export default class VictoryContainer extends React.Component {
@@ -37,20 +37,17 @@ export default class VictoryContainer extends React.Component {
     responsive: true
   };
 
-  static contextTypes = {
-    getTimer: PropTypes.func
-  };
+  static contextType = TimerContext;
 
   static childContextTypes = {
     portalUpdate: PropTypes.func,
     portalRegister: PropTypes.func,
     portalDeregister: PropTypes.func,
-    getTimer: PropTypes.func
   };
 
-  constructor(props) {
-    super(props);
-    this.getTimer = this.getTimer.bind(this);
+  constructor(props, context) {
+    super(props, context);
+    this.timer = this.context;
     this.containerId =
       !isObject(props) || props.containerId === undefined
         ? uniqueId("victory-container-")
@@ -82,7 +79,6 @@ export default class VictoryContainer extends React.Component {
       portalUpdate: this.portalUpdate,
       portalRegister: this.portalRegister,
       portalDeregister: this.portalDeregister,
-      getTimer: this.getTimer
     };
   }
 
@@ -93,22 +89,10 @@ export default class VictoryContainer extends React.Component {
   }
 
   componentWillUnmount() {
-    if (!this.context.getTimer) {
-      this.getTimer().stop();
-    }
+    this.timer.stop();
     if (this.shouldHandleWheel && this.containerRef) {
       this.containerRef.removeEventListener("wheel", this.handleWheel);
     }
-  }
-
-  getTimer() {
-    if (this.context.getTimer) {
-      return this.context.getTimer();
-    }
-    if (!this.timer) {
-      this.timer = new Timer();
-    }
-    return this.timer;
   }
 
   getIdForElement(elementName) {

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "../victory-util/prop-types";
 import { assign, defaults, uniqueId, isObject, isFunction } from "lodash";
 import Portal from "../victory-portal/portal";
+import PortalContext from "../victory-portal/portal-context";
 import TimerContext from "../victory-util/timer-context";
 import Helpers from "../victory-util/helpers";
 
@@ -39,12 +40,6 @@ export default class VictoryContainer extends React.Component {
 
   static contextType = TimerContext;
 
-  static childContextTypes = {
-    portalUpdate: PropTypes.func,
-    portalRegister: PropTypes.func,
-    portalDeregister: PropTypes.func,
-  };
-
   constructor(props, context) {
     super(props, context);
     this.timer = this.context;
@@ -72,14 +67,6 @@ export default class VictoryContainer extends React.Component {
     if (this.shouldHandleWheel) {
       this.handleWheel = (e) => e.preventDefault();
     }
-  }
-
-  getChildContext() {
-    return {
-      portalUpdate: this.portalUpdate,
-      portalRegister: this.portalRegister,
-      portalDeregister: this.portalDeregister,
-    };
   }
 
   componentDidMount() {
@@ -134,16 +121,28 @@ export default class VictoryContainer extends React.Component {
       style: portalSvgStyle
     };
     return (
-      <div style={defaults({}, style, divStyle)} className={className} ref={this.saveContainerRef}>
-        <svg {...svgProps} style={svgStyle}>
-          {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
-          {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
-          {children}
-        </svg>
-        <div style={portalDivStyle}>
-          {React.cloneElement(portalComponent, { ...portalProps, ref: this.savePortalRef })}
+      <PortalContext.Provider
+        value={{
+          portalUpdate: this.portalUpdate,
+          portalRegister: this.portalRegister,
+          portalDeregister: this.portalDeregister
+        }}
+      >
+        <div
+          style={defaults({}, style, divStyle)}
+          className={className}
+          ref={this.saveContainerRef}
+        >
+          <svg {...svgProps} style={svgStyle}>
+            {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
+            {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
+            {children}
+          </svg>
+          <div style={portalDivStyle}>
+            {React.cloneElement(portalComponent, { ...portalProps, ref: this.savePortalRef })}
+          </div>
         </div>
-      </div>
+      </PortalContext.Provider>
     );
   }
 

--- a/packages/victory-core/src/victory-portal/portal-context.js
+++ b/packages/victory-core/src/victory-portal/portal-context.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+/**
+ * The React context object consumers may use to access the context of the
+ * portal.
+ */
+const PortalContext = React.createContext({});
+PortalContext.displayName = "PortalContext";
+
+export default PortalContext;

--- a/packages/victory-core/src/victory-portal/victory-portal.js
+++ b/packages/victory-core/src/victory-portal/victory-portal.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { defaults } from "lodash";
 import Log from "../victory-util/log";
 import Helpers from "../victory-util/helpers";
+import PortalContext from "./portal-context";
 
 export default class VictoryPortal extends React.Component {
   static displayName = "VictoryPortal";
@@ -18,11 +19,7 @@ export default class VictoryPortal extends React.Component {
     groupComponent: <g />
   };
 
-  static contextTypes = {
-    portalDeregister: PropTypes.func,
-    portalRegister: PropTypes.func,
-    portalUpdate: PropTypes.func
-  };
+  static contextType = PortalContext;
 
   componentDidMount() {
     if (!this.checkedContext) {

--- a/packages/victory-core/src/victory-transition/victory-transition.js
+++ b/packages/victory-core/src/victory-transition/victory-transition.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import VictoryAnimation from "../victory-animation/victory-animation";
 import Collection from "../victory-util/collection";
 import Helpers from "../victory-util/helpers";
-import Timer from "../victory-util/timer";
+import TimerContext from "../victory-util/timer-context";
 import Transitions from "../victory-util/transitions";
 import { defaults, isFunction, pick, isObject } from "lodash";
 import isEqual from "react-fast-compare";
@@ -17,8 +17,11 @@ export default class VictoryTransition extends React.Component {
     children: PropTypes.node
   };
 
-  constructor(props) {
-    super(props);
+  static contextType = TimerContext;
+
+  constructor(props, context) {
+    super(props, context);
+
     this.state = {
       nodesShouldLoad: false,
       nodesDoneLoad: false
@@ -27,7 +30,7 @@ export default class VictoryTransition extends React.Component {
     const polar = child.props.polar;
     this.continuous = !polar && child.type && child.type.continuous === true;
     this.getTransitionState = this.getTransitionState.bind(this);
-    this.getTimer = this.getTimer.bind(this);
+    this.timer = context;
   }
 
   componentDidMount() {
@@ -36,26 +39,16 @@ export default class VictoryTransition extends React.Component {
 
   shouldComponentUpdate(nextProps) {
     if (!isEqual(this.props, nextProps)) {
-      this.getTimer().bypassAnimation();
+      this.timer.bypassAnimation();
       this.setState(this.getTransitionState(this.props, nextProps), () =>
-        this.getTimer().resumeAnimation()
+        this.timer.resumeAnimation()
       );
     }
     return true;
   }
 
   componentWillUnmount() {
-    this.getTimer().stop();
-  }
-
-  getTimer() {
-    if (this.context.getTimer) {
-      return this.context.getTimer();
-    }
-    if (!this.timer) {
-      this.timer = new Timer();
-    }
-    return this.timer;
+    this.timer.stop();
   }
 
   getTransitionState(props, nextProps) {

--- a/packages/victory-core/src/victory-util/timer-context.js
+++ b/packages/victory-core/src/victory-util/timer-context.js
@@ -1,0 +1,11 @@
+import React from "react";
+import Timer from "./timer";
+
+/**
+ * The React context object consumers may use to access or override the global
+ * timer.
+ */
+const TimerContext = React.createContext(new Timer());
+TimerContext.displayName = "TimerContext";
+
+export default TimerContext;

--- a/packages/victory-shared-events/src/victory-shared-events.js
+++ b/packages/victory-shared-events/src/victory-shared-events.js
@@ -1,7 +1,7 @@
 import { assign, isFunction, defaults, isEmpty, fromPairs } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
-import { PropTypes as CustomPropTypes, Events, Helpers, Timer } from "victory-core";
+import { PropTypes as CustomPropTypes, Events, Helpers } from "victory-core";
 import isEqual from "react-fast-compare";
 
 export default class VictorySharedEvents extends React.Component {
@@ -51,27 +51,12 @@ export default class VictorySharedEvents extends React.Component {
     groupComponent: <g />
   };
 
-  static contextTypes = {
-    getTimer: PropTypes.func
-  };
-
-  static childContextTypes = {
-    getTimer: PropTypes.func
-  };
-
   constructor(props) {
     super(props);
     this.state = this.state || {};
     this.getScopedEvents = Events.getScopedEvents.bind(this);
     this.getEventState = Events.getEventState.bind(this);
-    this.getTimer = this.getTimer.bind(this);
     this.baseProps = this.getBaseProps(props);
-  }
-
-  getChildContext() {
-    return {
-      getTimer: this.getTimer
-    };
   }
 
   shouldComponentUpdate(nextProps) {
@@ -81,16 +66,6 @@ export default class VictorySharedEvents extends React.Component {
       this.applyExternalMutations(nextProps, externalMutations);
     }
     return true;
-  }
-
-  getTimer() {
-    if (this.context.getTimer) {
-      return this.context.getTimer();
-    }
-    if (!this.timer) {
-      this.timer = new Timer();
-    }
-    return this.timer;
   }
 
   getAllEvents(props) {

--- a/packages/victory-zoom-container/src/zoom-helpers.js
+++ b/packages/victory-zoom-container/src/zoom-helpers.js
@@ -143,12 +143,10 @@ const RawZoomHelpers = {
   },
 
   handleAnimation(ctx) {
-    const getTimer = isFunction(ctx.getTimer) && ctx.getTimer.bind(ctx);
-    if (getTimer && isFunction(getTimer().bypassAnimation)) {
-      getTimer().bypassAnimation();
-      return isFunction(getTimer().resumeAnimation)
-        ? () => getTimer().resumeAnimation()
-        : undefined;
+    const { timer } = ctx;
+    if (timer && isFunction(timer.bypassAnimation)) {
+      timer.bypassAnimation();
+      return isFunction(timer.resumeAnimation) ? () => timer.resumeAnimation() : undefined;
     }
     return undefined;
   },


### PR DESCRIPTION
Hi!

When running an application in StrictMode, I stumbled upon the warning that Victory is still using the legacy context API (#1442). This pull requests removes the usage of the legacy API and adds two new context types `TimerContext` and `PortalContext`, which carry respectively the application's global timer and the portal context functions.

Some parts of the code are not well-tested (yet), so might not be implemented correctly. In particular, no test touches the code in `zoom-helpers.js`. In this case, I assume the context passed to the function is the class instance of the component (where `this.timer` is set).

Hope this is helpful!

Fixes #1442