### PR TITLE
Export TextSize types from VictoryCore

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -632,11 +632,11 @@ export namespace Selection {
 }
 
 export interface TextSizeStyleInterface {
+  angle?: number;
+  characterConstant?: string;
   fontFamily?: string;
   fontSize?: number | string;
-  angle?: number;
   letterSpacing?: string;
-  characterConstant?: string;
   lineHeight?: number;
 }
 

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -631,6 +631,20 @@ export namespace Selection {
   export function getBounds(props: any): SVGCoordinateType;
 }
 
+export interface TextSizeStyleInterface {
+  fontFamily?: string;
+  fontSize?: number | string;
+  angle?: number;
+  letterSpacing?: string;
+  characterConstant?: string;
+  lineHeight?: number;
+}
+
+export namespace TextSize {
+  export function approximateTextSize(text: string, style: TextSizeStyleInterface): number;
+  export function convertLengthToPixels(length: string, fontSize: number): number;
+}
+
 // #endregion
 
 // #region Victory Portal

--- a/packages/victory/src/index.d.ts
+++ b/packages/victory/src/index.d.ts
@@ -34,7 +34,7 @@ declare module "victory" {
     // PropTypes,
     // Scale,
     // Style,
-    // TextSize,
+    TextSize,
     // Transitions,
     Selection
     // LabelHelpers,
@@ -190,7 +190,7 @@ declare module "victory" {
     // PropTypes,
     // Scale,
     // Style,
-    // TextSize,
+    TextSize,
     // Transitions,
     Selection
     // LabelHelpers,


### PR DESCRIPTION
This PR adds an interface for TextSizeStyle and exports types for public TextSize methods