### PR TITLE
Added missing dependencies

### DIFF
--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
-    "victory-core": "^34.1.1"
+    "victory-core": "^34.1.1",
+    "react-fast-compare": "^2.0.0"
   },
   "scripts": {
     "version": "nps build-libs && nps build-dists"

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -22,7 +22,8 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0",
-    "victory-core": "^34.1.1"
+    "victory-core": "^34.1.1",
+    "victory-shared-events": "^34.1.1"
   },
   "scripts": {
     "version": "nps build-libs && nps build-dists"

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -22,7 +22,8 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0",
-    "victory-core": "^34.1.1"
+    "victory-core": "^34.1.1",
+    "victory-shared-events": "^34.1.1"
   },
   "scripts": {
     "version": "nps build-libs && nps build-dists"

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -23,7 +23,8 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
     "victory-core": "^34.1.1",
-    "victory-tooltip": "^34.1.1"
+    "victory-tooltip": "^34.1.1",
+    "react-fast-compare": "^2.0.0"
   },
   "scripts": {
     "version": "nps build-libs && nps build-dists"


### PR DESCRIPTION
Closes #1495

Victory charts is incompatible with Yarn PnP due to out of spec imports.

For example, `victory-voronoi-container` imports `react-fast-compare` but it is not declared in `victory-voronoi-container`s package.json.

This currently works for other package managers due to how the node_modules folders just happen to be mounted, but this should be considered undefined behavior.

This PR adds the imported dependencies into the relevant package.json files.