### PR TITLE
Add activePoints props to flyout & label components in voronoi container

### DIFF
--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -9,9 +9,9 @@ import { VictoryLine } from "../../packages/victory-line/src/index";
 import { VictoryScatter } from "../../packages/victory-scatter/src/index";
 import { VictoryVoronoiContainer } from "../../packages/victory-voronoi-container/src/index";
 import { random, range } from "lodash";
-import { VictoryTooltip } from "../../packages/victory-tooltip/src/index";
+import { Flyout, VictoryTooltip } from "../../packages/victory-tooltip/src/index";
 import { VictoryLegend } from "../../packages/victory-legend/src/index";
-import { VictoryTheme } from "../../packages/victory-core/src/index";
+import { VictoryLabel, VictoryTheme } from "../../packages/victory-core/src/index";
 
 class App extends React.Component {
   constructor() {
@@ -51,6 +51,33 @@ class App extends React.Component {
     };
 
     const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
+
+    const dy = 13;
+    const CustomLabel = (props) => {
+      const x = props.x - 2 - 4 * Math.max(...props.text.map((t) => t.length));
+      const startY = 2 + props.y - (props.text.length * dy) / 2;
+      return (
+        <g>
+          {props.activePoints.map((pt, idx) => {
+            return (
+              <rect
+                key={`square_${idx}`}
+                width={10}
+                height={10}
+                x={x}
+                y={startY + dy * idx}
+                style={{ fill: pt.c }}
+              />
+            );
+          })}
+          <VictoryLabel {...props} />
+        </g>
+      );
+    };
+
+    const CustomFlyout = (props) => {
+      return <Flyout {...props} width={props.width + 15} />;
+    };
 
     return (
       <div className="demo">
@@ -511,6 +538,48 @@ class App extends React.Component {
               ]}
             />
           </VictoryStack>
+
+          <VictoryChart
+            style={chartStyle}
+            theme={VictoryTheme.material}
+            domainPadding={{ y: 2 }}
+            containerComponent={
+              <VictoryVoronoiContainer
+                labels={({ datum }) => `${datum.l}: ${datum.y}`}
+                labelComponent={
+                  <VictoryTooltip
+                    y={150}
+                    flyoutComponent={<CustomFlyout />}
+                    labelComponent={<CustomLabel />}
+                  />
+                }
+              />
+            }
+          >
+            <VictoryLine
+              name="first"
+              data={[
+                { x: 1, y: 5, c: "red", l: "error" },
+                { x: 2, y: 4, c: "red", l: "error" },
+                { x: 3, y: 0, c: "red", l: "error" }
+              ]}
+              style={{
+                data: { stroke: "red", strokeWidth: ({ active }) => (active ? 4 : 2) }
+              }}
+            />
+
+            <VictoryLine
+              name="second"
+              data={[
+                { x: 1, y: 0, c: "green", l: "success" },
+                { x: 2, y: 4, c: "green", l: "success" },
+                { x: 3, y: 3, c: "green", l: "success" }
+              ]}
+              style={{
+                data: { stroke: "green", strokeWidth: ({ active }) => (active ? 4 : 2) }
+              }}
+            />
+          </VictoryChart>
         </div>
       </div>
     );

--- a/packages/victory-tooltip/src/victory-tooltip.js
+++ b/packages/victory-tooltip/src/victory-tooltip.js
@@ -24,6 +24,7 @@ export default class VictoryTooltip extends React.Component {
   static propTypes = {
     activateData: PropTypes.bool,
     active: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+    activePoints: PropTypes.array,
     angle: PropTypes.number,
     center: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
     centerOffset: PropTypes.shape({
@@ -404,7 +405,7 @@ export default class VictoryTooltip extends React.Component {
 
   getLabelProps(props, calculatedValues) {
     const { flyoutCenter, style, labelSize, dy, dx } = calculatedValues;
-    const { text, datum, labelComponent, index } = props;
+    const { text, datum, activePoints, labelComponent, index } = props;
     const textAnchor =
       (Array.isArray(style) && style.length ? style[0].textAnchor : style.textAnchor) || "middle";
     const getLabelX = () => {
@@ -415,6 +416,7 @@ export default class VictoryTooltip extends React.Component {
       key: `${this.id}-label-${index}`,
       text,
       datum,
+      activePoints,
       textAnchor,
       dy,
       dx,
@@ -452,6 +454,7 @@ export default class VictoryTooltip extends React.Component {
       dx,
       dy,
       datum,
+      activePoints,
       index,
       pointerLength,
       pointerWidth,
@@ -466,6 +469,7 @@ export default class VictoryTooltip extends React.Component {
       dx,
       dy,
       datum,
+      activePoints,
       index,
       pointerLength,
       pointerWidth,

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -160,6 +160,7 @@ export const voronoiContainerMixin = (base) =>
           flyoutStyle: this.getStyle(props, points, "flyout")[0],
           renderInPortal: false,
           style: this.getStyle(props, points, "labels"),
+          activePoints: points,
           datum,
           scale,
           theme,


### PR DESCRIPTION
Also add a demo to show what it enables

Fixes https://github.com/FormidableLabs/victory/issues/1473

Notes: I've added a demo, not a story, because there's a comment in stories stating "only add visual test for containers that have visual elements without interaction" which isn't the case here (interactions are needed to trigger tooltip)
