### PR TITLE
Fix VictoryLegendProps style typing by adding title property

### DIFF
--- a/packages/victory-legend/src/index.d.ts
+++ b/packages/victory-legend/src/index.d.ts
@@ -20,7 +20,8 @@ import {
   VictoryCommonProps,
   VictoryDatableProps,
   VictorySingleLabableProps,
-  VictoryStyleInterface
+  VictoryStyleInterface,
+  VictoryStyleObject
 } from "victory-core";
 
 export interface VictoryLegendProps
@@ -47,7 +48,7 @@ export interface VictoryLegendProps
   labelComponent?: React.ReactElement;
   orientation?: "horizontal" | "vertical";
   rowGutter?: number | Omit<BlockProps, "left" | "right">;
-  style?: VictoryStyleInterface;
+  style?: VictoryStyleInterface & { title?: VictoryStyleObject };
   symbolSpacer?: number;
   title?: string | string[];
   titleComponent?: React.ReactElement;


### PR DESCRIPTION
Hi!

As seen in the [documentation for VictoryLegend](https://formidable.com/open-source/victory/docs/victory-legend/#style), a VictoryLegend style prop can expect styling for the `title` property. However, when we look at the type definition for `VictoryLegendProps`, we see that the style property uses `VictoryStyleInterface`, which does not contain a property for `title`.

This PR simply combines the optional `title` style property with `VictoryStyleInterface` to fulfill this definition. `title` is a `VictoryStyleObject` identical to the other properties in the interface.