### PR TITLE
fix: Missing package.json dep - react-fast-compare

### DIFF
--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
+    "react-fast-compare": "^2.0.0",
     "victory-core": "^34.0.0"
   },
   "scripts": {


### PR DESCRIPTION
As per this [case study](https://github.com/yarnpkg/berry/issues/843), victory-brush-container is missing a reference to `react-fast-compare`