### PR TITLE
Update DefinitelyTyped props for VictoryStack

### DIFF
--- a/packages/victory-stack/src/index.d.ts
+++ b/packages/victory-stack/src/index.d.ts
@@ -5,20 +5,26 @@ import {
   DomainPaddingPropType,
   DomainPropType,
   EventPropTypeInterface,
+  OriginType,
   StringOrNumberOrCallback,
   VictoryCommonProps,
+  VictoryLabelableProps,
   VictoryMultiLabelableProps,
   VictoryStyleInterface
 } from "victory-core";
 
-export interface VictoryStackProps extends VictoryCommonProps, VictoryMultiLabelableProps {
+export interface VictoryStackProps
+  extends VictoryCommonProps,
+    VictoryLabelableProps,
+    VictoryMultiLabelableProps {
   categories?: CategoryPropType;
+  children?: React.ReactNode | React.ReactNode[];
   colorScale?: ColorScalePropType;
   domain?: DomainPropType;
-  domainPadding?: DomainPaddingPropType;
   events?: EventPropTypeInterface<"data" | "labels" | "parent", StringOrNumberOrCallback>[];
   eventKey?: StringOrNumberOrCallback;
-  horizontal?: boolean;
+  fillInMissingData?: boolean;
+  origin?: OriginType;
   style?: VictoryStyleInterface;
   xOffset?: number;
 }


### PR DESCRIPTION
Add the following props to VictoryStack:

- children
- fillInMissingData
- origin

and remove the following redundant props:

- domainPadding
- horizontal