### PR TITLE
Audits and Adds typescript props, definitions, and demo: VictoryZoomContainer

### DIFF
--- a/demo/js/components/victory-zoom-container-demo.js
+++ b/demo/js/components/victory-zoom-container-demo.js
@@ -2,7 +2,7 @@
 /*eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { range, merge, random, minBy, maxBy, last, round } from "lodash";
+import { range, merge, random, minBy, maxBy, last } from "lodash";
 import { VictoryChart } from "Packages/victory-chart/src/index";
 import { VictoryStack } from "Packages/victory-stack/src/index";
 import { VictoryGroup } from "Packages/victory-group/src/index";
@@ -60,11 +60,6 @@ class CustomChart extends React.Component {
       y: [minBy(data, (d) => d.y).y, maxBy(data, (d) => d.y).y],
       x: [data[0].x, last(data).x]
     };
-  }
-  getZoomFactor() {
-    const { zoomedXDomain } = this.state;
-    const factor = 10 / (zoomedXDomain[1] - zoomedXDomain[0]);
-    return round(factor, factor < 3 ? 1 : 0);
   }
 
   render() {

--- a/demo/js/components/victory-zoom-container-demo.js
+++ b/demo/js/components/victory-zoom-container-demo.js
@@ -118,7 +118,7 @@ export default class App extends React.Component {
 
   getZoomDomain() {
     return {
-      y: [random(0, 0.4, 0.1), random(0.6, 1, 0.1)]
+      y: [random(0, 0.4), random(0.6, 1)]
     };
   }
 

--- a/demo/ts/app.tsx
+++ b/demo/ts/app.tsx
@@ -21,6 +21,7 @@ import TooltipDemo from "./components/victory-tooltip-demo";
 import VictorySelectionContainerDemo from "./components/victory-selection-container-demo";
 import VictorySharedEventsDemo from "./components/victory-shared-events-demo";
 import VoronoiDemo from "./components/victory-voronoi-demo";
+import ZoomContainerDemo from "./components/victory-zoom-container-demo";
 
 const MAP = {
   "/area": { component: AreaDemo, name: "AreaDemo" },
@@ -44,7 +45,8 @@ const MAP = {
     name: "VictorySelectionContainerDemo"
   },
   "/victory-shared-events": { component: VictorySharedEventsDemo, name: "VictorySharedEventsDemo" },
-  "/voronoi": { component: VoronoiDemo, name: "VoronoiDemo" }
+  "/voronoi": { component: VoronoiDemo, name: "VoronoiDemo" },
+  "/zoom-container": { component: ZoomContainerDemo, name: "ZoomContainerDemo" }
 };
 
 class Home extends React.Component {

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -10,11 +10,12 @@ import { VictoryScatter } from "@packages/victory-scatter";
 import { VictoryLegend } from "@packages/victory-legend";
 import { VictoryZoomContainer } from "@packages/victory-zoom-container";
 import { VictoryBrushContainer } from "@packages/victory-brush-container";
+import { DomainTuple } from "@packages/victory-core";
 
 interface VictoryBrushContainerDemoState {
   zoomDomain: {
-    x?: [number, number];
-    y?: [number, number];
+    x?: DomainTuple;
+    y?: DomainTuple;
   };
 }
 
@@ -29,7 +30,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
     };
   }
 
-  handleZoom(domain: { x?: [number, number]; y?: [number, number] }) {
+  handleZoom(domain: { x?: DomainTuple; y?: DomainTuple }) {
     this.setState({ zoomDomain: domain });
   }
 

--- a/demo/ts/components/victory-cursor-container-demo.tsx
+++ b/demo/ts/components/victory-cursor-container-demo.tsx
@@ -11,18 +11,18 @@ import { VictoryScatter } from "@packages/victory-scatter";
 import { VictoryCursorContainer } from "@packages/victory-cursor-container";
 import { VictoryTooltip } from "@packages/victory-tooltip";
 import { VictoryLegend } from "@packages/victory-legend";
-import { VictoryTheme, CursorData } from "@packages/victory-core";
+import { VictoryTheme, CoordinatesPropType } from "@packages/victory-core";
 
 interface VictoryCursorContainerStateInterface {
   data: { a: number; b: number }[];
-  cursorValue: CursorData;
-  bigData: CursorData[];
+  cursorValue: CoordinatesPropType;
+  bigData: CoordinatesPropType[];
 }
 
 const makeData = () => range(1500).map((x) => ({ x, y: x + 10 * Math.random() }));
 
 class App extends React.Component<any, VictoryCursorContainerStateInterface> {
-  defaultCursorValue?: CursorData = undefined;
+  defaultCursorValue?: CoordinatesPropType = undefined;
   setStateInterval?: number = undefined;
 
   constructor(props: any) {
@@ -67,7 +67,7 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
 
     const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
 
-    const cursorLabel = (datum: CursorData) => round(datum.x, 2);
+    const cursorLabel = (datum: CoordinatesPropType) => round(datum.x, 2);
 
     return (
       <div className="demo">
@@ -155,7 +155,7 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
             }}
             containerComponent={
               <VictoryCursorContainer
-                cursorLabel={(datum: CursorData) => round(datum.x, 2)}
+                cursorLabel={(datum: CoordinatesPropType) => round(datum.x, 2)}
                 cursorDimension="x"
                 defaultCursorValue={1}
               />
@@ -193,7 +193,7 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
               <VictoryCursorContainer
                 defaultCursorValue={2}
                 cursorDimension="x"
-                cursorLabel={(datum: CursorData) => round(datum.x, 2)}
+                cursorLabel={(datum: CoordinatesPropType) => round(datum.x, 2)}
                 cursorLabelOffset={15}
               />
             }

--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -1,0 +1,444 @@
+/*eslint-disable no-magic-numbers,react/no-multi-comp */
+import React from "react";
+import PropTypes from "prop-types";
+import { range, merge, random, minBy, maxBy, last, round } from "lodash";
+import { VictoryChart } from "@packages/victory-chart";
+import { VictoryStack } from "@packages/victory-stack";
+import { VictoryGroup } from "@packages/victory-group";
+import { VictoryAxis } from "@packages/victory-axis";
+import { VictoryArea } from "@packages/victory-area";
+import { VictoryBar } from "@packages/victory-bar";
+import { VictoryLine } from "@packages/victory-line";
+import { VictoryScatter } from "@packages/victory-scatter";
+import { VictoryZoomContainer } from "@packages/victory-zoom-container";
+import { VictoryTooltip } from "@packages/victory-tooltip";
+import { VictoryLegend } from "@packages/victory-legend";
+import { VictoryClipContainer, VictoryPortal, VictoryTheme } from "@packages/victory-core";
+
+const allData = range(0, 10, 0.001).map((x) => ({
+  x,
+  y: (Math.sin((Math.PI * x) / 2) * x) / 10
+}));
+
+class CustomChart extends React.Component {
+  static propTypes = {
+    data: PropTypes.array,
+    maxPoints: PropTypes.number,
+    style: PropTypes.object
+  };
+
+  constructor(props: any) {
+    super(props);
+    this.entireDomain = this.getEntireDomain(props);
+    this.state = {
+      zoomedXDomain: this.entireDomain.x
+    };
+  }
+
+  onDomainChange(domain) {
+    this.setState({
+      zoomedXDomain: domain.x
+    });
+  }
+
+  getData() {
+    const { zoomedXDomain } = this.state;
+    const { data, maxPoints } = this.props;
+    const filtered = data.filter((d) => d.x >= zoomedXDomain[0] && d.x <= zoomedXDomain[1]);
+
+    if (filtered.length > maxPoints) {
+      const k = Math.ceil(filtered.length / maxPoints);
+      return filtered.filter((d, i) => i % k === 0);
+    }
+    return filtered;
+  }
+
+  getEntireDomain(props) {
+    const { data } = props;
+    return {
+      y: [minBy(data, (d) => d.y).y, maxBy(data, (d) => d.y).y],
+      x: [data[0].x, last(data).x]
+    };
+  }
+  getZoomFactor() {
+    const { zoomedXDomain } = this.state;
+    const factor = 10 / (zoomedXDomain[1] - zoomedXDomain[0]);
+    return round(factor, factor < 3 ? 1 : 0);
+  }
+
+  render() {
+    const renderedData = this.getData();
+    return (
+      <VictoryChart
+        style={this.props.style}
+        domain={this.entireDomain}
+        containerComponent={
+          <VictoryZoomContainer
+            zoomDimension="x"
+            onZoomDomainChange={this.onDomainChange.bind(this)}
+            minimumZoom={{ x: 1 / 10000 }}
+          />
+        }
+      >
+        <VictoryScatter data={renderedData} />
+      </VictoryChart>
+    );
+  }
+}
+
+export default class VictoryZoomContainerDemo extends React.Component<any> {
+  constructor() {
+    super();
+    this.state = {
+      data: this.getData(),
+      transitionData: this.getTransitionData(),
+      arrayData: this.getArrayData(),
+      style: {
+        stroke: "blue",
+        strokeWidth: 2
+      },
+      zoomDomain: this.getZoomDomain()
+    };
+  }
+
+  state = {
+    barData: range(-50, 75).map((i) => ({ x: i, y: Math.random() }))
+  };
+
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
+      this.setState({
+        data: this.getData(),
+        transitionData: this.getTransitionData(),
+        style: this.getStyles()
+      });
+    }, 3000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
+  getZoomDomain() {
+    return {
+      y: [random(0, 0.4, 0.1), random(0.6, 1, 0.1)]
+    };
+  }
+
+  getTransitionData() {
+    const lines = random(6, 10);
+    return range(lines).map((line) => {
+      return { x: line, y: random(2, 10) };
+    });
+  }
+
+  getData() {
+    return range(50).map((i) => {
+      return {
+        a: i + 20,
+        b: Math.random()
+      };
+    });
+  }
+  getArrayData() {
+    return range(40).map((i) => [i, i + Math.random() * 3]);
+  }
+
+  getStyles() {
+    const colors = ["red", "orange", "cyan", "green", "blue", "purple"];
+    return {
+      stroke: colors[random(0, 5)],
+      strokeWidth: random(1, 5)
+    };
+  }
+  render() {
+    const parentStyle = { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" };
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+
+    return (
+      <div className="demo" style={containerStyle}>
+        <CustomChart style={{ parent: parentStyle }} data={allData} maxPoints={120} />
+
+        <VictoryGroup
+          containerComponent={<VictoryZoomContainer zoomDimension="y" />}
+          style={{ parent: parentStyle }}
+          data={this.state.transitionData}
+        >
+          <VictoryLine animate={{ duration: 1500 }} style={{ data: this.state.style }} />
+        </VictoryGroup>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          containerComponent={
+            <VictoryZoomContainer
+              zoomDomain={{ x: [new Date(1993, 1, 1), new Date(2005, 1, 1)] }}
+              dimension="x"
+            />
+          }
+          scale={{
+            x: "time"
+          }}
+        >
+          <VictoryAxis tickFormat={(x) => new Date(x).getFullYear()} />
+          <VictoryLine
+            style={{
+              data: { stroke: "red", strokeWidth: 5 }
+            }}
+            data={[
+              { x: new Date(1982, 1, 1), y: 125 },
+              { x: new Date(1987, 1, 1), y: 257 },
+              { x: new Date(1993, 1, 1), y: 345 },
+              { x: new Date(1997, 1, 1), y: 515 },
+              { x: new Date(2001, 1, 1), y: 132 },
+              { x: new Date(2005, 1, 1), y: 305 },
+              { x: new Date(2011, 1, 1), y: 270 },
+              { x: new Date(2015, 1, 1), y: 470 }
+            ]}
+          />
+        </VictoryChart>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          animate={{ duration: 1500 }}
+          domainPadding={{ x: 20, y: 0 }}
+          containerComponent={
+            <VictoryZoomContainer
+              minimumZoom={{ x: 5 }}
+              zoomDimension="x"
+              downsample={10}
+              clipContainerComponent={
+                <VictoryClipContainer clipPadding={{ top: 15, bottom: 15 }} />
+              }
+            />
+          }
+        >
+          <VictoryPortal>
+            <VictoryScatter
+              style={{ parent: parentStyle, data: { fill: "orange" } }}
+              size={15}
+              data={this.state.data}
+              x="a"
+              y="b"
+            />
+          </VictoryPortal>
+        </VictoryChart>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          animate={{ duration: 1500 }}
+          domainPadding={{ x: 20, y: 0 }}
+          containerComponent={
+            <VictoryZoomContainer
+              minimumZoom={{ x: 5 }}
+              zoomDimension="x"
+              downsample={10}
+              clipContainerComponent={
+                <VictoryClipContainer clipPadding={{ top: 15, bottom: 15 }} />
+              }
+            />
+          }
+        >
+          <VictoryScatter
+            style={{ parent: parentStyle, data: { fill: "orange" } }}
+            size={15}
+            data={this.state.data}
+            x="a"
+            y="b"
+            labels={({ datum }) => datum.x}
+            labelComponent={<VictoryTooltip />}
+          />
+        </VictoryChart>
+
+        <VictoryChart style={{ parent: parentStyle }} containerComponent={<VictoryZoomContainer />}>
+          <VictoryLine
+            style={{
+              parent: parentStyle,
+              data: { stroke: "red", strokeWidth: 6 }
+            }}
+            events={[
+              {
+                target: "data",
+                eventHandlers: {
+                  onClick: () => {
+                    return [
+                      {
+                        mutation: (props) => {
+                          return { style: merge({}, props.style, { stroke: "orange" }) };
+                        }
+                      },
+                      {
+                        target: "labels",
+                        mutation: () => {
+                          return { text: "hey" };
+                        }
+                      }
+                    ];
+                  }
+                }
+              }
+            ]}
+            data={range(0, 100)}
+            y={(d) => d * d}
+          />
+        </VictoryChart>
+
+        <VictoryChart style={{ parent: parentStyle }} containerComponent={<VictoryZoomContainer />}>
+          <VictoryArea
+            style={{ parent: parentStyle, data: { stroke: "#333", fill: "#888", opacity: 0.4 } }}
+            data={this.state.data}
+            x="a"
+            y="b"
+            interpolation="stepBefore"
+          />
+          <VictoryAxis />
+          <VictoryLine data={this.state.data} x="a" y="b" interpolation="stepBefore" />
+          <VictoryAxis dependentAxis />
+        </VictoryChart>
+
+        <button onClick={() => this.setState({ zoomDomain: this.getZoomDomain() })}>
+          random y domain
+        </button>
+
+        <VictoryChart
+          containerComponent={
+            <VictoryZoomContainer zoomDimension="x" zoomDomain={this.state.zoomDomain} />
+          }
+          animate={{ duration: 500 }}
+          style={{ parent: parentStyle }}
+        >
+          <VictoryLine
+            name="line"
+            style={{ parent: parentStyle, data: { stroke: "blue" } }}
+            y={(d) => Math.sin(2 * Math.PI * d.x)}
+            sample={25}
+          />
+        </VictoryChart>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          height={400}
+          padding={{ top: 80, bottom: 50, left: 50, right: 50 }}
+          containerComponent={<VictoryZoomContainer />}
+          theme={VictoryTheme.material}
+          events={[
+            {
+              childName: "area-1",
+              target: "data",
+              eventHandlers: {
+                onClick: () => {
+                  return [
+                    {
+                      childName: "area-2",
+                      target: "data",
+                      mutation: (props) => {
+                        return { style: merge({}, props.style, { fill: "gold" }) };
+                      }
+                    },
+                    {
+                      childName: "area-3",
+                      target: "data",
+                      mutation: (props) => {
+                        return {
+                          style: merge({}, props.style, { fill: "orange" })
+                        };
+                      }
+                    },
+                    {
+                      childName: "area-4",
+                      target: "data",
+                      mutation: (props) => {
+                        return {
+                          style: merge({}, props.style, { fill: "red" })
+                        };
+                      }
+                    }
+                  ];
+                }
+              }
+            }
+          ]}
+        >
+          <VictoryLegend
+            x={83}
+            y={10}
+            title="Legend"
+            centerTitle
+            orientation="horizontal"
+            gutter={20}
+            style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
+            data={[
+              { name: "One", symbol: { fill: "tomato" } },
+              { name: "Two", symbol: { fill: "orange" } },
+              { name: "Three", symbol: { fill: "gold" } }
+            ]}
+          />
+          <VictoryAxis />
+          <VictoryStack>
+            <VictoryArea
+              name="area-1"
+              data={[
+                { x: "a", y: 2 },
+                { x: "b", y: 3 },
+                { x: "c", y: 5 },
+                { x: "d", y: 4 },
+                { x: "e", y: 7 }
+              ]}
+            />
+            <VictoryArea
+              name="area-2"
+              data={[
+                { x: "a", y: 1 },
+                { x: "b", y: 4 },
+                { x: "c", y: 5 },
+                { x: "d", y: 7 },
+                { x: "e", y: 5 }
+              ]}
+            />
+            <VictoryArea
+              name="area-3"
+              data={[
+                { x: "a", y: 3 },
+                { x: "b", y: 2 },
+                { x: "c", y: 6 },
+                { x: "d", y: 2 },
+                { x: "e", y: 6 }
+              ]}
+            />
+            <VictoryArea
+              name="area-4"
+              data={[
+                { x: "a", y: 2 },
+                { x: "b", y: 3 },
+                { x: "c", y: 3 },
+                { x: "d", y: 4 },
+                { x: "e", y: 7 }
+              ]}
+            />
+          </VictoryStack>
+          <VictoryAxis dependentAxis />
+        </VictoryChart>
+        <VictoryChart
+          horizontal
+          style={{ parent: parentStyle }}
+          containerComponent={<VictoryZoomContainer zoomDimension="x" />}
+        >
+          <VictoryBar
+            style={{ data: { stroke: "#333", fill: "#888", opacity: 0.4 } }}
+            data={this.state.data}
+            x="a"
+            y="b"
+          />
+          <VictoryAxis />
+          <VictoryAxis dependentAxis />
+        </VictoryChart>
+      </div>
+    );
+  }
+}

--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -25,15 +25,12 @@ const allData = range(0, 10, 0.001).map((x) => ({
   y: (Math.sin((Math.PI * x) / 2) * x) / 10
 }));
 
-interface CustomChartProps {
-  data: { x: number; y: number }[];
-  maxPoint: number;
-  style: React.CSSProperties;
+interface CustomChartState {
   zoomedXDomain: RangeTuple;
 }
 
-class CustomChart extends React.Component<any, CustomChartProps> {
-  entireDomain?: { x?: RangeTuple; y?: RangeTuple };
+class CustomChart extends React.Component<any, CustomChartState> {
+  entireDomain: { x: RangeTuple; y: RangeTuple };
 
   static propTypes = {
     data: PropTypes.array,
@@ -49,7 +46,7 @@ class CustomChart extends React.Component<any, CustomChartProps> {
     };
   }
 
-  onDomainChange(domain: { x?: RangeTuple | [Date, Date]; y?: RangeTuple | [Date, Date] }) {
+  onDomainChange(domain: { x: RangeTuple; y: RangeTuple }) {
     this.setState({
       zoomedXDomain: domain.x
     });
@@ -69,11 +66,24 @@ class CustomChart extends React.Component<any, CustomChartProps> {
     return filtered;
   }
 
-  getEntireDomain(props: any) {
-    const { data } = props;
+  getEntireDomain(props: { data: { x: RangeTuple; y: RangeTuple }[] }) {
+    const { data }: { data: { x: RangeTuple; y: RangeTuple }[] } = props;
+
+    const minPoint = minBy(data, (d: { x: RangeTuple; y: RangeTuple }) => d.y);
+    const yMin = minPoint ? minPoint.y : 0;
+
+    const maxPoint = maxBy(data, (d: { x: RangeTuple; y: RangeTuple }) => d.y);
+    const yMax = maxPoint ? maxPoint.y : 0;
+
+    const lastPoint = last(data);
+    const xLast = lastPoint ? lastPoint.x : 0;
+
+    const yArr: RangeTuple = [yMin, yMax];
+    const xArr: RangeTuple = [data[0].x, xLast];
+
     return {
-      y: [minBy(data, (d: { y: number }) => d.y), maxBy(data, (d: { y: number }) => d.y)],
-      x: [data[0], last(data)]
+      y: yArr,
+      x: xArr
     };
   }
 
@@ -106,21 +116,21 @@ class CustomChart extends React.Component<any, CustomChartProps> {
 interface VictoryZoomContainerDemoState {
   arrayData: number[][];
   barData: {
-    x?: number;
-    y?: number;
+    x: number;
+    y: number;
   }[];
   data: {
-    a?: number;
-    b?: number;
+    a: number;
+    b: number;
   }[];
   style: React.CSSProperties;
   transitionData: {
-    x?: number;
-    y?: number;
+    x: number;
+    y: number;
   }[];
   zoomDomain: {
-    x?: RangeTuple | [Date, Date] | number[];
-    y?: RangeTuple | [Date, Date] | number[];
+    x?: RangeTuple;
+    y?: RangeTuple;
   };
 }
 

--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -1,7 +1,6 @@
 /*eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
-import PropTypes from "prop-types";
-import { range, merge, random, minBy, maxBy, last, round } from "lodash";
+import { range, merge, random, minBy, maxBy, last } from "lodash";
 import { VictoryChart } from "@packages/victory-chart";
 import { VictoryStack } from "@packages/victory-stack";
 import { VictoryGroup } from "@packages/victory-group";
@@ -14,7 +13,8 @@ import { VictoryZoomContainer } from "@packages/victory-zoom-container";
 import { VictoryTooltip } from "@packages/victory-tooltip";
 import { VictoryLegend } from "@packages/victory-legend";
 import {
-  RangeTuple,
+  CoordinatesPropType,
+  DomainTuple,
   VictoryClipContainer,
   VictoryPortal,
   VictoryTheme
@@ -26,27 +26,23 @@ const allData = range(0, 10, 0.001).map((x) => ({
 }));
 
 interface CustomChartState {
-  zoomedXDomain: RangeTuple;
+  zoomedXDomain: DomainTuple;
 }
 
 class CustomChart extends React.Component<any, CustomChartState> {
-  entireDomain: { x: RangeTuple; y: RangeTuple };
-
-  static propTypes = {
-    data: PropTypes.array,
-    maxPoints: PropTypes.number,
-    style: PropTypes.object
-  };
+  entireDomain: { x: DomainTuple; y: DomainTuple };
 
   constructor(props: any) {
     super(props);
+
     this.entireDomain = this.getEntireDomain(props);
+
     this.state = {
       zoomedXDomain: this.entireDomain.x
     };
   }
 
-  onDomainChange(domain: { x: RangeTuple; y: RangeTuple }) {
+  onDomainChange(domain: { x: DomainTuple; y: DomainTuple }) {
     this.setState({
       zoomedXDomain: domain.x
     });
@@ -66,31 +62,25 @@ class CustomChart extends React.Component<any, CustomChartState> {
     return filtered;
   }
 
-  getEntireDomain(props: { data: { x: RangeTuple; y: RangeTuple }[] }) {
-    const { data }: { data: { x: RangeTuple; y: RangeTuple }[] } = props;
+  getEntireDomain(props: { data: CoordinatesPropType[] }) {
+    const { data }: { data: CoordinatesPropType[] } = props;
 
-    const minPoint = minBy(data, (d: { x: RangeTuple; y: RangeTuple }) => d.y);
+    const minPoint = minBy(data, (d: CoordinatesPropType) => d.y);
     const yMin = minPoint ? minPoint.y : 0;
 
-    const maxPoint = maxBy(data, (d: { x: RangeTuple; y: RangeTuple }) => d.y);
+    const maxPoint = maxBy(data, (d: CoordinatesPropType) => d.y);
     const yMax = maxPoint ? maxPoint.y : 0;
 
     const lastPoint = last(data);
     const xLast = lastPoint ? lastPoint.x : 0;
 
-    const yArr: RangeTuple = [yMin, yMax];
-    const xArr: RangeTuple = [data[0].x, xLast];
+    const yArr: DomainTuple = [yMin, yMax];
+    const xArr: DomainTuple = [data[0].x, xLast];
 
     return {
-      y: yArr,
-      x: xArr
+      x: xArr,
+      y: yArr
     };
-  }
-
-  getZoomFactor() {
-    const { zoomedXDomain } = this.state;
-    const factor = 10 / (zoomedXDomain[1] - zoomedXDomain[0]);
-    return round(factor, factor < 3 ? 1 : 0);
   }
 
   render() {
@@ -129,8 +119,8 @@ interface VictoryZoomContainerDemoState {
     y: number;
   }[];
   zoomDomain: {
-    x?: RangeTuple;
-    y?: RangeTuple;
+    x?: DomainTuple;
+    y?: DomainTuple;
   };
 }
 
@@ -187,8 +177,10 @@ export default class VictoryZoomContainerDemo extends React.Component<
   }
 
   getZoomDomain() {
+    const yZoomDomain: DomainTuple = [random(0, 0.4), random(0.6, 1)];
+
     return {
-      y: [random(0, 0.4), random(0.6, 1)]
+      y: yZoomDomain
     };
   }
 

--- a/packages/victory-brush-container/src/index.d.ts
+++ b/packages/victory-brush-container/src/index.d.ts
@@ -17,11 +17,11 @@ export interface VictoryBrushContainerProps extends VictoryContainerProps {
     props: VictoryBrushContainerProps
   ) => void;
   onBrushDomainChange?: (
-    domain: { x?: DomainTuple; y?: DomainTuple },
+    domain: { x: DomainTuple; y: DomainTuple },
     props: VictoryBrushContainerProps
   ) => void;
   onBrushDomainChangeEnd?: (
-    domain: { x?: DomainTuple; y?: DomainTuple },
+    domain: { x: DomainTuple; y: DomainTuple },
     props: VictoryBrushContainerProps
   ) => void;
 }

--- a/packages/victory-brush-container/src/index.d.ts
+++ b/packages/victory-brush-container/src/index.d.ts
@@ -1,27 +1,27 @@
 import * as React from "react";
-import { RangeTuple, VictoryContainerProps } from "victory-core";
+import { DomainTuple, VictoryContainerProps } from "victory-core";
 
 export interface VictoryBrushContainerProps extends VictoryContainerProps {
   allowDrag?: boolean;
   allowResize?: boolean;
   brushComponent?: React.ReactElement;
   brushDimension?: "x" | "y";
-  brushDomain?: { x?: RangeTuple; y?: RangeTuple };
+  brushDomain?: { x?: DomainTuple; y?: DomainTuple };
   brushStyle?: React.CSSProperties;
   defaultBrushArea?: "all" | "none" | "disable" | "move";
   disable?: boolean;
   handleComponent?: React.ReactElement;
   handleStyle?: React.CSSProperties;
   onBrushCleared?: (
-    domain: { x?: RangeTuple; y?: RangeTuple },
+    domain: { x: DomainTuple; y: DomainTuple },
     props: VictoryBrushContainerProps
   ) => void;
   onBrushDomainChange?: (
-    domain: { x?: RangeTuple; y?: RangeTuple },
+    domain: { x?: DomainTuple; y?: DomainTuple },
     props: VictoryBrushContainerProps
   ) => void;
   onBrushDomainChangeEnd?: (
-    domain: { x?: RangeTuple; y?: RangeTuple },
+    domain: { x?: DomainTuple; y?: DomainTuple },
     props: VictoryBrushContainerProps
   ) => void;
 }

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -107,7 +107,7 @@ export type VictoryStyleObject = { [K in keyof React.CSSProperties]: StringOrNum
 
 export type StringOrNumberOrList = string | number | (string | number)[];
 
-export type CursorData = {
+export type CoordinatesPropType = {
   x: number;
   y: number;
 };

--- a/packages/victory-cursor-container/src/index.d.ts
+++ b/packages/victory-cursor-container/src/index.d.ts
@@ -1,15 +1,15 @@
 import * as React from "react";
-import { VictoryContainerProps, CursorData } from "victory-core";
+import { VictoryContainerProps, CoordinatesPropType } from "victory-core";
 
 export interface VictoryCursorContainerProps extends VictoryContainerProps {
   cursorComponent?: React.ReactElement;
   cursorDimension?: "x" | "y";
-  cursorLabel?: (point: CursorData) => any | void;
+  cursorLabel?: (point: CoordinatesPropType) => any | void;
   cursorLabelComponent?: React.ReactElement;
-  cursorLabelOffset?: number | CursorData;
-  defaultCursorValue?: number | CursorData;
+  cursorLabelOffset?: number | CoordinatesPropType;
+  defaultCursorValue?: number | CoordinatesPropType;
   disable?: boolean;
-  onCursorChange?: (value: CursorData, props: VictoryCursorContainerProps) => void;
+  onCursorChange?: (value: CoordinatesPropType, props: VictoryCursorContainerProps) => void;
 }
 
 export class VictoryCursorContainer extends React.Component<VictoryCursorContainerProps, any> {}

--- a/packages/victory-zoom-container/src/index.d.ts
+++ b/packages/victory-zoom-container/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { RangeTuple, VictoryContainerProps, CoordinatesPropType } from "victory-core";
+import { VictoryContainerProps, RangeTuple } from "victory-core";
 
 export interface VictoryZoomContainerProps extends VictoryContainerProps {
   allowPan?: boolean;
@@ -7,13 +7,13 @@ export interface VictoryZoomContainerProps extends VictoryContainerProps {
   clipContainerComponent?: React.ReactElement;
   disable?: boolean;
   downsample?: number | boolean;
-  minimumZoom?: CoordinatesPropType;
+  minimumZoom?: { x?: number; y?: number };
   onZoomDomainChange?: (
-    domain: { x?: RangeTuple | [Date, Date]; y?: RangeTuple | [Date, Date] },
+    domain: { x: RangeTuple; y: RangeTuple },
     props: VictoryZoomContainerProps
   ) => void;
   zoomDimension?: "x" | "y";
-  zoomDomain?: { x?: RangeTuple | [Date, Date]; y?: RangeTuple | [Date, Date] };
+  zoomDomain?: { x?: RangeTuple; y?: RangeTuple };
 }
 
 export class VictoryZoomContainer extends React.Component<VictoryZoomContainerProps, any> {}

--- a/packages/victory-zoom-container/src/index.d.ts
+++ b/packages/victory-zoom-container/src/index.d.ts
@@ -1,15 +1,13 @@
 import * as React from "react";
-import { RangeTuple, VictoryContainerProps, CursorData } from "victory-core";
+import { RangeTuple, VictoryContainerProps, CoordinatesPropType } from "victory-core";
 
 export interface VictoryZoomContainerProps extends VictoryContainerProps {
   allowPan?: boolean;
   allowZoom?: boolean;
-  brushStyle?: React.CSSProperties;
   clipContainerComponent?: React.ReactElement;
-  defaultBrushArea?: "all" | "none" | "disable";
   disable?: boolean;
   downsample?: number | boolean;
-  minimumZoom?: CursorData;
+  minimumZoom?: CoordinatesPropType;
   onZoomDomainChange?: (
     domain: { x?: RangeTuple; y?: RangeTuple },
     props: VictoryZoomContainerProps

--- a/packages/victory-zoom-container/src/index.d.ts
+++ b/packages/victory-zoom-container/src/index.d.ts
@@ -9,11 +9,11 @@ export interface VictoryZoomContainerProps extends VictoryContainerProps {
   downsample?: number | boolean;
   minimumZoom?: CoordinatesPropType;
   onZoomDomainChange?: (
-    domain: { x?: RangeTuple; y?: RangeTuple },
+    domain: { x?: RangeTuple | [Date, Date]; y?: RangeTuple | [Date, Date] },
     props: VictoryZoomContainerProps
   ) => void;
   zoomDimension?: "x" | "y";
-  zoomDomain?: { x?: RangeTuple; y?: RangeTuple };
+  zoomDomain?: { x?: RangeTuple | [Date, Date]; y?: RangeTuple | [Date, Date] };
 }
 
 export class VictoryZoomContainer extends React.Component<VictoryZoomContainerProps, any> {}

--- a/packages/victory-zoom-container/src/index.d.ts
+++ b/packages/victory-zoom-container/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { VictoryContainerProps, RangeTuple } from "victory-core";
+import { DomainTuple, VictoryContainerProps } from "victory-core";
 
 export interface VictoryZoomContainerProps extends VictoryContainerProps {
   allowPan?: boolean;
@@ -9,11 +9,11 @@ export interface VictoryZoomContainerProps extends VictoryContainerProps {
   downsample?: number | boolean;
   minimumZoom?: { x?: number; y?: number };
   onZoomDomainChange?: (
-    domain: { x: RangeTuple; y: RangeTuple },
+    domain: { x: DomainTuple; y: DomainTuple },
     props: VictoryZoomContainerProps
   ) => void;
   zoomDimension?: "x" | "y";
-  zoomDomain?: { x?: RangeTuple; y?: RangeTuple };
+  zoomDomain?: { x?: DomainTuple; y?: DomainTuple };
 }
 
 export class VictoryZoomContainer extends React.Component<VictoryZoomContainerProps, any> {}


### PR DESCRIPTION
* Updates the name of `CursorData` to `CoordinatesPropType` 
* Updates the `VictoryBrushContainerProps` and `VictoryBrushContainerDemo` to use `DomainTuple` instead `RangeTuple`
* Adds a `VictoryZoomContainerDemo`
* Adds and updates missing props and their typescript definitions for `VictoryZoomContainerProps` interface
* Removes props from `VictoryZoomContainerProps` interface that do not belong