### PR TITLE
Add types: VictorySharedEvents

### DIFF
--- a/demo/ts/app.tsx
+++ b/demo/ts/app.tsx
@@ -16,6 +16,7 @@ import PieDemo from "./components/victory-pie-demo";
 import PolarAxisDemo from "./components/victory-polar-axis-demo";
 import ScatterDemo from "./components/victory-scatter-demo";
 import TooltipDemo from "./components/victory-tooltip-demo";
+import VictorySharedEventsDemo from "./components/victory-shared-events-demo";
 import VoronoiDemo from "./components/victory-voronoi-demo";
 
 const MAP = {
@@ -33,6 +34,7 @@ const MAP = {
   "/pie": { component: PieDemo, name: "PieDemo" },
   "/polar-axis": { component: PolarAxisDemo, name: "PolarAxisDemo" },
   "/scatter": { component: ScatterDemo, name: "ScatterDemo" },
+  "/victory-shared-events": { component: VictorySharedEventsDemo, name: "VictorySharedEventsDemo" },
   "/voronoi": { component: VoronoiDemo, name: "VoronoiDemo" }
 };
 

--- a/demo/ts/components/victory-shared-events-demo.tsx
+++ b/demo/ts/components/victory-shared-events-demo.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { VictoryBar } from "@packages/victory-bar";
+import { VictorySharedEvents } from "@packages/victory-shared-events";
+import { merge } from "lodash";
+
+export default class VictoryBarDemo extends React.Component<any, {}> {
+  render() {
+    const containerStyle: React.CSSProperties = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+
+    return (
+      <div className="demo" style={containerStyle}>
+        <svg width={500} height={300}>
+          <VictorySharedEvents
+            events={[
+              {
+                childName: "firstBar",
+                target: "data",
+                eventKey: 1,
+                eventHandlers: {
+                  onClick: () => {
+                    return {
+                      childName: "secondBar",
+                      mutation: (props) => {
+                        return { style: merge({}, props.style, { fill: "blue" }) };
+                      }
+                    };
+                  }
+                }
+              },
+              {
+                childName: "secondBar",
+                target: "data",
+                eventKey: 0,
+                eventHandlers: {
+                  onClick: () => {
+                    return [
+                      {
+                        childName: "firstBar",
+                        mutation: (props) => {
+                          return props.style.fill === "cyan"
+                            ? null
+                            : { style: merge({}, props.style, { fill: "cyan" }) };
+                        }
+                      },
+                      {
+                        mutation: (props) => {
+                          return { style: merge({}, props.style, { fill: "orange" }) };
+                        }
+                      },
+                      {
+                        target: "labels",
+                        eventKey: 1,
+                        mutation: () => {
+                          return { text: "CLICKED" };
+                        }
+                      }
+                    ];
+                  }
+                }
+              }
+            ]}
+          >
+            <VictoryBar
+              name="firstBar"
+              style={{
+                data: { width: 25, fill: "gold" }
+              }}
+              data={[{ x: "a", y: 2 }, { x: "b", y: 3 }, { x: "c", y: 4 }]}
+            />
+            <VictoryBar
+              name={"secondBar"}
+              data={[{ x: "a", y: 2 }, { x: "b", y: 3 }, { x: "c", y: 4 }]}
+            />
+          </VictorySharedEvents>
+        </svg>
+      </div>
+    );
+  }
+}

--- a/demo/ts/components/victory-shared-events-demo.tsx
+++ b/demo/ts/components/victory-shared-events-demo.tsx
@@ -3,7 +3,7 @@ import { VictoryBar } from "@packages/victory-bar";
 import { VictorySharedEvents } from "@packages/victory-shared-events";
 import { merge } from "lodash";
 
-export default class VictoryBarDemo extends React.Component<any, {}> {
+export default class VictorySharedEventsDemo extends React.Component<any, {}> {
   render() {
     const containerStyle: React.CSSProperties = {
       display: "flex",

--- a/packages/victory-area/src/index.d.ts
+++ b/packages/victory-area/src/index.d.ts
@@ -15,14 +15,14 @@ import {
   InterpolationPropType,
   VictoryCommonProps,
   VictoryDatableProps,
-  VictorySingleLabableProps,
+  VictorySingleLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
 export interface VictoryAreaProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictorySingleLabableProps {
+    VictorySingleLabelableProps {
   events?: EventPropTypeInterface<"data" | "labels" | "parent", string | number>[];
   interpolation?: InterpolationPropType;
   labels?: string[] | number[] | Function;

--- a/packages/victory-bar/src/index.d.ts
+++ b/packages/victory-bar/src/index.d.ts
@@ -16,14 +16,14 @@ import {
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryDatableProps,
-  VictoryMultiLabeableProps,
+  VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
 export interface VictoryBarProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictoryMultiLabeableProps {
+    VictoryMultiLabelableProps {
   alignment?: "start" | "middle" | "end";
   barRatio?: number;
   barWidth?: NumberOrCallback;

--- a/packages/victory-candlestick/src/index.d.ts
+++ b/packages/victory-candlestick/src/index.d.ts
@@ -18,8 +18,8 @@ import {
   VictoryCommonProps,
   VictoryDatableProps,
   VictoryStyleObject,
-  VictoryLabableProps,
-  VictoryMultiLabeableProps,
+  VictoryLabelableProps,
+  VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
@@ -42,8 +42,8 @@ export type VictoryCandlestickLabelsType = (string | number)[] | boolean | ((dat
 export interface VictoryCandlestickProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictoryLabableProps,
-    VictoryMultiLabeableProps {
+    VictoryLabelableProps,
+    VictoryMultiLabelableProps {
   candleColors?: {
     positive?: string;
     negative?: string;

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -602,16 +602,16 @@ export interface VictoryDatableProps {
   y0?: DataGetterPropType;
 }
 
-export interface VictoryLabableProps {
+export interface VictoryLabelableProps {
   labelComponent?: React.ReactElement;
 }
 
-export interface VictoryMultiLabeableProps extends VictoryLabableProps {
-  labels?: string[] | number[] | { (data: any): string | number | null };
+export interface VictoryMultiLabelableProps extends VictoryLabelableProps {
+  labels?: string[] | { (data: any): string | null };
 }
 
-export interface VictorySingleLabableProps extends VictoryLabableProps {
-  label?: string | number | { (data: any): string | number };
+export interface VictorySingleLabelableProps extends VictoryLabelableProps {
+  label?: string | { (data: any): string };
 }
 
 // #endregion

--- a/packages/victory-group/src/index.d.ts
+++ b/packages/victory-group/src/index.d.ts
@@ -19,14 +19,14 @@ import {
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryDatableProps,
-  VictoryMultiLabeableProps,
+  VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
 export interface VictoryGroupProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictoryMultiLabeableProps {
+    VictoryMultiLabelableProps {
   categories?: CategoryPropType;
   color?: string;
   colorScale?: ColorScalePropType;

--- a/packages/victory-legend/src/index.d.ts
+++ b/packages/victory-legend/src/index.d.ts
@@ -20,8 +20,7 @@ import {
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryDatableProps,
-  VictoryLabableProps,
-  VictorySingleLabableProps,
+  VictorySingleLabelableProps,
   VictoryStyleInterface,
   VictoryStyleObject
 } from "victory-core";
@@ -29,8 +28,7 @@ import {
 export interface VictoryLegendProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictoryLabableProps,
-    VictorySingleLabableProps {
+    VictorySingleLabelableProps {
   borderComponent?: React.ReactElement;
   borderPadding?: PaddingProps;
   centerTitle?: boolean;

--- a/packages/victory-legend/src/index.d.ts
+++ b/packages/victory-legend/src/index.d.ts
@@ -13,7 +13,6 @@ import * as React from "react";
 import {
   BlockProps,
   ColorScalePropType,
-  EventCallbackInterface,
   EventPropTypeInterface,
   OrientationTypes,
   PaddingProps,

--- a/packages/victory-line/src/index.d.ts
+++ b/packages/victory-line/src/index.d.ts
@@ -16,14 +16,14 @@ import {
   VictoryCommonProps,
   VictoryCommonPrimitiveProps,
   VictoryDatableProps,
-  VictorySingleLabableProps,
+  VictorySingleLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
 export interface VictoryLineProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictorySingleLabableProps {
+    VictorySingleLabelableProps {
   events?: EventPropTypeInterface<"data" | "labels" | "parent", number | string>[];
   interpolation?: InterpolationPropType;
   samples?: number;

--- a/packages/victory-pie/src/index.d.ts
+++ b/packages/victory-pie/src/index.d.ts
@@ -17,7 +17,7 @@ import {
   SliceNumberOrCallback,
   StringOrNumberOrCallback,
   VictoryCommonProps,
-  VictoryMultiLabeableProps,
+  VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
@@ -46,7 +46,7 @@ export interface VictorySliceProps extends VictoryCommonProps {
   sliceStartAngle?: SliceNumberOrCallback<VictorySliceProps, "sliceStartAngle">;
 }
 
-export interface VictoryPieProps extends VictoryCommonProps, VictoryMultiLabeableProps {
+export interface VictoryPieProps extends VictoryCommonProps, VictoryMultiLabelableProps {
   colorScale?: ColorScalePropType;
   data?: any[];
   dataComponent?: React.ReactElement;

--- a/packages/victory-polar-axis/src/index.d.ts
+++ b/packages/victory-polar-axis/src/index.d.ts
@@ -12,19 +12,17 @@
 import * as React from "react";
 import {
   DomainPropType,
-  DomainPaddingPropType,
   EventPropTypeInterface,
   LabelOrientationType,
-  StringOrNumberOrCallback,
   VictoryAxisCommonProps,
   VictoryCommonProps,
-  VictorySingleLabableProps
+  VictorySingleLabelableProps
 } from "victory-core";
 
 export interface VictoryPolarAxisProps
   extends VictoryAxisCommonProps,
     VictoryCommonProps,
-    VictorySingleLabableProps {
+    VictorySingleLabelableProps {
   axisAngle?: number;
   axisValue?: number | string | Date;
   circularAxisComponent?: React.ReactElement;

--- a/packages/victory-scatter/src/index.d.ts
+++ b/packages/victory-scatter/src/index.d.ts
@@ -17,14 +17,14 @@ import {
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryDatableProps,
-  VictoryMultiLabeableProps,
+  VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
 export interface VictoryScatterProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictoryMultiLabeableProps {
+    VictoryMultiLabelableProps {
   bubbleProperty?: string;
   events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback>[];
   eventKey?: StringOrNumberOrCallback;

--- a/packages/victory-shared-events/src/index.d.ts
+++ b/packages/victory-shared-events/src/index.d.ts
@@ -1,0 +1,18 @@
+import * as React from "react";
+import {
+  EventCallbackInterface,
+  EventPropTypeInterface,
+  StringOrNumberOrCallback
+} from "victory-core";
+
+export type VictorySharedEventsProps = {
+  groupComponent?: React.ReactElement;
+  events?: EventPropTypeInterface<string, StringOrNumberOrCallback>[];
+  eventKey?: StringOrNumberOrCallback;
+  externalEventMutations?: EventCallbackInterface<
+    string | string[],
+    string | number | (string | number)[]
+  >[];
+};
+
+export class VictorySharedEvents extends React.Component<VictorySharedEventsProps, any> {}

--- a/packages/victory-shared-events/src/index.d.ts
+++ b/packages/victory-shared-events/src/index.d.ts
@@ -6,6 +6,8 @@ import {
 } from "victory-core";
 
 export type VictorySharedEventsProps = {
+  children?: React.ReactElement | React.ReactElement[];
+  container?: React.ReactElement;
   groupComponent?: React.ReactElement;
   events?: EventPropTypeInterface<string, StringOrNumberOrCallback>[];
   eventKey?: StringOrNumberOrCallback;

--- a/packages/victory-stack/src/index.d.ts
+++ b/packages/victory-stack/src/index.d.ts
@@ -18,11 +18,11 @@ import {
   EventPropTypeInterface,
   StringOrNumberOrCallback,
   VictoryCommonProps,
-  VictoryMultiLabeableProps,
+  VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
-export interface VictoryStackProps extends VictoryCommonProps, VictoryMultiLabeableProps {
+export interface VictoryStackProps extends VictoryCommonProps, VictoryMultiLabelableProps {
   categories?: CategoryPropType;
   colorScale?: ColorScalePropType;
   domain?: DomainPropType;

--- a/packages/victory-voronoi/src/index.d.ts
+++ b/packages/victory-voronoi/src/index.d.ts
@@ -15,16 +15,16 @@ import {
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryDatableProps,
-  VictoryLabableProps,
-  VictoryMultiLabeableProps,
+  VictoryLabelableProps,
+  VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
 export interface VictoryVoronoiProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictoryLabableProps,
-    VictoryMultiLabeableProps {
+    VictoryLabelableProps,
+    VictoryMultiLabelableProps {
   events?: EventPropTypeInterface<string, string | number | (string | number)[]>[];
   type?: number;
   sortKey?: StringOrNumberOrCallback | string[];


### PR DESCRIPTION
This PR introduces types for `VictorySharedEvents` and updates our spelling of `Labelable` across 3 different interfaces.

Tested by running `yarn nps check.dev` locally