### PR TITLE
Audit typescript prop types for VictoryAxis, moving some properties i…

### DIFF
--- a/packages/victory-axis/src/index.d.ts
+++ b/packages/victory-axis/src/index.d.ts
@@ -2,12 +2,13 @@ import * as React from "react";
 import {
   DomainPropType,
   EventPropTypeInterface,
+  OrientationTypes,
   VictoryAxisCommonProps,
-  VictoryCommonProps
+  VictoryCommonProps,
+  VictorySingleLabelableProps
 } from "victory-core";
 
-export interface VictoryAxisProps extends VictoryAxisCommonProps, VictoryCommonProps {
-  axisValue?: number | string | object;
+export interface VictoryAxisProps extends VictoryAxisCommonProps, VictoryCommonProps, VictorySingleLabelableProps {
   crossAxis?: boolean;
   domain?: DomainPropType;
   events?: EventPropTypeInterface<
@@ -15,12 +16,9 @@ export interface VictoryAxisProps extends VictoryAxisCommonProps, VictoryCommonP
     number | string
   >[];
   fixLabelOverlap?: boolean;
-  gridComponent?: React.ReactElement;
-  invertAxis?: boolean;
-  label?: any;
   offsetX?: number;
   offsetY?: number;
-  orientation?: "top" | "bottom" | "left" | "right";
+  orientation?: OrientationTypes;
 }
 
 /**

--- a/packages/victory-axis/src/index.d.ts
+++ b/packages/victory-axis/src/index.d.ts
@@ -8,7 +8,10 @@ import {
   VictorySingleLabelableProps
 } from "victory-core";
 
-export interface VictoryAxisProps extends VictoryAxisCommonProps, VictoryCommonProps, VictorySingleLabelableProps {
+export interface VictoryAxisProps
+  extends VictoryAxisCommonProps,
+    VictoryCommonProps,
+    VictorySingleLabelableProps {
   crossAxis?: boolean;
   domain?: DomainPropType;
   events?: EventPropTypeInterface<

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -149,7 +149,9 @@ export type TickLabelProps = React.CSSProperties & {
 export interface VictoryAxisCommonProps {
   axisComponent?: React.ReactElement;
   axisLabelComponent?: React.ReactElement;
+  axisValue?: number | string | object | Date;
   dependentAxis?: boolean;
+  gridComponent?: React.ReactElement;
   invertAxis?: boolean;
   style?: {
     parent?: {


### PR DESCRIPTION
Audited VictoryAxis props, moved the following to the VictoryAxisCommonProps interface:

 axisValue, gridComponent