### PR TITLE
Task/audit victory chart typerscript props

### DIFF
--- a/packages/victory-chart/src/index.d.ts
+++ b/packages/victory-chart/src/index.d.ts
@@ -9,14 +9,23 @@ import {
   VictoryStyleInterface
 } from "victory-core";
 
+export type AxesType = {
+  independent: React.ReactElement;
+  dependent: React.ReactElement;
+}
+
 export interface VictoryChartProps extends VictoryCommonProps {
+  defaultAxes?: AxesType;
+  defaultPolarAxes?: AxesType;
   categories?: CategoryPropType;
+  children?: React.ReactElement | React.ReactElement[];
   domain?: DomainPropType;
-  domainPadding?: DomainPaddingPropType;
+  endAngle?: number;
   events?: EventPropTypeInterface<string, string | number>[];
   eventKey?: StringOrNumberOrCallback;
   innerRadius?: number;
-  polar?: boolean;
+  prependDefaultAxes: boolean;
+  startAngle?: number;
   style?: Pick<VictoryStyleInterface, "parent">;
 }
 

--- a/packages/victory-chart/src/index.d.ts
+++ b/packages/victory-chart/src/index.d.ts
@@ -10,21 +10,21 @@ import {
 } from "victory-core";
 
 export type AxesType = {
-  independent: React.ReactElement;
-  dependent: React.ReactElement;
-}
+  independent?: React.ReactElement;
+  dependent?: React.ReactElement;
+};
 
 export interface VictoryChartProps extends VictoryCommonProps {
   defaultAxes?: AxesType;
   defaultPolarAxes?: AxesType;
   categories?: CategoryPropType;
-  children?: React.ReactElement | React.ReactElement[];
+  children?: React.ReactNode | React.ReactNode[];
   domain?: DomainPropType;
   endAngle?: number;
   events?: EventPropTypeInterface<string, string | number>[];
   eventKey?: StringOrNumberOrCallback;
   innerRadius?: number;
-  prependDefaultAxes: boolean;
+  prependDefaultAxes?: boolean;
   startAngle?: number;
   style?: Pick<VictoryStyleInterface, "parent">;
 }

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -540,6 +540,7 @@ export interface VictoryCommonProps {
   minDomain?: number | { x?: number; y?: number };
   name?: string;
   padding?: PaddingProps;
+  polar?: boolean;
   range?: RangePropType;
   scale?:
     | ScalePropType

--- a/packages/victory-tooltip/src/index.d.ts
+++ b/packages/victory-tooltip/src/index.d.ts
@@ -66,7 +66,6 @@ export interface FlyoutProps extends VictoryCommonProps {
   pathComponent?: React.ReactElement;
   pointerLength?: number;
   pointerWidth?: number;
-  polar?: boolean;
   role?: string;
   shapeRendering?: string;
   style?: VictoryStyleObject;

--- a/packages/victory-voronoi/src/index.d.ts
+++ b/packages/victory-voronoi/src/index.d.ts
@@ -20,7 +20,6 @@ export interface VictoryVoronoiProps
   sortOrder?: "ascending" | "descending";
   size?: number | { (data: any): number };
   style?: VictoryStyleInterface;
-  polar?: boolean;
 }
 
 export class VictoryVoronoi extends React.Component<VictoryVoronoiProps, any> {}


### PR DESCRIPTION
- Audit typescript prop defs in VictoryAxisCharts and add the following properties: children, defaultAxes, defaultPolarAxes, endAngle, prependDefaultAxes
- Move polar to the VictoryCommonProps interface