### PR TITLE
Imported typescript definitions from definitely typed

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,6 +2,9 @@ The MIT License (MIT)
 
 Copyright (c) 2015 Formidable Labs
 
+Copyrights are respective of each contributor listed at the beginning of each
+typescript definition file.
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/packages/victory-area/src/index.d.ts
+++ b/packages/victory-area/src/index.d.ts
@@ -1,0 +1,34 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  EventPropTypeInterface,
+  InterpolationPropType,
+  VictoryCommonProps,
+  VictoryDatableProps,
+  VictorySingleLabableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryAreaProps extends VictoryCommonProps, VictoryDatableProps, VictorySingleLabableProps {
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", "all">[];
+  interpolation?: InterpolationPropType;
+  labels?: string[] | number[] | Function;
+  samples?: number;
+  style?: VictoryStyleInterface;
+}
+
+/**
+ * Draw area charts with React. VictoryArea is a composable component, so it doesn"t include axes.
+ * Add VictoryArea as a child of VictoryChart for a complete chart.
+ */
+export class VictoryArea extends React.Component<VictoryAreaProps, any> {}

--- a/packages/victory-axis/src/index.d.ts
+++ b/packages/victory-axis/src/index.d.ts
@@ -1,0 +1,59 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import { DomainPropType, EventPropTypeInterface, VictoryCommonProps } from "victory-core";
+
+export interface VictoryAxisProps extends VictoryCommonProps {
+  axisComponent?: React.ReactElement;
+  axisLabelComponent?: React.ReactElement;
+  axisValue?: number | string | object;
+  crossAxis?: boolean;
+  dependentAxis?: boolean;
+  domain?: DomainPropType;
+  events?: EventPropTypeInterface<
+    "axis" | "axisLabel" | "grid" | "ticks" | "tickLabels" | "parent",
+    number | string
+  >[];
+  fixLabelOverlap?: boolean;
+  gridComponent?: React.ReactElement;
+  invertAxis?: boolean;
+  label?: any;
+  offsetX?: number;
+  offsetY?: number;
+  orientation?: "top" | "bottom" | "left" | "right";
+  style?: {
+    parent?: React.CSSProperties;
+    axis?: React.CSSProperties;
+    axisLabel?: React.CSSProperties;
+    grid?: {
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+    };
+    ticks?: {
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+    };
+    tickLabels?: {
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+    };
+  };
+  tickComponent?: React.ReactElement;
+  tickCount?: number;
+  tickLabelComponent?: React.ReactElement;
+  tickFormat?: any[] | { (tick: any, index: number, ticks: any[]): string | number };
+  tickValues?: any[];
+}
+
+/**
+ * VictoryAxis draws an SVG chart axis with React.
+ * Styles and data can be customized by passing in your own values as properties to the component.
+ * Data changes are animated with VictoryAnimation.
+ */
+export class VictoryAxis extends React.Component<VictoryAxisProps, any> {}

--- a/packages/victory-bar/src/index.d.ts
+++ b/packages/victory-bar/src/index.d.ts
@@ -1,0 +1,47 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  EventPropTypeInterface,
+  NumberOrCallback,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryDatableProps,
+  VictoryMultiLabeableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryBarProps extends VictoryCommonProps, VictoryDatableProps, VictoryMultiLabeableProps {
+  alignment?: "start" | "middle" | "end";
+  barRatio?: number;
+  barWidth?: NumberOrCallback;
+  cornerRadius?:
+    | NumberOrCallback
+    | {
+        top?: NumberOrCallback;
+        topLeft?: NumberOrCallback;
+        topRight?: NumberOrCallback;
+        bottom?: NumberOrCallback;
+        bottomLeft?: NumberOrCallback;
+        bottomRight?: NumberOrCallback;
+      };
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", number | string>[];
+  eventKey?: StringOrNumberOrCallback;
+  horizontal?: boolean;
+  style?: VictoryStyleInterface;
+}
+
+/**
+ * Draw SVG bar charts with React. VictoryBar is a composable component, so it doesn"t include axes
+ * Check out VictoryChart for complete bar charts and more.
+ */
+export class VictoryBar extends React.Component<VictoryBarProps, any> {}

--- a/packages/victory-box-plot/src/index.d.ts
+++ b/packages/victory-box-plot/src/index.d.ts
@@ -1,0 +1,65 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  EventPropTypeInterface,
+  DomainPropType,
+  DomainPaddingPropType,
+  StringOrNumberOrCallback,
+  VictoryDatableProps,
+  VictoryCommonProps,
+  VictoryStyleInterface,
+  VictoryStyleObject
+} from "victory-core";
+
+export interface VictoryBoxPlotStyleInterface extends VictoryStyleInterface {
+  max?: VictoryStyleObject;
+  maxLabels?: VictoryStyleObject;
+  min?: VictoryStyleObject;
+  minLabels?: VictoryStyleObject;
+  median?: VictoryStyleObject;
+  medianLabels?: VictoryStyleObject;
+  q1?: VictoryStyleObject;
+  q1Labels?: VictoryStyleObject;
+  q3?: VictoryStyleObject;
+  q3Labels?: VictoryStyleObject;
+}
+
+export interface VictoryBoxPlotProps extends VictoryCommonProps, VictoryDatableProps {
+  boxWidth?: number;
+  domain?: DomainPropType;
+  domainPadding?: DomainPaddingPropType;
+  events?: EventPropTypeInterface<string, StringOrNumberOrCallback>[];
+  eventKey?: StringOrNumberOrCallback;
+  horizontal?: boolean;
+  labelOrientation?: "top" | "bottom" | "left" | "right";
+  labels?: boolean;
+  max?: StringOrNumberOrCallback | string[];
+  maxComponent?: React.ReactElement;
+  maxLabelComponent?: React.ReactElement;
+  median?: StringOrNumberOrCallback | string[];
+  medianComponent?: React.ReactElement;
+  medianLabelComponent?: React.ReactElement;
+  min?: StringOrNumberOrCallback | string[];
+  minComponent?: React.ReactElement;
+  minLabelComponent?: React.ReactElement;
+  q1?: StringOrNumberOrCallback | string[];
+  q1Component?: React.ReactElement;
+  q1LabelComponent?: React.ReactElement;
+  q3?: StringOrNumberOrCallback | string[];
+  q3Component?: React.ReactElement;
+  q3LabelComponent?: React.ReactElement;
+  style?: VictoryBoxPlotStyleInterface;
+  whiskerWidth?: number;
+}
+
+export class VictoryBoxPlot extends React.Component<VictoryBoxPlotProps, any> {}

--- a/packages/victory-brush-container/src/index.d.ts
+++ b/packages/victory-brush-container/src/index.d.ts
@@ -1,0 +1,29 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import { DomainPropType, VictoryContainerProps } from "victory-core";
+
+export interface VictoryBrushContainerProps extends VictoryContainerProps {
+  allowDrag?: boolean;
+  allowResize?: boolean;
+  brushComponent?: React.ReactElement;
+  brushDimension?: "x" | "y";
+  brushDomain?: DomainPropType;
+  brushStyle?: React.CSSProperties;
+  defaultBrushArea?: "all" | "none" | "disable";
+  disable?: boolean;
+  handleComponent?: React.ReactElement;
+  handleStyle?: React.CSSProperties;
+  onBrushDomainChange?: (domain: DomainPropType, props: VictoryBrushContainerProps) => void;
+}
+
+export class VictoryBrushContainer extends React.Component<VictoryBrushContainerProps, any> {}

--- a/packages/victory-chart/src/index.d.ts
+++ b/packages/victory-chart/src/index.d.ts
@@ -1,0 +1,30 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  EventPropTypeInterface,
+  DomainPropType,
+  DomainPaddingPropType,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryChartProps extends VictoryCommonProps {
+  domain?: DomainPropType;
+  domainPadding?: DomainPaddingPropType;
+  events?: EventPropTypeInterface<string, StringOrNumberOrCallback>[];
+  eventKey?: StringOrNumberOrCallback;
+  style?: Pick<VictoryStyleInterface, "parent">;
+}
+
+export class VictoryChart extends React.Component<VictoryChartProps, any> {}

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -1,0 +1,505 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export type ScatterSymbolType = "circle" | "diamond" | "plus" | "square" | "star" | "triangleDown" | "triangleUp";
+
+/**
+ * @see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+ */
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export type BlockProps = {
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
+};
+
+export type PaddingProps = number | BlockProps;
+
+/**
+ * This is the first parameter of a callback when a callback is used to
+ * resolve the value of a property instead of a concrete value.
+ *
+ * Note that additional properties here like `scale`, `x`, `y`, etc are resolved
+ * values of properties from the VictoryXXXProps for each component.
+ */
+export interface CallbackArgs {
+  active: boolean;
+  datum: any;
+  horizontal: boolean;
+  x: number;
+  y: number;
+  scale?: {
+    x?: D3Scale;
+    y?: D3Scale;
+  };
+}
+
+export type VictoryStringOrNumberCallback = (args: CallbackArgs) => string | number;
+export type VictoryNumberCallback = (args: CallbackArgs) => number;
+export type StringOrNumberOrCallback = string | number | VictoryStringOrNumberCallback;
+export type NumberOrCallback = number | VictoryNumberCallback;
+
+export type SliceNumberOrCallback<T, P = null> = number | ((props: Omit<T, P>) => number);
+
+export type VictoryStyleObject = { [K in keyof React.CSSProperties]: StringOrNumberOrCallback };
+
+export type CursorData = {
+  x: number;
+  y: number;
+};
+
+export type OrientationTypes = "top" | "bottom" | "left" | "right";
+
+/**
+ * Style interface used in components/themeing
+ */
+export interface VictoryStyleInterface {
+  parent?: VictoryStyleObject;
+  data?: VictoryStyleObject;
+  labels?: VictoryStyleObject;
+}
+
+// #region Victory Animation
+
+export interface VictoryAnimationProps {
+  children?: (style: AnimationStyle) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data?: AnimationData;
+}
+
+export class VictoryAnimation extends React.Component<VictoryAnimationProps, any> {}
+
+// #endregion
+
+// #region Victory Label
+
+export type TextAnchorType = "start" | "middle" | "end" | "inherit";
+export type VerticalAnchorType = "start" | "middle" | "end";
+
+export interface VictoryLabelProps {
+  angle?: string | number;
+  capHeight?: StringOrNumberOrCallback;
+  className?: string;
+  datum?: {};
+  data?: any[];
+  events?: React.DOMAttributes<any>;
+  children?: StringOrNumberOrCallback;
+  labelPlacement?: "parallel" | "perpendicular" | "vertical";
+  lineHeight?: StringOrNumberOrCallback;
+  origin?: { x: number; y: number };
+  polar?: boolean;
+  renderInPortal?: boolean;
+  style?: React.CSSProperties | React.CSSProperties[];
+  text?: string[] | StringOrNumberOrCallback;
+  textAnchor?: TextAnchorType | { (): TextAnchorType };
+  verticalAnchor?: VerticalAnchorType | { (): VerticalAnchorType };
+  transform?: string | {} | { (): string | {} };
+  x?: number;
+  y?: number;
+  dx?: StringOrNumberOrCallback;
+  dy?: StringOrNumberOrCallback;
+}
+
+export class VictoryLabel extends React.Component<VictoryLabelProps, any> {}
+
+// #endregion
+
+// #region Victory Container
+
+export interface VictoryContainerProps {
+  responsive?: boolean;
+  style?: React.CSSProperties;
+  height?: number;
+  width?: number;
+  events?: React.DOMAttributes<any>;
+  title?: string;
+  desc?: string;
+}
+
+export class VictoryContainer extends React.Component<VictoryContainerProps, any> {}
+
+// #endregion
+
+// #region Victory Clip Container
+
+export interface VictoryClipContainerProps {
+  children?: React.ReactElement | React.ReactElement[];
+  circleComponent?: React.ReactElement;
+  className?: string;
+  clipHeight?: number;
+  clipId?: number | string;
+  clipPadding?: BlockProps;
+  clipPathComponent?: React.ReactElement;
+  clipWidth?: number;
+  events?: React.DOMAttributes<any>;
+  groupComponent?: React.ReactElement;
+  origin?: {
+    x?: number;
+    y?: number;
+  };
+  polar?: boolean;
+  radius?: number;
+  rectComponent?: React.ReactElement;
+  translateX?: number;
+  translateY?: number;
+}
+
+export class VictoryClipContainer extends React.Component<VictoryClipContainerProps, any> {}
+
+// #endregion
+
+// #region Victory Theme
+
+export type ThemeBaseProps = {
+  width: number;
+  height: number;
+  colorScale: string[];
+  padding?: number;
+};
+
+// Note: Many SVG attributes are missed in CSSProperties interface
+export interface VictoryThemeDefinition {
+  area?: {
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  axis?: {
+    style?: {
+      axis?: React.CSSProperties;
+      axisLabel?: React.CSSProperties;
+      grid?: React.CSSProperties;
+      ticks?: React.CSSProperties;
+      tickLabels?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  bar?: {
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  boxplot?: {
+    style?: {
+      max?: React.CSSProperties;
+      maxLabels?: React.CSSProperties;
+      median?: React.CSSProperties;
+      medianLabels?: React.CSSProperties;
+      min?: React.CSSProperties;
+      minLabels?: React.CSSProperties;
+      q1?: React.CSSProperties;
+      q1Labels?: React.CSSProperties;
+      q3?: React.CSSProperties;
+      q3Labels?: React.CSSProperties;
+    };
+    boxWidth?: number;
+  } & ThemeBaseProps;
+  candlestick?: {
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+    };
+    candleColors?: {
+      positive?: string;
+      negative?: string;
+    };
+  } & ThemeBaseProps;
+  chart?: ThemeBaseProps;
+  errorbar?: {
+    borderWidth?: number;
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  group?: ThemeBaseProps;
+  legend?: {
+    gutter?: number;
+    orientation?: "vertical" | "horizontal";
+    titleOrientation?: OrientationTypes;
+    style?: {
+      data?: React.CSSProperties & {
+        type?: ScatterSymbolType;
+      };
+      labels?: React.CSSProperties;
+      title?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  line?: {
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  pie?: {
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  scatter?: {
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+  stack?: ThemeBaseProps;
+  tooltip?: {
+    style?: React.CSSProperties;
+    flyoutStyle?: React.CSSProperties;
+    cornerRadius?: number;
+    pointerLength?: number;
+  };
+  voronoi?: {
+    style?: {
+      data?: React.CSSProperties;
+      labels?: React.CSSProperties;
+      flyout?: React.CSSProperties;
+    };
+  } & ThemeBaseProps;
+}
+
+export interface VictoryThemeInterface {
+  grayscale: VictoryThemeDefinition;
+  material: VictoryThemeDefinition;
+}
+
+export const VictoryTheme: VictoryThemeInterface;
+
+// #endregion
+
+// #region Victory Util
+
+export interface AnimatePropTypeInterface {
+  duration: number;
+  onEnd?: () => void;
+  onExit?: {
+    duration?: number;
+    before?: (datum: any) => AnimationStyle;
+  };
+  onEnter?: {
+    duration?: number;
+    before?: (datum: any) => AnimationStyle;
+    after?: (datum: any) => AnimationStyle;
+  };
+  onLoad?: {
+    duration?: number;
+    before?: (datum: any) => AnimationStyle;
+    after?: (datum: any) => AnimationStyle;
+  };
+  easing?: AnimationEasing;
+}
+
+export interface EventCallbackInterface<TTarget, TEventKey> {
+  childName?: string;
+  target?: TTarget;
+  eventKey?: TEventKey;
+  mutation: (props: any) => any;
+}
+
+export interface EventPropTypeInterface<TTarget, TEventKey> {
+  childName?: string;
+  target: TTarget;
+  eventKey?: TEventKey;
+  eventHandlers: {
+    [key: string]:
+      | {
+          (event: React.SyntheticEvent<any>): EventCallbackInterface<TTarget, TEventKey>;
+        }
+      | {
+          (event: React.SyntheticEvent<any>): EventCallbackInterface<TTarget, TEventKey>[];
+        };
+  };
+}
+
+export type DomainTuple = [number, number] | [Date, Date];
+export type DomainPropType = DomainTuple | { x?: DomainTuple; y: DomainTuple } | { x: DomainTuple; y?: DomainTuple };
+
+export type DomainPaddingPropType =
+  | number
+  | {
+      x?: number | [number, number];
+      y?: number | [number, number];
+    };
+
+/**
+ * D3 scale function shape. Don"t want to introduce typing dependency to d3
+ */
+export interface D3Scale {
+  (input: string | number): number;
+  domain: () => any;
+  range: () => any;
+  copy: () => any;
+}
+
+export type ScalePropType = "linear" | "time" | "log" | "sqrt";
+
+export type CategoryPropType =
+  | string[]
+  | { x: string[] }
+  | { y: string[] }
+  | {
+      x: string[];
+      y: string[];
+    };
+
+export type DataGetterPropType = number | string | string[] | { (data: any): number | string | string[] };
+
+export type InterpolationPropType =
+  | "basis"
+  | "basisClosed"
+  | "basisOpen"
+  | "bundle"
+  | "cardinal"
+  | "cardinalClosed"
+  | "cardinalOpen"
+  | "catmullRom"
+  | "catmullRomClosed"
+  | "catmullRomOpen"
+  | "linear"
+  | "linearClosed"
+  | "monotoneX"
+  | "monotoneY"
+  | "natural"
+  | "radial"
+  | "step"
+  | "stepAfter"
+  | "stepBefore";
+
+export type ColorScalePropType =
+  | "greyscale"
+  | "qualitative"
+  | "heatmap"
+  | "warm"
+  | "cool"
+  | "red"
+  | "green"
+  | "blue"
+  | string[];
+
+export interface VictoryCommonProps {
+  animate?: boolean | AnimatePropTypeInterface;
+  name?: string;
+  height?: number;
+  horizontal?: boolean;
+  maxDomain?: number | { x?: number; y?: number };
+  minDomain?: number | { x?: number; y?: number };
+  padding?: PaddingProps;
+  scale?:
+    | ScalePropType
+    | D3Scale
+    | {
+        x?: ScalePropType | D3Scale;
+        y?: ScalePropType | D3Scale;
+      };
+  singleQuadrantDomainPadding?: boolean | { x?: boolean; y?: boolean };
+  standalone?: boolean;
+  width?: number;
+  containerComponent?: React.ReactElement;
+  theme?: VictoryThemeDefinition;
+  groupComponent?: React.ReactElement;
+}
+
+export interface VictoryDatableProps {
+  categories?: CategoryPropType;
+  data?: any[];
+  dataComponent?: React.ReactElement;
+  domain?: DomainPropType;
+  x?: DataGetterPropType;
+  y?: DataGetterPropType;
+  y0?: DataGetterPropType;
+}
+
+export interface VictoryLabableProps {
+  labelComponent?: React.ReactElement;
+}
+
+export interface VictoryMultiLabeableProps extends VictoryLabableProps {
+  labels?: string[] | { (data: any): string };
+}
+
+export interface VictorySingleLabableProps extends VictoryLabableProps {
+  label?: string | { (data: any): string };
+}
+
+// #endregion
+
+// #region Victory Portal
+
+export interface VictoryPortalProps {
+  children?: React.ReactElement;
+  groupComponent?: React.ReactElement;
+}
+
+export class VictoryPortal extends React.Component<VictoryPortalProps, any> {}
+
+// #endregion

--- a/packages/victory-create-container/src/index.d.ts
+++ b/packages/victory-create-container/src/index.d.ts
@@ -1,0 +1,15 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+
+export type ContainerType = "brush" | "cursor" | "selection" | "voronoi" | "zoom";
+export function createContainer<V, W>(c1: ContainerType, c2: ContainerType): React.ComponentType<V & W>;

--- a/packages/victory-cursor-container/src/index.d.ts
+++ b/packages/victory-cursor-container/src/index.d.ts
@@ -1,0 +1,26 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import { VictoryContainerProps, CursorData } from "victory-core";
+
+export interface VictoryCursorContainerProps extends VictoryContainerProps {
+  cursorComponent?: React.ReactElement;
+  cursorDimension?: "x" | "y";
+  cursorLabel?: (point: CursorData) => void;
+  cursorLabelComponent?: React.ReactElement;
+  cursorLabelOffset?: number | CursorData;
+  defaultCursorValue?: number | CursorData;
+  disable?: boolean;
+  onCursorChange?: (value: CursorData, props: VictoryCursorContainerProps) => void;
+}
+
+export class VictoryCursorContainer extends React.Component<VictoryCursorContainerProps, any> {}

--- a/packages/victory-group/src/index.d.ts
+++ b/packages/victory-group/src/index.d.ts
@@ -1,0 +1,39 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  CategoryPropType,
+  ColorScalePropType,
+  DomainPropType,
+  DomainPaddingPropType,
+  EventPropTypeInterface,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryDatableProps,
+  VictoryMultiLabeableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryGroupProps extends VictoryCommonProps, VictoryDatableProps, VictoryMultiLabeableProps {
+  categories?: CategoryPropType;
+  color?: string;
+  colorScale?: ColorScalePropType;
+  domain?: DomainPropType;
+  domainPadding?: DomainPaddingPropType;
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback>[];
+  eventKey?: StringOrNumberOrCallback;
+  horizontal?: boolean;
+  offset?: number;
+  style?: VictoryStyleInterface;
+}
+
+export class VictoryGroup extends React.Component<VictoryGroupProps, any> {}

--- a/packages/victory-legend/src/index.d.ts
+++ b/packages/victory-legend/src/index.d.ts
@@ -1,0 +1,56 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  BlockProps,
+  ColorScalePropType,
+  EventPropTypeInterface,
+  OrientationTypes,
+  PaddingProps,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryDatableProps,
+  VictorySingleLabableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryLegendProps extends VictoryCommonProps, VictoryDatableProps, VictorySingleLabableProps {
+  borderComponent?: React.ReactElement;
+  borderPadding?: PaddingProps;
+  centerTitle?: boolean;
+  colorScale?: ColorScalePropType;
+  data?: Array<{
+    name?: string;
+    symbol?: {
+      fill?: string;
+      type?: string;
+    };
+  }>;
+  dataComponent?: React.ReactElement;
+  eventKey?: StringOrNumberOrCallback | string[];
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback>[];
+  externalEventMutations?: any[];
+  gutter?: number | { left: number; right: number };
+  itemsPerRow?: number;
+  labelComponent?: React.ReactElement;
+  orientation?: "horizontal" | "vertical";
+  rowGutter?: number | Omit<BlockProps, "left" | "right">;
+  style?: VictoryStyleInterface;
+  symbolSpacer?: number;
+  title?: string | string[];
+  titleComponent?: React.ReactElement;
+  titleOrientation?: OrientationTypes;
+  x?: number;
+  y?: number;
+}
+
+export class VictoryLegend extends React.Component<VictoryLegendProps, any> {}

--- a/packages/victory-line/src/index.d.ts
+++ b/packages/victory-line/src/index.d.ts
@@ -1,0 +1,31 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  EventPropTypeInterface,
+  InterpolationPropType,
+  VictoryCommonProps,
+  VictoryDatableProps,
+  VictorySingleLabableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryLineProps extends VictoryCommonProps, VictoryDatableProps, VictorySingleLabableProps {
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", number | string>[];
+  interpolation?: InterpolationPropType;
+  samples?: number;
+  labels?: string[] | number[] | Function;
+  sortKey?: string | string[] | Function;
+  style?: VictoryStyleInterface;
+}
+
+export class VictoryLine extends React.Component<VictoryLineProps, any> {}

--- a/packages/victory-pie/src/index.d.ts
+++ b/packages/victory-pie/src/index.d.ts
@@ -1,0 +1,63 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  ColorScalePropType,
+  DataGetterPropType,
+  EventPropTypeInterface,
+  SliceNumberOrCallback,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryMultiLabeableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictorySliceProps extends VictoryCommonProps {
+  cornerRadius?: SliceNumberOrCallback<VictorySliceProps, "cornerRadius">;
+  datum?: object;
+  innerRadius?: number | ((props: {
+    active?: boolean,
+    datum?: object,
+  }) => number);
+  padAngle?: SliceNumberOrCallback<VictorySliceProps, "padAngle">;
+  pathComponent?: React.ReactElement;
+  pathFunction?: (props: VictorySliceProps) => string;
+  radius?: SliceNumberOrCallback<VictorySliceProps, "radius">;
+  slice: {
+    startAngle?: number;
+    endAngle?: number;
+    padAngle?: number;
+    data?: any[];
+  };
+  sliceEndAngle?: SliceNumberOrCallback<VictorySliceProps, "sliceEndAngle">;
+  sliceStartAngle?: SliceNumberOrCallback<VictorySliceProps, "sliceStartAngle">;
+}
+
+export interface VictoryPieProps extends VictoryCommonProps, VictoryMultiLabeableProps {
+  colorScale?: ColorScalePropType;
+  data?: any[];
+  dataComponent?: React.ReactElement;
+  labelRadius?: number;
+  endAngle?: number;
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback | string[] | number[]>[];
+  eventKey?: StringOrNumberOrCallback;
+  radius?: number;
+  innerRadius?: number | ((props: VictorySliceProps) => number);
+  cornerRadius?: number;
+  padAngle?: number;
+  startAngle?: number;
+  style?: VictoryStyleInterface;
+  x?: DataGetterPropType;
+  y?: DataGetterPropType;
+}
+
+export class VictoryPie extends React.Component<VictoryPieProps, any> {}

--- a/packages/victory-scatter/src/index.d.ts
+++ b/packages/victory-scatter/src/index.d.ts
@@ -1,0 +1,34 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  EventPropTypeInterface,
+  ScatterSymbolType,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryDatableProps,
+  VictoryMultiLabeableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryScatterProps extends VictoryCommonProps, VictoryDatableProps, VictoryMultiLabeableProps {
+  bubbleProperty?: string;
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback>[];
+  eventKey?: StringOrNumberOrCallback;
+  maxBubbleSize?: number;
+  samples?: number;
+  size?: number | { (data: any): number };
+  style?: VictoryStyleInterface;
+  symbol?: ScatterSymbolType | { (data: any): ScatterSymbolType };
+}
+
+export class VictoryScatter extends React.Component<VictoryScatterProps, any> {}

--- a/packages/victory-stack/src/index.d.ts
+++ b/packages/victory-stack/src/index.d.ts
@@ -1,0 +1,37 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  CategoryPropType,
+  ColorScalePropType,
+  DomainPaddingPropType,
+  DomainPropType,
+  EventPropTypeInterface,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryMultiLabeableProps,
+  VictoryStyleInterface
+} from "victory-core";
+
+export interface VictoryStackProps extends VictoryCommonProps, VictoryMultiLabeableProps {
+  categories?: CategoryPropType;
+  colorScale?: ColorScalePropType;
+  domain?: DomainPropType;
+  domainPadding?: DomainPaddingPropType;
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback>[];
+  eventKey?: StringOrNumberOrCallback;
+  horizontal?: boolean;
+  style?: VictoryStyleInterface;
+  xOffset?: number;
+}
+
+export class VictoryStack extends React.Component<VictoryStackProps, any> {}

--- a/packages/victory-tooltip/src/index.d.ts
+++ b/packages/victory-tooltip/src/index.d.ts
@@ -1,0 +1,86 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import {
+  OrientationTypes,
+  NumberOrCallback,
+  StringOrNumberOrCallback,
+  VictoryCommonProps,
+  VictoryNumberCallback,
+  VictoryThemeDefinition,
+  VictoryStyleObject
+} from "victory-core";
+
+export interface VictoryTooltipProps {
+  active?: boolean;
+  activateData?: boolean;
+  angle?: string | number;
+  cornerRadius?: NumberOrCallback;
+  datum?: {};
+  data?: any[];
+  dx?: StringOrNumberOrCallback;
+  dy?: StringOrNumberOrCallback;
+  events?: {};
+  flyoutHeight?: NumberOrCallback;
+  flyoutWidth?: NumberOrCallback;
+  flyoutStyle?: VictoryStyleObject;
+  flyoutComponent?: React.ReactElement;
+  groupComponent?: React.ReactElement;
+  height?: number;
+  horizontal?: boolean;
+  index?: number | string;
+  labelComponent?: React.ReactElement;
+  orientation?: OrientationTypes | VictoryNumberCallback;
+  pointerLength?: NumberOrCallback;
+  pointerWidth?: NumberOrCallback;
+  renderInPortal?: boolean;
+  style?: React.CSSProperties;
+  text?: StringOrNumberOrCallback | string[] | number[];
+  theme?: VictoryThemeDefinition;
+  width?: number;
+  x?: number;
+  y?: number;
+}
+
+export interface FlyoutProps extends VictoryCommonProps {
+  active?: boolean;
+  center?: {
+    x?: number;
+    y?: number;
+  };
+  className?: string;
+  cornerRadius?: number;
+  data?: any[];
+  datum?: object;
+  dx?: number;
+  dy?: number;
+  events?: object;
+  height?: number;
+  id?: string | number;
+  index?: number;
+  orientation?: "top" | "bottom" | "left" | "right";
+  origin?: object;
+  pathComponent?: React.ReactElement;
+  pointerLength?: number;
+  pointerWidth?: number;
+  polar?: boolean;
+  role?: string;
+  shapeRendering?: string;
+  style?: VictoryStyleObject;
+  transform?: string;
+  width?: number;
+  x?: number;
+  y?: number;
+}
+
+export class Flyout extends React.Component<FlyoutProps, any> {}
+export class VictoryTooltip extends React.Component<VictoryTooltipProps, any> {}

--- a/packages/victory-voronoi-container/src/index.d.ts
+++ b/packages/victory-voronoi-container/src/index.d.ts
@@ -1,0 +1,29 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import { VictoryContainerProps, CursorData } from "victory-core";
+
+export interface VictoryVoronoiContainerProps extends VictoryContainerProps {
+  activateData?: boolean;
+  activateLabels?: boolean;
+  disable?: boolean;
+  labels?: (point: any, index: number, points: any[]) => string;
+  labelComponent?: React.ReactElement;
+  onActivated?: (points: any[], props: VictoryVoronoiContainerProps) => void;
+  onDeactivated?: (points: any[], props: VictoryVoronoiContainerProps) => void;
+  radius?: number;
+  voronoiBlacklist?: string[];
+  voronoiDimension?: "x" | "y";
+  voronoiPadding?: number;
+}
+
+export class VictoryVoronoiContainer extends React.Component<VictoryVoronoiContainerProps, any> {}

--- a/packages/victory-zoom-container/src/index.d.ts
+++ b/packages/victory-zoom-container/src/index.d.ts
@@ -1,0 +1,29 @@
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 snerks <https://github.com/snerks>
+//                 Krzysztof Cebula <https://github.com/Havret>
+//                 Vitaliy Polyanskiy <https://github.com/alreadyExisted>
+//                 James Lismore <https://github.com/jlismore>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban Ibarra <https://github.com/ibarrae>
+//                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
+//                 Alec Flett <https://github.com/alecf>
+
+import * as React from "react";
+import { DomainPropType, VictoryContainerProps, CursorData } from "victory-core";
+
+export interface VictoryZoomContainerProps extends VictoryContainerProps {
+  allowPan?: boolean;
+  allowZoom?: boolean;
+  clipContainerComponent?: React.ReactElement;
+  zoomDimension?: "x" | "y";
+  zoomDomain?: DomainPropType;
+  brushStyle?: React.CSSProperties;
+  defaultBrushArea?: "all" | "none" | "disable";
+  disable?: boolean;
+  downsample?: number | boolean;
+  minimumZoom?: CursorData;
+  onZoomDomainChange?: (domain: DomainPropType, props: VictoryZoomContainerProps) => void;
+}
+
+export class VictoryZoomContainer extends React.Component<VictoryZoomContainerProps, any> {}

--- a/packages/victory/src/index.d.ts
+++ b/packages/victory/src/index.d.ts
@@ -1,0 +1,201 @@
+// TODO: Add missing type definitions for all import/export
+// items that are commented out.
+
+declare module "victory" {
+  import {
+    // Border,
+    // Box,
+    // ClipPath,
+    // LineSegment,
+    // Whisker,
+    // Circle,
+    // Rect,
+    // Line,
+    // Path,
+    // TSpan,
+    // Text,
+    // Point,
+    VictoryAnimation,
+    VictoryContainer,
+    VictoryLabel,
+    VictoryTheme,
+    // VictoryTransition,
+    VictoryPortal,
+    // Portal,
+    VictoryClipContainer,
+    // addEvents,
+    // Collection,
+    // Data,
+    // DefaultTransitions,
+    // Domain,
+    // Events,
+    // Helpers,
+    // Log,
+    // PropTypes,
+    // Scale,
+    // Style,
+    // TextSize,
+    // Transitions,
+    // Selection,
+    // LabelHelpers,
+    // Axis,
+    // Wrapper
+  } from "victory-core";
+
+  import { VictoryChart } from "victory-chart";
+  import { VictoryGroup } from "victory-group";
+  import { VictoryStack } from "victory-stack";
+  import {
+    VictoryPie,
+    // Slice
+  } from "victory-pie"
+  import {
+    VictoryArea,
+    // Area
+  } from "victory-area";
+  import {
+    VictoryBar,
+    // Bar
+  } from "victory-bar";
+
+  // import { VictoryCandlestick, Candle } from "victory-candlestick";
+  // import { VictoryErrorBar, ErrorBar } from "victory-errorbar";
+
+  import {
+    VictoryLine,
+    // Curve
+  } from "victory-line";
+  import { VictoryScatter } from "victory-scatter";
+  import { VictoryBoxPlot } from "victory-box-plot";
+
+  // import { VictoryVoronoi, Voronoi } from "victory-voronoi";
+  // import { VictoryBrushLine } from "victory-brush-line";
+
+  import {
+    VictoryBrushContainer,
+    // BrushHelpers,
+    // brushContainerMixin
+  } from "victory-brush-container";
+  import {
+    VictoryCursorContainer,
+    // CursorHelpers,
+    // cursorContainerMixin
+  } from "victory-cursor-container";
+
+  // import {
+  //   VictorySelectionContainer,
+  //   SelectionHelpers,
+  //   selectionContainerMixin
+  // } from "victory-selection-container";
+
+  import {
+    VictoryVoronoiContainer,
+    // VoronoiHelpers,
+    // voronoiContainerMixin
+  } from "victory-voronoi-container";
+  import {
+    VictoryZoomContainer,
+    // ZoomHelpers,
+    // zoomContainerMixin,
+    // RawZoomHelpers
+  } from "victory-zoom-container";
+  import {
+    // combineContainerMixins,
+    // makeCreateContainerFunction,
+    createContainer
+  } from "victory-create-container";
+
+  import { VictoryTooltip, Flyout } from "victory-tooltip";
+  import { VictoryLegend } from "victory-legend";
+
+  // import { VictorySharedEvents } from "victory-shared-events";
+
+  import { VictoryAxis } from "victory-axis";
+
+  // import { VictoryPolarAxis } from "victory-polar-axis";
+
+  export {
+    // Area,
+    // Bar,
+    // Border,
+    // Box,
+    // Candle,
+    // ClipPath,
+    // Curve,
+    // ErrorBar,
+    // LineSegment,
+    // Point,
+    // Slice,
+    // Voronoi,
+    Flyout,
+    // Whisker,
+    // Circle,
+    // Rect,
+    // Line,
+    // Path,
+    // TSpan,
+    // Text,
+    VictoryAnimation,
+    VictoryArea,
+    VictoryAxis,
+    // VictoryPolarAxis,
+    VictoryBar,
+    VictoryBoxPlot,
+    // VictoryCandlestick,
+    VictoryChart,
+    // VictoryErrorBar,
+    VictoryGroup,
+    VictoryLine,
+    VictoryLabel,
+    VictoryLegend,
+    VictoryPie,
+    VictoryScatter,
+    VictoryStack,
+    VictoryTheme,
+    // VictoryTransition,
+    // VictorySharedEvents,
+    VictoryTooltip,
+    // VictoryVoronoi,
+    VictoryPortal,
+    // Portal,
+    VictoryContainer,
+    VictoryClipContainer,
+    VictoryZoomContainer,
+    // ZoomHelpers,
+    // zoomContainerMixin,
+    // RawZoomHelpers,
+    // VictorySelectionContainer,
+    // SelectionHelpers,
+    // selectionContainerMixin,
+    VictoryBrushContainer,
+    // BrushHelpers,
+    // brushContainerMixin,
+    VictoryCursorContainer,
+    // CursorHelpers,
+    // cursorContainerMixin,
+    VictoryVoronoiContainer,
+    // VoronoiHelpers,
+    // voronoiContainerMixin,
+    // combineContainerMixins,
+    // makeCreateContainerFunction,
+    createContainer,
+    // VictoryBrushLine,
+    // addEvents,
+    // Collection,
+    // Data,
+    // DefaultTransitions,
+    // Domain,
+    // Events,
+    // Helpers,
+    // Log,
+    // PropTypes,
+    // Scale,
+    // Style,
+    // TextSize,
+    // Transitions,
+    // Selection,
+    // LabelHelpers,
+    // Axis,
+    // Wrapper
+  };
+}


### PR DESCRIPTION
This PR imports the latest typescript definitions from definitely typed!  It's set to merge into a feature branch (`feature/typescript-defs`) so we can work out any kinks/typos before pushing to master.  This is the first of a few PRs.

**Upcoming PRs will add the following**
- Lint support for our typescript files.
- Demo project written in typescript.
- More type definitions (definitely typed did _not_ cover all packages)

**NOTE:**  If you take a look at the `index.d.ts` file in the main `victory` folder, you'll notice a lot of lines commented out.  Each import/export line commented out is an item that still needs type defs in order to fully cover the entire list of victory features.