### PR TITLE
Task/audit victory legend typescript props

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -399,7 +399,7 @@ export interface EventCallbackInterface<TTarget, TEventKey> {
 }
 
 export interface EventPropTypeInterface<TTarget, TEventKey> {
-  childName?: string;
+  childName?: string | Array<StringOrNumberOrCallback>;
   target: TTarget;
   eventKey?: TEventKey;
   eventHandlers: {

--- a/packages/victory-legend/src/index.d.ts
+++ b/packages/victory-legend/src/index.d.ts
@@ -13,12 +13,14 @@ import * as React from "react";
 import {
   BlockProps,
   ColorScalePropType,
+  EventCallbackInterface,
   EventPropTypeInterface,
   OrientationTypes,
   PaddingProps,
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryDatableProps,
+  VictoryLabableProps,
   VictorySingleLabableProps,
   VictoryStyleInterface,
   VictoryStyleObject
@@ -27,6 +29,7 @@ import {
 export interface VictoryLegendProps
   extends VictoryCommonProps,
     VictoryDatableProps,
+    VictoryLabableProps,
     VictorySingleLabableProps {
   borderComponent?: React.ReactElement;
   borderPadding?: PaddingProps;
@@ -34,6 +37,9 @@ export interface VictoryLegendProps
   colorScale?: ColorScalePropType;
   data?: Array<{
     name?: string;
+    labels?: {
+      fill?: string;
+    };
     symbol?: {
       fill?: string;
       type?: string;
@@ -42,10 +48,9 @@ export interface VictoryLegendProps
   dataComponent?: React.ReactElement;
   eventKey?: StringOrNumberOrCallback | string[];
   events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback>[];
-  externalEventMutations?: any[];
+  externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrCallback> & { callback?: Function };
   gutter?: number | { left: number; right: number };
   itemsPerRow?: number;
-  labelComponent?: React.ReactElement;
   orientation?: "horizontal" | "vertical";
   rowGutter?: number | Omit<BlockProps, "left" | "right">;
   style?: VictoryStyleInterface & { title?: VictoryStyleObject };


### PR DESCRIPTION
- Audit existing prop types for VictoryLegend
- Allow arrays in childName in the EventPropTypeInterface