### PR TITLE
Add types and demo: VictoryBrushContainer

### DIFF
--- a/demo/js/components/victory-brush-container-demo.js
+++ b/demo/js/components/victory-brush-container-demo.js
@@ -111,7 +111,7 @@ class App extends React.Component {
             height={400}
             padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
             containerComponent={
-              <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowDraw={false} />
+              <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowDrag={false} />
             }
           >
             <VictoryAxis dependentAxis invertAxis />
@@ -262,7 +262,7 @@ class App extends React.Component {
                   strokeWidth: 2
                 }
               }}
-              size={({ active }) => (active ? 5 : 3)}
+              barWidth={({ active }) => (active ? 5 : 3)}
               data={[
                 { x: 1, y: -5 },
                 { x: 2, y: 4 },
@@ -281,7 +281,7 @@ class App extends React.Component {
                   strokeWidth: 2
                 }
               }}
-              size={({ active }) => (active ? 5 : 3)}
+              barWidth={({ active }) => (active ? 5 : 3)}
               data={[
                 { x: 1, y: -3 },
                 { x: 2, y: 5 },
@@ -313,16 +313,13 @@ class App extends React.Component {
           </VictoryStack>
 
           <VictoryLine
-            style={chartStyle}
+            style={{ parent: chartStyle.parent, data: { stroke: "teal" } }}
             containerComponent={
               <VictoryBrushContainer
                 brushDomain={{ y: [-3, 3] }}
                 brushComponent={<rect style={{ fill: "teal" }} />}
               />
             }
-            style={{
-              data: { stroke: "teal" }
-            }}
             data={[
               { x: 1, y: -3 },
               { x: 2, y: 5 },

--- a/demo/ts/app.tsx
+++ b/demo/ts/app.tsx
@@ -6,6 +6,7 @@ import AreaDemo from "./components/victory-area-demo";
 import AxisDemo from "./components/victory-axis-demo";
 import BarDemo from "./components/victory-bar-demo";
 import BoxPlotDemo from "./components/victory-box-plot-demo";
+import BrushContainerDemo from "./components/victory-brush-container-demo";
 import BrushLineDemo from "./components/victory-brush-line-demo";
 import CandlestickDemo from "./components/victory-candlestick-demo";
 import ChartDemo from "./components/victory-chart-demo";
@@ -21,6 +22,7 @@ const MAP = {
   "/area": { component: AreaDemo, name: "AreaDemo" },
   "/bar": { component: BarDemo, name: "BarDemo" },
   "/box-plot": { component: BoxPlotDemo, name: "BoxPlotDemo" },
+  "/brush-container": { component: BrushContainerDemo, name: "BrushContainerDemo" },
   "/brush-line": { component: BrushLineDemo, name: "BrushLineDemo" },
   "/candlestick": { component: CandlestickDemo, name: "CandlestickDemo" },
   "/chart": { component: ChartDemo, name: "ChartDemo" },

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -11,18 +11,30 @@ import { VictoryLegend } from "@packages/victory-legend";
 import { VictoryZoomContainer } from "@packages/victory-zoom-container";
 import { VictoryBrushContainer } from "@packages/victory-brush-container";
 
-export default class VictoryBrushContainerDemo extends React.Component<any> {
+interface VictoryBrushContainerDemoState {
+  zoomDomain: {
+    x?: [number, number];
+    y?: [number, number];
+  };
+}
+
+export default class VictoryBrushContainerDemo extends React.Component<
+  any,
+  VictoryBrushContainerDemoState
+> {
   constructor(props: any) {
     super(props);
-    this.state = {};
+    this.state = {
+      zoomDomain: {}
+    };
   }
 
-  handleZoom(domain: any) {
+  handleZoom(domain: { x?: [number, number]; y?: [number, number] }) {
     this.setState({ zoomDomain: domain });
   }
 
   render() {
-    const containerStyle = {
+    const containerStyle: React.CSSProperties = {
       display: "flex",
       flexDirection: "row",
       flexWrap: "wrap",
@@ -111,7 +123,7 @@ export default class VictoryBrushContainerDemo extends React.Component<any> {
             height={400}
             padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
             containerComponent={
-              <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowDraw={false} />
+              <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowDrag={false} />
             }
           >
             <VictoryAxis dependentAxis invertAxis />
@@ -262,7 +274,7 @@ export default class VictoryBrushContainerDemo extends React.Component<any> {
                   strokeWidth: 2
                 }
               }}
-              size={({ active }) => (active ? 5 : 3)}
+              barWidth={({ active }) => (active ? 5 : 3)}
               data={[
                 { x: 1, y: -5 },
                 { x: 2, y: 4 },
@@ -281,7 +293,7 @@ export default class VictoryBrushContainerDemo extends React.Component<any> {
                   strokeWidth: 2
                 }
               }}
-              size={({ active }) => (active ? 5 : 3)}
+              barWidth={({ active }) => (active ? 5 : 3)}
               data={[
                 { x: 1, y: -3 },
                 { x: 2, y: 5 },
@@ -313,16 +325,13 @@ export default class VictoryBrushContainerDemo extends React.Component<any> {
           </VictoryStack>
 
           <VictoryLine
-            style={chartStyle}
+            style={{ parent: chartStyle.parent, data: { stroke: "teal" } }}
             containerComponent={
               <VictoryBrushContainer
                 brushDomain={{ y: [-3, 3] }}
                 brushComponent={<rect style={{ fill: "teal" }} />}
               />
             }
-            style={{
-              data: { stroke: "teal" }
-            }}
             data={[
               { x: 1, y: -3 },
               { x: 2, y: 5 },

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -1,0 +1,340 @@
+/*eslint-disable no-magic-numbers */
+import React from "react";
+import { VictoryChart } from "@packages/victory-chart";
+import { VictoryStack } from "@packages/victory-stack";
+import { VictoryGroup } from "@packages/victory-group";
+import { VictoryAxis } from "@packages/victory-axis";
+import { VictoryBar } from "@packages/victory-bar";
+import { VictoryLine } from "@packages/victory-line";
+import { VictoryScatter } from "@packages/victory-scatter";
+import { VictoryLegend } from "@packages/victory-legend";
+import { VictoryZoomContainer } from "@packages/victory-zoom";
+import { VictoryBrushContainer } from "@packages/victory-brush";
+
+export default class VictoryBrushContainerDemo extends React.Component<any> {
+  constructor(props: any) {
+    super(props);
+    this.state = {};
+  }
+
+  handleZoom(domain) {
+    this.setState({ zoomDomain: domain });
+  }
+
+  render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+
+    const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
+
+    return (
+      <div className="demo">
+        <div style={containerStyle}>
+          <VictoryChart
+            width={800}
+            height={500}
+            scale={{ x: "time" }}
+            containerComponent={
+              <VictoryZoomContainer
+                responsive={false}
+                zoomDomain={this.state.zoomDomain}
+                zoomDimension="x"
+                onZoomDomainChange={this.handleZoom.bind(this)}
+              />
+            }
+          >
+            <VictoryLine
+              style={{
+                data: { stroke: "tomato" }
+              }}
+              data={[
+                { x: new Date(1982, 1, 1), y: 125 },
+                { x: new Date(1987, 1, 1), y: 257 },
+                { x: new Date(1993, 1, 1), y: 345 },
+                { x: new Date(1997, 1, 1), y: 515 },
+                { x: new Date(2001, 1, 1), y: 132 },
+                { x: new Date(2005, 1, 1), y: 305 },
+                { x: new Date(2011, 1, 1), y: 270 },
+                { x: new Date(2015, 1, 1), y: 470 }
+              ]}
+            />
+          </VictoryChart>
+          <VictoryChart
+            padding={{ top: 0, left: 50, right: 50, bottom: 30 }}
+            width={800}
+            height={100}
+            scale={{ x: "time" }}
+            containerComponent={
+              <VictoryBrushContainer
+                responsive={false}
+                brushDomain={this.state.zoomDomain}
+                brushDimension="x"
+                onBrushDomainChange={this.handleZoom.bind(this)}
+              />
+            }
+          >
+            <VictoryAxis
+              tickValues={[
+                new Date(1985, 1, 1),
+                new Date(1990, 1, 1),
+                new Date(1995, 1, 1),
+                new Date(2000, 1, 1),
+                new Date(2005, 1, 1),
+                new Date(2010, 1, 1)
+              ]}
+              tickFormat={(x) => new Date(x).getFullYear()}
+            />
+            <VictoryLine
+              style={{
+                data: { stroke: "tomato" }
+              }}
+              data={[
+                { x: new Date(1982, 1, 1), y: 125 },
+                { x: new Date(1987, 1, 1), y: 257 },
+                { x: new Date(1993, 1, 1), y: 345 },
+                { x: new Date(1997, 1, 1), y: 515 },
+                { x: new Date(2001, 1, 1), y: 132 },
+                { x: new Date(2005, 1, 1), y: 305 },
+                { x: new Date(2011, 1, 1), y: 270 },
+                { x: new Date(2015, 1, 1), y: 470 }
+              ]}
+            />
+          </VictoryChart>
+
+          <VictoryChart
+            style={chartStyle}
+            height={400}
+            padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
+            containerComponent={
+              <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowDraw={false} />
+            }
+          >
+            <VictoryAxis dependentAxis invertAxis />
+            <VictoryLegend
+              x={120}
+              y={20}
+              title="Legend"
+              centerTitle
+              orientation="horizontal"
+              gutter={20}
+              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
+              data={[
+                { name: "One", symbol: { fill: "tomato" } },
+                { name: "Two", symbol: { fill: "orange" } },
+                { name: "Three", symbol: { fill: "gold" } }
+              ]}
+            />
+            <VictoryLine
+              style={{
+                data: { stroke: "tomato" }
+              }}
+              data={[
+                { x: 1, y: -5 },
+                { x: 2, y: 4 },
+                { x: 3, y: 2 },
+                { x: 4, y: 3 },
+                { x: 5, y: 1 },
+                { x: 6, y: -3 },
+                { x: 7, y: 3 }
+              ]}
+            />
+            <VictoryLine
+              style={{
+                data: { stroke: "blue" }
+              }}
+              data={[
+                { x: 1, y: -3 },
+                { x: 2, y: 5 },
+                { x: 3, y: 3 },
+                { x: 4, y: 0 },
+                { x: 5, y: -2 },
+                { x: 6, y: -2 },
+                { x: 7, y: 5 }
+              ]}
+            />
+            <VictoryLine
+              data={[
+                { x: 1, y: 5 },
+                { x: 2, y: -4 },
+                { x: 3, y: -2 },
+                { x: 4, y: -3 },
+                { x: 5, y: -1 },
+                { x: 6, y: 3 },
+                { x: 7, y: -3 }
+              ]}
+            />
+          </VictoryChart>
+
+          <VictoryScatter
+            style={{
+              parent: chartStyle.parent,
+              data: {
+                fill: ({ active }) => (active ? "tomato" : "black")
+              }
+            }}
+            domain={{ x: [0, 10], y: [-5, 5] }}
+            containerComponent={
+              <VictoryBrushContainer defaultBrushArea="none" brushDomain={{ x: [0, 10] }} />
+            }
+            size={({ active }) => (active ? 5 : 3)}
+            data={[
+              { x: 1, y: -5 },
+              { x: 2, y: 4 },
+              { x: 3, y: 2 },
+              { x: 4, y: 3 },
+              { x: 5, y: 1 },
+              { x: 6, y: -3 },
+              { x: 7, y: 3 }
+            ]}
+          />
+
+          <VictoryScatter
+            style={{
+              parent: chartStyle.parent,
+              data: {
+                fill: ({ active }) => (active ? "tomato" : "black")
+              }
+            }}
+            containerComponent={<VictoryBrushContainer defaultBrushArea="disable" />}
+            size={({ active }) => (active ? 5 : 3)}
+            y={(d) => d.x * d.x}
+          />
+
+          <VictoryGroup
+            style={chartStyle}
+            containerComponent={<VictoryBrushContainer defaultBrushArea="move" />}
+          >
+            <VictoryScatter
+              style={{
+                data: { fill: "tomato" }
+              }}
+              size={({ active }) => (active ? 5 : 3)}
+              data={[
+                { x: 1, y: -5 },
+                { x: 2, y: 4 },
+                { x: 3, y: 2 },
+                { x: 4, y: 3 },
+                { x: 5, y: 1 },
+                { x: 6, y: -3 },
+                { x: 7, y: 3 }
+              ]}
+            />
+            <VictoryScatter
+              style={{
+                data: { fill: "blue" }
+              }}
+              size={({ active }) => (active ? 5 : 3)}
+              data={[
+                { x: 1, y: -3 },
+                { x: 2, y: 5 },
+                { x: 3, y: 3 },
+                { x: 4, y: 0 },
+                { x: 5, y: -2 },
+                { x: 6, y: -2 },
+                { x: 7, y: 5 }
+              ]}
+            />
+            <VictoryScatter
+              data={[
+                { x: 1, y: 5 },
+                { x: 2, y: -4 },
+                { x: 3, y: -2 },
+                { x: 4, y: -3 },
+                { x: 5, y: -1 },
+                { x: 6, y: 3 },
+                { x: 7, y: -3 }
+              ]}
+              size={({ active }) => (active ? 5 : 3)}
+            />
+          </VictoryGroup>
+
+          <VictoryStack style={chartStyle} containerComponent={<VictoryBrushContainer />}>
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "tomato",
+                  stroke: ({ active }) => (active ? "black" : "none"),
+                  strokeWidth: 2
+                }
+              }}
+              size={({ active }) => (active ? 5 : 3)}
+              data={[
+                { x: 1, y: -5 },
+                { x: 2, y: 4 },
+                { x: 3, y: 2 },
+                { x: 4, y: 3 },
+                { x: 5, y: 1 },
+                { x: 6, y: -3 },
+                { x: 7, y: 3 }
+              ]}
+            />
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "orange",
+                  stroke: ({ active }) => (active ? "black" : "none"),
+                  strokeWidth: 2
+                }
+              }}
+              size={({ active }) => (active ? 5 : 3)}
+              data={[
+                { x: 1, y: -3 },
+                { x: 2, y: 5 },
+                { x: 3, y: 3 },
+                { x: 4, y: 0 },
+                { x: 5, y: -2 },
+                { x: 6, y: -2 },
+                { x: 7, y: 5 }
+              ]}
+            />
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "gold",
+                  stroke: ({ active }) => (active ? "black" : "none"),
+                  strokeWidth: 2
+                }
+              }}
+              data={[
+                { x: 1, y: 5 },
+                { x: 2, y: -4 },
+                { x: 3, y: -2 },
+                { x: 4, y: -3 },
+                { x: 5, y: -1 },
+                { x: 6, y: 3 },
+                { x: 7, y: -3 }
+              ]}
+            />
+          </VictoryStack>
+
+          <VictoryLine
+            style={chartStyle}
+            containerComponent={
+              <VictoryBrushContainer
+                brushDomain={{ y: [-3, 3] }}
+                brushComponent={<rect style={{ fill: "teal" }} />}
+              />
+            }
+            style={{
+              data: { stroke: "teal" }
+            }}
+            data={[
+              { x: 1, y: -3 },
+              { x: 2, y: 5 },
+              { x: 3, y: -3 },
+              { x: 4, y: 0 },
+              { x: 5, y: -5 },
+              { x: 6, y: 2 },
+              { x: 7, y: 0 }
+            ]}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -8,8 +8,8 @@ import { VictoryBar } from "@packages/victory-bar";
 import { VictoryLine } from "@packages/victory-line";
 import { VictoryScatter } from "@packages/victory-scatter";
 import { VictoryLegend } from "@packages/victory-legend";
-import { VictoryZoomContainer } from "@packages/victory-zoom";
-import { VictoryBrushContainer } from "@packages/victory-brush";
+import { VictoryZoomContainer } from "@packages/victory-zoom-container";
+import { VictoryBrushContainer } from "@packages/victory-brush-container";
 
 export default class VictoryBrushContainerDemo extends React.Component<any> {
   constructor(props: any) {
@@ -17,7 +17,7 @@ export default class VictoryBrushContainerDemo extends React.Component<any> {
     this.state = {};
   }
 
-  handleZoom(domain) {
+  handleZoom(domain: any) {
     this.setState({ zoomDomain: domain });
   }
 

--- a/packages/victory-brush-container/src/index.d.ts
+++ b/packages/victory-brush-container/src/index.d.ts
@@ -10,22 +10,31 @@
 //                 Alec Flett <https://github.com/alecf>
 
 import * as React from "react";
-import { DomainPropType, VictoryContainerProps } from "victory-core";
+import { RangeTuple, VictoryContainerProps } from "victory-core";
 
 export interface VictoryBrushContainerProps extends VictoryContainerProps {
   allowDrag?: boolean;
   allowResize?: boolean;
   brushComponent?: React.ReactElement;
   brushDimension?: "x" | "y";
-  brushDomain?: DomainPropType;
+  brushDomain?: { x?: RangeTuple; y?: RangeTuple };
   brushStyle?: React.CSSProperties;
   defaultBrushArea?: "all" | "none" | "disable" | "move";
   disable?: boolean;
   handleComponent?: React.ReactElement;
   handleStyle?: React.CSSProperties;
-  onBrushCleared?: (domain: DomainPropType, props: VictoryBrushContainerProps) => void;
-  onBrushDomainChange?: (domain: DomainPropType, props: VictoryBrushContainerProps) => void;
-  onBrushDomainChangeEnd?: (domain: DomainPropType, props: VictoryBrushContainerProps) => void;
+  onBrushCleared?: (
+    domain: { x?: RangeTuple; y?: RangeTuple },
+    props: VictoryBrushContainerProps
+  ) => void;
+  onBrushDomainChange?: (
+    domain: { x?: RangeTuple; y?: RangeTuple },
+    props: VictoryBrushContainerProps
+  ) => void;
+  onBrushDomainChangeEnd?: (
+    domain: { x?: RangeTuple; y?: RangeTuple },
+    props: VictoryBrushContainerProps
+  ) => void;
 }
 
 export class VictoryBrushContainer extends React.Component<VictoryBrushContainerProps, any> {}

--- a/packages/victory-brush-container/src/index.d.ts
+++ b/packages/victory-brush-container/src/index.d.ts
@@ -19,11 +19,13 @@ export interface VictoryBrushContainerProps extends VictoryContainerProps {
   brushDimension?: "x" | "y";
   brushDomain?: DomainPropType;
   brushStyle?: React.CSSProperties;
-  defaultBrushArea?: "all" | "none" | "disable";
+  defaultBrushArea?: "all" | "none" | "disable" | "move";
   disable?: boolean;
   handleComponent?: React.ReactElement;
   handleStyle?: React.CSSProperties;
+  onBrushCleared?: (domain: DomainPropType, props: VictoryBrushContainerProps) => void;
   onBrushDomainChange?: (domain: DomainPropType, props: VictoryBrushContainerProps) => void;
+  onBrushDomainChangeEnd?: (domain: DomainPropType, props: VictoryBrushContainerProps) => void;
 }
 
 export class VictoryBrushContainer extends React.Component<VictoryBrushContainerProps, any> {}

--- a/packages/victory-zoom-container/src/index.d.ts
+++ b/packages/victory-zoom-container/src/index.d.ts
@@ -10,20 +10,23 @@
 //                 Alec Flett <https://github.com/alecf>
 
 import * as React from "react";
-import { DomainPropType, VictoryContainerProps, CursorData } from "victory-core";
+import { RangeTuple, VictoryContainerProps, CursorData } from "victory-core";
 
 export interface VictoryZoomContainerProps extends VictoryContainerProps {
   allowPan?: boolean;
   allowZoom?: boolean;
-  clipContainerComponent?: React.ReactElement;
-  zoomDimension?: "x" | "y";
-  zoomDomain?: DomainPropType;
   brushStyle?: React.CSSProperties;
+  clipContainerComponent?: React.ReactElement;
   defaultBrushArea?: "all" | "none" | "disable";
   disable?: boolean;
   downsample?: number | boolean;
   minimumZoom?: CursorData;
-  onZoomDomainChange?: (domain: DomainPropType, props: VictoryZoomContainerProps) => void;
+  onZoomDomainChange?: (
+    domain: { x?: RangeTuple; y?: RangeTuple },
+    props: VictoryZoomContainerProps
+  ) => void;
+  zoomDimension?: "x" | "y";
+  zoomDomain?: { x?: RangeTuple; y?: RangeTuple };
 }
 
 export class VictoryZoomContainer extends React.Component<VictoryZoomContainerProps, any> {}


### PR DESCRIPTION
* Adds a `VictoryBrushContainerDemo` 
* Updates some of the mislabelled props for the demos
* Updates the type definition to use `RangeTuple` instead of `DomainPropType` since it is possible to have the prop to not be provided initially, therefore `DomainPropType` is the wrong type definition due to it requiring either `x` or `y`
* Adds additional missing props for `VictoryBrushContainerProps` interface