### PR TITLE
Fixed typescript props bug and added typescript compile to linting process

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -20,7 +20,6 @@ module.exports = {
       default: "karma start ./config/karma/karma.conf.js"
     },
     test: {
-      ci: npsUtils.series.nps("build-package-libs", "karma.ci"),
       cov: npsUtils.series.nps("build-package-libs", "karma.cov"),
       dev: "karma start ./config/karma/karma.conf.dev.js",
       default: npsUtils.series.nps("build-package-libs", "karma")
@@ -39,12 +38,14 @@ module.exports = {
       stories: "eslint --color stories",
       storybook: "eslint --color --no-ignore .storybook/config.js",
       test: "eslint --color test",
+      ts: npsUtils.series.nps("build-package-libs", "compile-ts"),
       default: npsUtils.series.nps(
         "lint.test",
         "lint.stories",
         "lint.storybook",
         "lint.demo",
-        "lint.src"
+        "lint.src",
+        "lint.ts"
       )
     },
     format: {
@@ -52,7 +53,7 @@ module.exports = {
       ci: 'prettier --list-different "./**/*.{js,jsx,json,ts,tsx}"'
     },
     check: {
-      ci: npsUtils.series.nps("format.ci", "lint", "test.ci"),
+      ci: npsUtils.series.nps("format.ci", "lint", "karma.ci"),
       cov: npsUtils.series.nps("lint", "test.cov"),
       dev: npsUtils.series.nps("lint", "test.dev"),
       default: npsUtils.series.nps("lint", "test")
@@ -71,6 +72,7 @@ module.exports = {
       default: npsUtils.concurrent.nps("clean.es", "clean.lib", "clean.dist"),
       all: "lerna exec --parallel -- nps clean"
     },
+    "compile-ts": "tsc --project tsconfig.json --noEmit",
     // Version testing helpers
     "lerna-dry-run": "lerna publish --skip-git --skip-npm --loglevel silly",
     // TODO: organize build scripts once build perf is sorted out

--- a/packages/victory-chart/src/index.d.ts
+++ b/packages/victory-chart/src/index.d.ts
@@ -11,6 +11,7 @@
 
 import * as React from "react";
 import {
+  CategoryPropType,
   EventPropTypeInterface,
   DomainPropType,
   DomainPaddingPropType,
@@ -20,6 +21,7 @@ import {
 } from "victory-core";
 
 export interface VictoryChartProps extends VictoryCommonProps {
+  categories?: CategoryPropType;
   domain?: DomainPropType;
   domainPadding?: DomainPaddingPropType;
   events?: EventPropTypeInterface<string, StringOrNumberOrCallback>[];

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -487,7 +487,6 @@ export type ColorScalePropType =
 
 export interface VictoryCommonProps {
   animate?: boolean | AnimatePropTypeInterface;
-  categories?: string | { x?: string[]; y?: string[] };
   name?: string;
   height?: number;
   horizontal?: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,8 @@
     }
   },
   "include": [
-    "**/*.ts",
-    "**/*.tsx"
+    "**/src/*",
+    "demo/ts/*"
   ],
   "exclude": [
       "node_modules",


### PR DESCRIPTION
This PR fixes a small bug I found in the typescript definitions that wasn't caught by `eslint`.  

After some googling, I realized that `typescript-eslint` does not catch very specific typescript errors (like interface errors, or type mis-match errors).  So the best way to ensure that all the typescript code (and definition files) are correct is to use `tsc` to compile the typescript files in the project. `tsc` will catch any type errors that `typescript-eslint` misses.

So, I added `lint.ts` to our linting pipeline.  It will simply build the typescript files (with no output generated thanks to the `noEmit` flag) and report any build errors.  This caught the bug in our definitions, so I was able to fix it and re-lint and voila things are working!

**Note:** The bug was that `VictoryCommonProps` and another interface both defined the same prop `categories` (it was a mistake I introduced when fleshing out the demos).  This isn't a breaking bug, just an annoying warning about duplicate definitions.  