### PR TITLE
VictoryChart: adds an option for adding background for chart area

### DIFF
--- a/demo/js/components/victory-axis-demo.js
+++ b/demo/js/components/victory-axis-demo.js
@@ -42,7 +42,7 @@ export default class App extends React.Component {
 
   render() {
     const style = {
-      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
     };
 
     const styleOverrides = {

--- a/demo/js/components/victory-axis-demo.js
+++ b/demo/js/components/victory-axis-demo.js
@@ -42,7 +42,7 @@ export default class App extends React.Component {
 
   render() {
     const style = {
-      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
     };
 
     const styleOverrides = {

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -182,7 +182,7 @@ class App extends React.Component {
     };
     const chartStyle = {
       parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
-      background: { fill: "orange" }
+      background: { fill: "red", opacity: .4 }
     };
     const axisStyle = {
       grid: { stroke: "grey", strokeWidth: 1 },
@@ -190,10 +190,26 @@ class App extends React.Component {
       ticks: { stroke: "transparent" },
       tickLabels: { fill: "none" }
     };
+
     return (
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
+          <VictoryChart polar={true} style={chartStyle}>
+            <VictoryBar
+              data={[
+                { x: 1, y: 1 },
+                { x: 2, y: 2 },
+                { x: 3, y: 3 },
+                { x: 4, y: 4 },
+                { x: 5, y: 5 },
+                { x: 6, y: 4 },
+                { x: 7, y: 3 },
+                { x: 8, y: 2 },
+                { x: 9, y: 1 }
+              ]}
+            />
+          </VictoryChart>
           <VictoryChart style={chartStyle}>
             <VictoryScatter data={[{ x: -3, y: -3 }]} />
           </VictoryChart>

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -181,8 +181,7 @@ class App extends React.Component {
       justifyContent: "center"
     };
     const chartStyle = {
-      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
-      background: { fill: "red", opacity: .4 }
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
     };
     const axisStyle = {
       grid: { stroke: "grey", strokeWidth: 1 },
@@ -195,21 +194,6 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
-          <VictoryChart polar={true} style={chartStyle}>
-            <VictoryBar
-              data={[
-                { x: 1, y: 1 },
-                { x: 2, y: 2 },
-                { x: 3, y: 3 },
-                { x: 4, y: 4 },
-                { x: 5, y: 5 },
-                { x: 6, y: 4 },
-                { x: 7, y: 3 },
-                { x: 8, y: 2 },
-                { x: 9, y: 1 }
-              ]}
-            />
-          </VictoryChart>
           <VictoryChart style={chartStyle}>
             <VictoryScatter data={[{ x: -3, y: -3 }]} />
           </VictoryChart>

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -180,7 +180,7 @@ class App extends React.Component {
       alignItems: "center",
       justifyContent: "center"
     };
-    const chartStyle = { 
+    const chartStyle = {
       parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
       background: { fill: "orange" }
     };

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -180,7 +180,10 @@ class App extends React.Component {
       alignItems: "center",
       justifyContent: "center"
     };
-    const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
+    const chartStyle = { 
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
+      background: { fill: "orange" }
+    };
     const axisStyle = {
       grid: { stroke: "grey", strokeWidth: 1 },
       axis: { stroke: "transparent" },

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -182,8 +182,7 @@ class App extends React.Component {
     };
     const chartStyle = {
       parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
-    }
-    ;
+    };
     const axisStyle = {
       grid: { stroke: "grey", strokeWidth: 1 },
       axis: { stroke: "transparent" },
@@ -193,7 +192,7 @@ class App extends React.Component {
 
     const bgStyle = {
       background: { fill: "#e6e6ff" }
-    }
+    };
 
     return (
       <div className="demo">

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -203,11 +203,7 @@ class App extends React.Component {
           </VictoryChart>
 
           <VictoryChart style={assign({}, chartStyle, bgStyle)}>
-            <VictoryScatter data={[{ x: -3, y: -3 }]} />
-          </VictoryChart>
-
-          <VictoryChart style={chartStyle} theme={dependentAxisTheme}>
-            <VictoryScatter />
+            <VictoryScatter data={[{ x: -3, y: -3 }, { x: -2, y: 2 }, { x: 1, y: -1 }]} />
           </VictoryChart>
 
           <VictoryChart style={chartStyle} theme={dependentAxisTheme}>

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -11,7 +11,12 @@ import { VictoryArea } from "Packages/victory-area/src/index";
 import { VictoryBar } from "Packages/victory-bar/src/index";
 import { VictoryLine } from "Packages/victory-line/src/index";
 import { VictoryScatter } from "Packages/victory-scatter/src/index";
-import { VictoryLabel, VictoryTheme, VictoryClipContainer } from "Packages/victory-core/src/index";
+import {
+  Background,
+  VictoryLabel,
+  VictoryTheme,
+  VictoryClipContainer
+} from "Packages/victory-core/src/index";
 
 const UPDATE_INTERVAL = 3000;
 

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -181,8 +181,7 @@ class App extends React.Component {
       justifyContent: "center"
     };
     const chartStyle = {
-      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
-      background: {fill: "cornflowerblue"}
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
     };
     const axisStyle = {
       grid: { stroke: "grey", strokeWidth: 1 },
@@ -195,7 +194,7 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
-        <VictoryChart style={chartStyle} polar={true}>
+          <VictoryChart style={chartStyle} polar>
             <VictoryScatter data={[{ x: -3, y: -3 }]} />
           </VictoryChart>
 

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -181,7 +181,8 @@ class App extends React.Component {
       justifyContent: "center"
     };
     const chartStyle = {
-      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
+      background: {fill: "cornflowerblue"}
     };
     const axisStyle = {
       grid: { stroke: "grey", strokeWidth: 1 },
@@ -194,6 +195,10 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
+        <VictoryChart style={chartStyle} polar={true}>
+            <VictoryScatter data={[{ x: -3, y: -3 }]} />
+          </VictoryChart>
+
           <VictoryChart style={chartStyle}>
             <VictoryScatter data={[{ x: -3, y: -3 }]} />
           </VictoryChart>

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -11,12 +11,7 @@ import { VictoryArea } from "Packages/victory-area/src/index";
 import { VictoryBar } from "Packages/victory-bar/src/index";
 import { VictoryLine } from "Packages/victory-line/src/index";
 import { VictoryScatter } from "Packages/victory-scatter/src/index";
-import {
-  Background,
-  VictoryLabel,
-  VictoryTheme,
-  VictoryClipContainer
-} from "Packages/victory-core/src/index";
+import { VictoryLabel, VictoryTheme, VictoryClipContainer } from "Packages/victory-core/src/index";
 
 const UPDATE_INTERVAL = 3000;
 

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -182,7 +182,8 @@ class App extends React.Component {
     };
     const chartStyle = {
       parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
-    };
+    }
+    ;
     const axisStyle = {
       grid: { stroke: "grey", strokeWidth: 1 },
       axis: { stroke: "transparent" },
@@ -190,16 +191,24 @@ class App extends React.Component {
       tickLabels: { fill: "none" }
     };
 
+    const bgStyle = {
+      background: { fill: "#e6e6ff" }
+    }
+
     return (
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
           <VictoryChart style={chartStyle} polar>
+            <VictoryScatter />
+          </VictoryChart>
+
+          <VictoryChart style={assign({}, chartStyle, bgStyle)}>
             <VictoryScatter data={[{ x: -3, y: -3 }]} />
           </VictoryChart>
 
-          <VictoryChart style={chartStyle}>
-            <VictoryScatter data={[{ x: -3, y: -3 }]} />
+          <VictoryChart style={chartStyle} theme={dependentAxisTheme}>
+            <VictoryScatter />
           </VictoryChart>
 
           <VictoryChart style={chartStyle} theme={dependentAxisTheme}>

--- a/demo/ts/components/victory-chart-demo.tsx
+++ b/demo/ts/components/victory-chart-demo.tsx
@@ -208,13 +208,18 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
       alignItems: "center",
       justifyContent: "center"
     };
-    const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
-    const axisStyle = {
+
+    const chartStyle: { [key: string]: React.CSSProperties } = {
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
+    };
+
+    const axisStyle: { [key: string]: React.CSSProperties } = {
       grid: { stroke: "grey", strokeWidth: 1 },
       axis: { stroke: "transparent" },
       ticks: { stroke: "transparent" },
       tickLabels: { fill: "none" }
     };
+
     return (
       <div className="demo">
         <h1>VictoryChart</h1>

--- a/demo/ts/components/victory-chart-demo.tsx
+++ b/demo/ts/components/victory-chart-demo.tsx
@@ -220,12 +220,20 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
       tickLabels: { fill: "none" }
     };
 
+    const bgStyle: { [key: string]: React.CSSProperties } = {
+      background: { fill: "#e6e6ff" }
+    };
+
     return (
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
-          <VictoryChart style={chartStyle}>
-            <VictoryScatter data={[{ x: -3, y: -3 }]} />
+          <VictoryChart style={chartStyle} polar>
+            <VictoryScatter />
+          </VictoryChart>
+
+          <VictoryChart style={assign({}, chartStyle, bgStyle)}>
+            <VictoryScatter data={[{ x: -3, y: -3 }, { x: -2, y: 2 }, { x: 1, y: -1 }]} />
           </VictoryChart>
 
           <VictoryChart style={chartStyle} theme={dependentAxisTheme}>

--- a/demo/ts/components/victory-polar-axis-demo.tsx
+++ b/demo/ts/components/victory-polar-axis-demo.tsx
@@ -10,7 +10,7 @@ import { VictoryScatter } from "@packages/victory-scatter";
 import { VictoryZoomContainer } from "@packages/victory-zoom-container";
 import { VictoryVoronoiContainer } from "@packages/victory-voronoi-container";
 import { random, range, keys } from "lodash";
-import { VictoryTheme, VictoryLabel, VictoryStyleInterface } from "@packages/victory-core";
+import { VictoryTheme, VictoryLabel } from "@packages/victory-core";
 
 type multiAxisDataListType = {
   strength?: number;
@@ -115,7 +115,7 @@ class App extends React.Component<any, VictoryPolarAxisState> {
       justifyContent: "center"
     };
 
-    const chartStyle: VictoryStyleInterface = {
+    const chartStyle: { [key: string]: React.CSSProperties } = {
       parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
     };
 

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -48,7 +48,7 @@ function getChildProps(child, props, calculatedProps) {
 function getStyles(props) {
   const styleProps = props.style && props.style.parent;
   const background = props.style && props.style.background;
-  
+
   return {
     parent: defaults({}, styleProps, {
       height: "100%",
@@ -162,26 +162,28 @@ function getChildren(props, childComponents, calculatedProps) {
 
 const getChildComponents = (props, defaultAxes) => {
   const childComponents = React.Children.toArray(props.children);
+  let newChildComponents = [...childComponents];
+
   if (childComponents.length === 0) {
-    return [defaultAxes.independent, defaultAxes.dependent];
-  }
+    newChildComponents.push(defaultAxes.independent, defaultAxes.dependent);
+  } else {
+    const axisComponents = {
+      dependent: Axis.getAxisComponentsWithParent(childComponents, "dependent"),
+      independent: Axis.getAxisComponentsWithParent(childComponents, "independent")
+    };
 
-  const axisComponents = {
-    dependent: Axis.getAxisComponentsWithParent(childComponents, "dependent"),
-    independent: Axis.getAxisComponentsWithParent(childComponents, "independent")
-  };
-
-  if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
-    return props.prependDefaultAxes
-      ? [defaultAxes.independent, defaultAxes.dependent].concat(childComponents)
-      : childComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
+    if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
+      newChildComponents = props.prependDefaultAxes
+        ? [defaultAxes.independent, defaultAxes.dependent].concat(newChildComponents)
+        : newChildComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
+    }
   }
 
   if (props.style && props.style.background && typeof props.backgroundComponent === "object") {
-    return [props.backgroundComponent].concat(childComponents);
+    newChildComponents.unshift(props.backgroundComponent);
   }
 
-  return childComponents;
+  return newChildComponents;
 };
 
 const getDomain = (props, axis, childComponents) => {

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -172,6 +172,11 @@ const getChildComponents = (props, defaultAxes) => {
       ? [defaultAxes.independent, defaultAxes.dependent].concat(childComponents)
       : childComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
   }
+
+  if (props.style && props.style.background && typeof props.backgroundComponent === "object") {
+    return [props.backgroundComponent].concat(childComponents);
+  }
+
   return childComponents;
 };
 

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -47,12 +47,15 @@ function getChildProps(child, props, calculatedProps) {
 
 function getStyles(props) {
   const styleProps = props.style && props.style.parent;
+  const background = props.style && props.style.background;
+  
   return {
     parent: defaults({}, styleProps, {
       height: "100%",
       width: "100%",
       userSelect: "none"
-    })
+    }),
+    background
   };
 }
 
@@ -126,6 +129,7 @@ function getChildren(props, childComponents, calculatedProps) {
   childComponents = childComponents || getChildComponents(props);
   calculatedProps = calculatedProps || getCalculatedProps(props, childComponents);
   const baseStyle = calculatedProps.style.parent;
+  const backgroundStyle = calculatedProps.style.background;
   const { height, polar, theme, width } = props;
   const { origin, horizontal } = calculatedProps;
   const parentName = props.name || "chart";
@@ -133,7 +137,7 @@ function getChildren(props, childComponents, calculatedProps) {
     const role = child.type && child.type.role;
     const style = Array.isArray(child.props.style)
       ? child.props.style
-      : defaults({}, child.props.style, { parent: baseStyle });
+      : defaults({}, child.props.style, { parent: baseStyle, background: backgroundStyle });
     const childProps = getChildProps(child, props, calculatedProps);
     const name = child.props.name || `${parentName}-${role}-${index}`;
     const newProps = defaults(

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -57,6 +57,7 @@ function getBackgroundWithProps(props, calculatedProps) {
   const backgroundProps = {
     height,
     polar: props.polar,
+    scale: calculatedProps.scale,
     style: props.style.background,
     x: xCoordinate,
     y: yCoordinate,

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -77,15 +77,13 @@ function getChildProps(child, props, calculatedProps) {
 
 function getStyles(props) {
   const styleProps = props.style && props.style.parent;
-  const background = props.style && props.style.background;
 
   return {
     parent: defaults({}, styleProps, {
       height: "100%",
       width: "100%",
       userSelect: "none"
-    }),
-    background
+    })
   };
 }
 
@@ -159,7 +157,6 @@ function getChildren(props, childComponents, calculatedProps) {
   childComponents = childComponents || getChildComponents(props);
   calculatedProps = calculatedProps || getCalculatedProps(props, childComponents);
   const baseStyle = calculatedProps.style.parent;
-  const backgroundStyle = calculatedProps.style.background;
   const { height, polar, theme, width } = props;
   const { origin, horizontal } = calculatedProps;
   const parentName = props.name || "chart";
@@ -168,7 +165,7 @@ function getChildren(props, childComponents, calculatedProps) {
     const role = child.type && child.type.role;
     const style = Array.isArray(child.props.style)
       ? child.props.style
-      : defaults({}, child.props.style, { parent: baseStyle, background: backgroundStyle });
+      : defaults({}, child.props.style, { parent: baseStyle });
     const childProps = getChildProps(child, props, calculatedProps);
     const name = child.props.name || `${parentName}-${role}-${index}`;
     const newProps = defaults(

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -38,16 +38,29 @@ function getAxisProps(child, props, calculatedProps) {
 
 function getBackgroundWithProps(props, calculatedProps) {
   const backgroundElement = props.backgroundComponent;
-  const height = props.polar ? calculatedProps.range.y[1] : calculatedProps.range.y[0] - calculatedProps.range.y[1];
+
+  const height = props.polar
+    ? calculatedProps.range.y[1]
+    : calculatedProps.range.y[0] - calculatedProps.range.y[1];
   const width = calculatedProps.range.x[1] - calculatedProps.range.x[0];
 
+  const xScale = props.horizontal
+    ? calculatedProps.scale.y.range()[0]
+    : calculatedProps.scale.x.range()[0];
+  const yScale = props.horizontal
+    ? calculatedProps.scale.x.range()[1]
+    : calculatedProps.scale.y.range()[1];
+
+  const xCoordinate = props.polar ? calculatedProps.origin.x : xScale;
+  const yCoordinate = props.polar ? calculatedProps.origin.y : yScale;
+
   const backgroundProps = {
-    height: height,
-    origin: calculatedProps.origin,
+    height,
     polar: props.polar,
-    scale: calculatedProps.scale,
     style: props.style.background,
-    width: width
+    x: xCoordinate,
+    y: yCoordinate,
+    width
   };
 
   return React.cloneElement(backgroundElement, backgroundProps);

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -64,7 +64,10 @@ function getBackgroundWithProps(props, calculatedProps) {
     width
   };
 
-  return React.cloneElement(backgroundElement, backgroundProps);
+  return React.cloneElement(
+    backgroundElement,
+    defaults({}, backgroundElement.props, backgroundProps)
+  );
 }
 
 function getChildProps(child, props, calculatedProps) {

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -36,6 +36,23 @@ function getAxisProps(child, props, calculatedProps) {
   };
 }
 
+function getBackgroundWithProps(props, calculatedProps) {
+  const backgroundElement = props.backgroundComponent;
+  const height = props.polar ? calculatedProps.range.y[1] : calculatedProps.range.y[0] - calculatedProps.range.y[1];
+  const width = calculatedProps.range.x[1] - calculatedProps.range.x[0];
+
+  const backgroundProps = {
+    height: height,
+    origin: calculatedProps.origin,
+    polar: props.polar,
+    scale: calculatedProps.scale,
+    style: props.style.background,
+    width: width
+  };
+
+  return React.cloneElement(backgroundElement, backgroundProps);
+}
+
 function getChildProps(child, props, calculatedProps) {
   const axisChild = Axis.findAxisComponents([child]);
   if (axisChild.length > 0) {
@@ -133,6 +150,7 @@ function getChildren(props, childComponents, calculatedProps) {
   const { height, polar, theme, width } = props;
   const { origin, horizontal } = calculatedProps;
   const parentName = props.name || "chart";
+
   return childComponents.map((child, index) => {
     const role = child.type && child.type.role;
     const style = Array.isArray(child.props.style)
@@ -177,10 +195,6 @@ const getChildComponents = (props, defaultAxes) => {
         ? [defaultAxes.independent, defaultAxes.dependent].concat(newChildComponents)
         : newChildComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
     }
-  }
-
-  if (props.style && props.style.background && typeof props.backgroundComponent === "object") {
-    newChildComponents.unshift(props.backgroundComponent);
   }
 
   return newChildComponents;
@@ -263,4 +277,4 @@ const createStringMap = (props, childComponents) => {
   return { x, y };
 };
 
-export { getChildren, getCalculatedProps, getChildComponents };
+export { getBackgroundWithProps, getChildren, getCalculatedProps, getChildComponents };

--- a/packages/victory-chart/src/index.d.ts
+++ b/packages/victory-chart/src/index.d.ts
@@ -1,31 +1,32 @@
 import * as React from "react";
 import {
   CategoryPropType,
-  EventPropTypeInterface,
   DomainPropType,
+  EventPropTypeInterface,
   StringOrNumberOrCallback,
   VictoryCommonProps,
-  VictoryStyleInterface
+  VictoryStyleInterface,
+  VictoryStyleObject
 } from "victory-core";
 
 export type AxesType = {
-  independent?: React.ReactElement;
   dependent?: React.ReactElement;
+  independent?: React.ReactElement;
 };
 
 export interface VictoryChartProps extends VictoryCommonProps {
-  defaultAxes?: AxesType;
-  defaultPolarAxes?: AxesType;
   categories?: CategoryPropType;
   children?: React.ReactNode | React.ReactNode[];
+  defaultAxes?: AxesType;
+  defaultPolarAxes?: AxesType;
   domain?: DomainPropType;
   endAngle?: number;
-  events?: EventPropTypeInterface<string, string[] | number[] | string | number>[];
   eventKey?: StringOrNumberOrCallback;
+  events?: EventPropTypeInterface<string, string[] | number[] | string | number>[];
   innerRadius?: number;
   prependDefaultAxes?: boolean;
   startAngle?: number;
-  style?: Pick<VictoryStyleInterface, "parent">;
+  style?: Pick<VictoryStyleInterface, "parent"> & { background?: VictoryStyleObject };
 }
 
 export class VictoryChart extends React.Component<VictoryChartProps, any> {}

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -2,6 +2,7 @@ import { defaults, assign, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import {
+  Background,
   Helpers,
   VictoryContainer,
   VictoryTheme,
@@ -26,6 +27,7 @@ export default class VictoryChart extends React.Component {
 
   static propTypes = {
     ...CommonProps.baseProps,
+    backgroundComponent: PropTypes.element,
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
     defaultAxes: PropTypes.shape({
       independent: PropTypes.element,
@@ -42,6 +44,7 @@ export default class VictoryChart extends React.Component {
   };
 
   static defaultProps = {
+    backgroundComponent: <Background />,
     containerComponent: <VictoryContainer />,
     defaultAxes: {
       independent: <VictoryAxis />,
@@ -114,6 +117,32 @@ export default class VictoryChart extends React.Component {
     };
   }
 
+  renderBackground(backgroundComponent, props) {
+    const backgroundProps = defaults({}, backgroundComponent.props, props);
+    
+    return React.cloneElement(backgroundComponent, backgroundProps);
+  }
+
+  getBackgroundProps(props, calculatedProps) {
+    const { width, height, standalone, theme, polar, name } = props;
+    const { domain, scale, style, origin, radius, horizontal } = calculatedProps;
+    
+    return {
+      domain,
+      scale,
+      width,
+      height,
+      standalone,
+      theme,
+      style: style.background,
+      horizontal,
+      name,
+      polar,
+      radius,
+      origin: polar ? origin : undefined
+    };
+  }
+
   render() {
     const props =
       this.state && this.state.nodesWillExit ? this.state.oldProps || this.props : this.props;
@@ -126,6 +155,7 @@ export default class VictoryChart extends React.Component {
       externalEventMutations
     } = modifiedProps;
     const axes = props.polar ? modifiedProps.defaultPolarAxes : modifiedProps.defaultAxes;
+    const backgroundProps = props.style && props.style.background ? this.getBackgroundProps(modifiedProps, calculatedProps) : {};
     const childComponents = getChildComponents(modifiedProps, axes);
     const calculatedProps = getCalculatedProps(modifiedProps, childComponents);
     const newChildren = this.getNewChildren(modifiedProps, childComponents, calculatedProps);
@@ -134,6 +164,7 @@ export default class VictoryChart extends React.Component {
       ? this.renderContainer(containerComponent, containerProps)
       : groupComponent;
     const events = Wrapper.getAllEvents(props);
+    
     if (!isEmpty(events)) {
       return (
         <VictorySharedEvents

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -157,10 +157,6 @@ export default class VictoryChart extends React.Component {
     const axes = props.polar ? modifiedProps.defaultPolarAxes : modifiedProps.defaultAxes;
     const childComponents = getChildComponents(modifiedProps, axes);
     const calculatedProps = getCalculatedProps(modifiedProps, childComponents);
-    const backgroundProps =
-      props.style && props.style.background
-        ? this.getBackgroundProps(modifiedProps, calculatedProps)
-        : {};
     const newChildren = this.getNewChildren(modifiedProps, childComponents, calculatedProps);
     const containerProps = standalone ? this.getContainerProps(modifiedProps, calculatedProps) : {};
     const container = standalone

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -119,14 +119,14 @@ export default class VictoryChart extends React.Component {
 
   renderBackground(backgroundComponent, props) {
     const backgroundProps = defaults({}, backgroundComponent.props, props);
-    
+
     return React.cloneElement(backgroundComponent, backgroundProps);
   }
 
   getBackgroundProps(props, calculatedProps) {
     const { width, height, standalone, theme, polar, name } = props;
     const { domain, scale, style, origin, radius, horizontal } = calculatedProps;
-    
+
     return {
       domain,
       scale,
@@ -155,16 +155,19 @@ export default class VictoryChart extends React.Component {
       externalEventMutations
     } = modifiedProps;
     const axes = props.polar ? modifiedProps.defaultPolarAxes : modifiedProps.defaultAxes;
-    const backgroundProps = props.style && props.style.background ? this.getBackgroundProps(modifiedProps, calculatedProps) : {};
     const childComponents = getChildComponents(modifiedProps, axes);
     const calculatedProps = getCalculatedProps(modifiedProps, childComponents);
+    const backgroundProps =
+      props.style && props.style.background
+        ? this.getBackgroundProps(modifiedProps, calculatedProps)
+        : {};
     const newChildren = this.getNewChildren(modifiedProps, childComponents, calculatedProps);
     const containerProps = standalone ? this.getContainerProps(modifiedProps, calculatedProps) : {};
     const container = standalone
       ? this.renderContainer(containerComponent, containerProps)
       : groupComponent;
     const events = Wrapper.getAllEvents(props);
-    
+
     if (!isEmpty(events)) {
       return (
         <VictorySharedEvents

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -92,7 +92,6 @@ export default class VictoryChart extends React.Component {
   getNewChildren(props, childComponents, calculatedProps) {
     const children = getChildren(props, childComponents, calculatedProps);
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
-    const backgroundComponent = getBackgroundWithProps(props, calculatedProps);
 
     const newChildren = children.map((child, index) => {
       const childProps = assign({ animate: getAnimationProps(props, child, index) }, child.props);
@@ -100,6 +99,8 @@ export default class VictoryChart extends React.Component {
     });
 
     if (props.style && props.style.background) {
+      const backgroundComponent = getBackgroundWithProps(props, calculatedProps);
+
       newChildren.unshift(backgroundComponent);
     }
 

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -13,7 +13,7 @@ import {
 import { VictorySharedEvents } from "victory-shared-events";
 import { VictoryAxis } from "victory-axis";
 import { VictoryPolarAxis } from "victory-polar-axis";
-import { getChildComponents, getCalculatedProps, getChildren } from "./helper-methods";
+import { getBackgroundWithProps, getChildComponents, getCalculatedProps, getChildren } from "./helper-methods";
 import isEqual from "react-fast-compare";
 
 const fallbackProps = {
@@ -87,10 +87,18 @@ export default class VictoryChart extends React.Component {
   getNewChildren(props, childComponents, calculatedProps) {
     const children = getChildren(props, childComponents, calculatedProps);
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
-    return children.map((child, index) => {
+    const backgroundComponent = getBackgroundWithProps(props, calculatedProps);
+    
+    let newChildren = children.map((child, index) => {
       const childProps = assign({ animate: getAnimationProps(props, child, index) }, child.props);
       return React.cloneElement(child, childProps);
     });
+
+    if (props.style.background) {
+      newChildren.unshift(backgroundComponent);
+    }
+    
+    return newChildren;
   }
 
   renderContainer(containerComponent, props) {

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -13,7 +13,12 @@ import {
 import { VictorySharedEvents } from "victory-shared-events";
 import { VictoryAxis } from "victory-axis";
 import { VictoryPolarAxis } from "victory-polar-axis";
-import { getBackgroundWithProps, getChildComponents, getCalculatedProps, getChildren } from "./helper-methods";
+import {
+  getBackgroundWithProps,
+  getChildComponents,
+  getCalculatedProps,
+  getChildren
+} from "./helper-methods";
 import isEqual from "react-fast-compare";
 
 const fallbackProps = {
@@ -88,8 +93,8 @@ export default class VictoryChart extends React.Component {
     const children = getChildren(props, childComponents, calculatedProps);
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
     const backgroundComponent = getBackgroundWithProps(props, calculatedProps);
-    
-    let newChildren = children.map((child, index) => {
+
+    const newChildren = children.map((child, index) => {
       const childProps = assign({ animate: getAnimationProps(props, child, index) }, child.props);
       return React.cloneElement(child, childProps);
     });
@@ -97,7 +102,7 @@ export default class VictoryChart extends React.Component {
     if (props.style.background) {
       newChildren.unshift(backgroundComponent);
     }
-    
+
     return newChildren;
   }
 

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -117,32 +117,6 @@ export default class VictoryChart extends React.Component {
     };
   }
 
-  renderBackground(backgroundComponent, props) {
-    const backgroundProps = defaults({}, backgroundComponent.props, props);
-
-    return React.cloneElement(backgroundComponent, backgroundProps);
-  }
-
-  getBackgroundProps(props, calculatedProps) {
-    const { width, height, standalone, theme, polar, name } = props;
-    const { domain, scale, style, origin, radius, horizontal } = calculatedProps;
-
-    return {
-      domain,
-      scale,
-      width,
-      height,
-      standalone,
-      theme,
-      style: style.background,
-      horizontal,
-      name,
-      polar,
-      radius,
-      origin: polar ? origin : undefined
-    };
-  }
-
   render() {
     const props =
       this.state && this.state.nodesWillExit ? this.state.oldProps || this.props : this.props;

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -99,7 +99,7 @@ export default class VictoryChart extends React.Component {
       return React.cloneElement(child, childProps);
     });
 
-    if (props.style.background) {
+    if (props.style && props.style.background) {
       newChildren.unshift(backgroundComponent);
     }
 

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -662,8 +662,6 @@ export class VictoryPortal extends React.Component<VictoryPortalProps, any> {}
 
 export interface BackgroundProps extends VictoryCommonPrimitiveProps {
   circleComponent?: React.ReactElement;
-  cx?: number;
-  cy?: number;
   height?: number;
   rectComponent?: React.ReactElement;
   width?: number;

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -660,6 +660,19 @@ export class VictoryPortal extends React.Component<VictoryPortalProps, any> {}
 
 // #region Victory Primitives
 
+export interface BackgroundProps extends VictoryCommonPrimitiveProps {
+  circleComponent?: React.ReactElement;
+  cx?: number;
+  cy?: number;
+  height?: number;
+  rectComponent?: React.ReactElement;
+  width?: number;
+  x?: number;
+  y?: number;
+}
+
+export class Background extends React.Component<BackgroundProps> {}
+
 export interface VictoryPointProps extends VictoryCommonPrimitiveProps {
   datum?: any;
   getPath?: Function;

--- a/packages/victory-core/src/index.js
+++ b/packages/victory-core/src/index.js
@@ -7,6 +7,7 @@ export { default as VictoryTheme } from "./victory-theme/victory-theme";
 export { default as VictoryPortal } from "./victory-portal/victory-portal";
 export { default as Portal } from "./victory-portal/portal";
 export { default as Arc } from "./victory-primitives/arc";
+export { default as Background } from "./victory-primitives/background";
 export { default as Border, default as Box } from "./victory-primitives/border";
 export { default as ClipPath } from "./victory-primitives/clip-path";
 export { default as LineSegment } from "./victory-primitives/line-segment";

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Helpers from "../victory-util/helpers";
+import { assign } from "lodash";
+import CommonProps from "../victory-util/common-props";
+import Rect from "./rect";
+
+const Background = (props) =>
+  React.cloneElement(props.rectComponent, {
+    ...props.events,
+    style: Helpers.evaluateStyle(assign({ fill: "none" }, props.style), props),
+    desc: Helpers.evaluateProp(props.desc, props),
+    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
+    transform: props.transform,
+    className: props.className,
+    role: props.role,
+    shapeRendering: props.shapeRendering,
+    x: props.x,
+    y: props.y,
+    width: props.width,
+    height: props.height,
+    clipPath: props.clipPath
+  });
+
+Background.propTypes = {
+  ...CommonProps.primitiveProps,
+  height: PropTypes.number,
+  rectComponent: PropTypes.element,
+  width: PropTypes.number,
+  x: PropTypes.number,
+  y: PropTypes.number
+};
+
+Background.defaultProps = {
+  rectComponent: <Rect />,
+  role: "presentation",
+  shapeRendering: "auto"
+};
+
+export default Background;

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -1,38 +1,67 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Helpers from "../victory-util/helpers";
-import { assign } from "lodash";
 import CommonProps from "../victory-util/common-props";
 import Rect from "./rect";
+import Circle from "./circle";
 
-const Background = (props) =>
-  React.cloneElement(props.rectComponent, {
+const getRangeBounds = (props) => { x: props.range.x[0], y: props.range.y[1] };
+const getHeight = (props) => props.range.y[0] - props.range.y[1];
+const getWidth = (props) => props.range.x[1] - props.range.x[0];
+
+const Background = (props) => {
+  return props.polar
+  ? React.cloneElement(props.circleComponent, {
     ...props.events,
     style: props.style && props.style.background,
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
-    transform: props.transform,
-    className: props.className,
     role: props.role,
     shapeRendering: props.shapeRendering,
-    x: props.range.x[0],
-    y: props.range.y[1],
-    width: props.range.x[1] - props.range.x[0],
-    height: props.range.y[0] - props.range.y[1],
-    clipPath: props.clipPath
-  });
+    cx: '50%',
+    cy: '50%',
+    r: getHeight(props)
+  })
+  : React.cloneElement(props.rectComponent, {
+    ...props.events,
+    style: props.style && props.style.background,
+    role: props.role,
+    shapeRendering: props.shapeRendering,
+    x: getRangeBounds(props).x,
+    y: getRangeBounds(props).y,
+    width: getWidth(props),
+    height: getHeight(props)
+  })
+ };
 
 Background.propTypes = {
-  ...CommonProps.primitiveProps,
-  height: PropTypes.number,
+  ...CommonProps.baseProps,
+  categories: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.shape({
+      x: PropTypes.arrayOf(PropTypes.string),
+      y: PropTypes.arrayOf(PropTypes.string)
+    })
+  ]),
+  domain: PropTypes.shape({
+    x: PropTypes.arrayOf(PropTypes.number),
+    y: PropTypes.arrayOf(PropTypes.number)
+  }),
   rectComponent: PropTypes.element,
-  width: PropTypes.number,
+  circleComponent: PropTypes.element,
+  horizontal: PropTypes.bool,
+  role: PropTypes.string,
+  shapeRendering: PropTypes.string,
+  stringMap: PropTypes.shape({
+    x: PropTypes.arrayOf(PropTypes.string),
+    y: PropTypes.arrayOf(PropTypes.string)
+  }),
+  style: PropTypes.object,
   x: PropTypes.number,
   y: PropTypes.number
 };
 
 Background.defaultProps = {
   rectComponent: <Rect />,
+  circleComponent: <Circle />,
   role: "presentation",
   shapeRendering: "auto"
 };

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -1,38 +1,35 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
 import CommonProps from "../victory-util/common-props";
 import Rect from "./rect";
 import Circle from "./circle";
 
 const getRangeBounds = (props) => ({ x: props.range.x[0], y: props.range.y[1] });
-const getHeight = (props) =>  props.polar
-  ? props.range.y[1]
-  : props.range.y[0] - props.range.y[1];
+const getHeight = (props) => (props.polar ? props.range.y[1] : props.range.y[0] - props.range.y[1]);
 const getWidth = (props) => props.range.x[1] - props.range.x[0];
 
 const Background = (props) => {
   return props.polar
-  ? React.cloneElement(props.circleComponent, {
-    ...props.events,
-    style: props.style && props.style.background,
-    role: props.role,
-    shapeRendering: props.shapeRendering,
-    cx: '50%',
-    cy: '50%',
-    r: getHeight(props)
-  })
-  : React.cloneElement(props.rectComponent, {
-    ...props.events,
-    style: props.style && props.style.background,
-    role: props.role,
-    shapeRendering: props.shapeRendering,
-    x: getRangeBounds(props).x,
-    y: getRangeBounds(props).y,
-    width: getWidth(props),
-    height: getHeight(props)
-  })
- };
+    ? React.cloneElement(props.circleComponent, {
+        ...props.events,
+        style: props.style && props.style.background,
+        role: props.role,
+        shapeRendering: props.shapeRendering,
+        cx: "50%",
+        cy: "50%",
+        r: getHeight(props)
+      })
+    : React.cloneElement(props.rectComponent, {
+        ...props.events,
+        style: props.style && props.style.background,
+        role: props.role,
+        shapeRendering: props.shapeRendering,
+        x: getRangeBounds(props).x,
+        y: getRangeBounds(props).y,
+        width: getWidth(props),
+        height: getHeight(props)
+      });
+};
 
 Background.propTypes = {
   ...CommonProps.baseProps,
@@ -43,13 +40,13 @@ Background.propTypes = {
       y: PropTypes.arrayOf(PropTypes.string)
     })
   ]),
+  circleComponent: PropTypes.element,
   domain: PropTypes.shape({
     x: PropTypes.arrayOf(PropTypes.number),
     y: PropTypes.arrayOf(PropTypes.number)
   }),
-  rectComponent: PropTypes.element,
-  circleComponent: PropTypes.element,
   horizontal: PropTypes.bool,
+  rectComponent: PropTypes.element,
   role: PropTypes.string,
   shapeRendering: PropTypes.string,
   stringMap: PropTypes.shape({

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -5,8 +5,10 @@ import CommonProps from "../victory-util/common-props";
 import Rect from "./rect";
 import Circle from "./circle";
 
-const getRangeBounds = (props) => { x: props.range.x[0], y: props.range.y[1] };
-const getHeight = (props) => props.range.y[0] - props.range.y[1];
+const getRangeBounds = (props) => ({ x: props.range.x[0], y: props.range.y[1] });
+const getHeight = (props) =>  props.polar
+  ? props.range.y[1]
+  : props.range.y[0] - props.range.y[1];
 const getWidth = (props) => props.range.x[1] - props.range.x[0];
 
 const Background = (props) => {

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -8,17 +8,17 @@ import Rect from "./rect";
 const Background = (props) =>
   React.cloneElement(props.rectComponent, {
     ...props.events,
-    style: Helpers.evaluateStyle(assign({ fill: "none" }, props.style), props),
+    style: props.style && props.style.background,
     desc: Helpers.evaluateProp(props.desc, props),
     tabIndex: Helpers.evaluateProp(props.tabIndex, props),
     transform: props.transform,
     className: props.className,
     role: props.role,
     shapeRendering: props.shapeRendering,
-    x: props.x,
-    y: props.y,
-    width: props.width,
-    height: props.height,
+    x: props.range.x[0],
+    y: props.range.y[1],
+    width: props.range.x[1] - props.range.x[0],
+    height: props.range.y[0] - props.range.y[1],
     clipPath: props.clipPath
   });
 

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -59,8 +59,8 @@ Background.propTypes = {
 };
 
 Background.defaultProps = {
-  rectComponent: <Rect />,
   circleComponent: <Circle />,
+  rectComponent: <Rect />,
   role: "presentation",
   shapeRendering: "auto"
 };

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -4,58 +4,33 @@ import CommonProps from "../victory-util/common-props";
 import Rect from "./rect";
 import Circle from "./circle";
 
-const getRangeBounds = (props) => ({ x: props.range.x[0], y: props.range.y[1] });
-const getHeight = (props) => (props.polar ? props.range.y[1] : props.range.y[0] - props.range.y[1]);
-const getWidth = (props) => props.range.x[1] - props.range.x[0];
-
 const Background = (props) => {
   return props.polar
     ? React.cloneElement(props.circleComponent, {
         ...props.events,
-        style: props.style && props.style.background,
+        style: props.style,
         role: props.role,
         shapeRendering: props.shapeRendering,
-        cx: "50%",
-        cy: "50%",
-        r: getHeight(props)
+        cx: origin.x,
+        cy: origin.y,
+        r: props.height
       })
     : React.cloneElement(props.rectComponent, {
         ...props.events,
-        style: props.style && props.style.background,
+        style: props.style,
         role: props.role,
         shapeRendering: props.shapeRendering,
-        x: getRangeBounds(props).x,
-        y: getRangeBounds(props).y,
-        width: getWidth(props),
-        height: getHeight(props)
+        x: props.scale.x.range(),
+        y: props.scale.y.range(),
+        width: props.width,
+        height: props.height
       });
 };
 
 Background.propTypes = {
-  ...CommonProps.baseProps,
-  categories: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.shape({
-      x: PropTypes.arrayOf(PropTypes.string),
-      y: PropTypes.arrayOf(PropTypes.string)
-    })
-  ]),
+  ...CommonProps.primitiveProps,
   circleComponent: PropTypes.element,
-  domain: PropTypes.shape({
-    x: PropTypes.arrayOf(PropTypes.number),
-    y: PropTypes.arrayOf(PropTypes.number)
-  }),
-  horizontal: PropTypes.bool,
   rectComponent: PropTypes.element,
-  role: PropTypes.string,
-  shapeRendering: PropTypes.string,
-  stringMap: PropTypes.shape({
-    x: PropTypes.arrayOf(PropTypes.string),
-    y: PropTypes.arrayOf(PropTypes.string)
-  }),
-  style: PropTypes.object,
-  x: PropTypes.number,
-  y: PropTypes.number
 };
 
 Background.defaultProps = {

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -11,8 +11,8 @@ const Background = (props) => {
         style: props.style,
         role: props.role,
         shapeRendering: props.shapeRendering,
-        cx: origin.x,
-        cy: origin.y,
+        cx: props.x,
+        cy: props.y,
         r: props.height
       })
     : React.cloneElement(props.rectComponent, {
@@ -20,8 +20,8 @@ const Background = (props) => {
         style: props.style,
         role: props.role,
         shapeRendering: props.shapeRendering,
-        x: props.scale.x.range(),
-        y: props.scale.y.range(),
+        x: props.x,
+        y: props.y,
         width: props.width,
         height: props.height
       });
@@ -30,7 +30,7 @@ const Background = (props) => {
 Background.propTypes = {
   ...CommonProps.primitiveProps,
   circleComponent: PropTypes.element,
-  rectComponent: PropTypes.element,
+  rectComponent: PropTypes.element
 };
 
 Background.defaultProps = {

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -30,8 +30,6 @@ const Background = (props) => {
 Background.propTypes = {
   ...CommonProps.primitiveProps,
   circleComponent: PropTypes.element,
-  cx: PropTypes.number,
-  cy: PropTypes.number,
   height: PropTypes.number,
   rectComponent: PropTypes.element,
   width: PropTypes.number,

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -30,7 +30,13 @@ const Background = (props) => {
 Background.propTypes = {
   ...CommonProps.primitiveProps,
   circleComponent: PropTypes.element,
-  rectComponent: PropTypes.element
+  cx: PropTypes.number,
+  cy: PropTypes.number,
+  height: PropTypes.number,
+  rectComponent: PropTypes.element,
+  width: PropTypes.number,
+  x: PropTypes.number,
+  y: PropTypes.number
 };
 
 Background.defaultProps = {

--- a/packages/victory/src/index.d.ts
+++ b/packages/victory/src/index.d.ts
@@ -3,6 +3,7 @@
 
 declare module "victory" {
   import {
+    Background,
     // Border,
     // Box,
     // ClipPath,
@@ -115,6 +116,7 @@ declare module "victory" {
 
   export {
     // Area,
+    Background,
     // Bar,
     // Border,
     // Box,

--- a/packages/victory/src/index.js
+++ b/packages/victory/src/index.js
@@ -1,4 +1,5 @@
 import {
+  Background,
   Border,
   Box,
   ClipPath,
@@ -87,6 +88,7 @@ import { VictoryPolarAxis } from "victory-polar-axis";
 
 export {
   Area,
+  Background,
   Bar,
   Border,
   Box,

--- a/stories/victory-chart.js
+++ b/stories/victory-chart.js
@@ -165,10 +165,26 @@ storiesOf("VictoryChart.calculated domain", module)
     </VictoryChart>
   ));
 
-storiesOf("VictoryChart.style", module).add("with parent styles", () => (
-  <VictoryChart
-    style={{
-      parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }
-    }}
-  />
-));
+storiesOf("VictoryChart.style", module)
+  .add("with parent styles", () => (
+    <VictoryChart
+      style={{
+        parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }
+      }}
+    />
+  ))
+  .add("with background style", () => (
+    <VictoryChart
+      style={{
+        background: { fill: "pink" }
+      }}
+    />
+  ))
+  .add("with background and parent styles", () => (
+    <VictoryChart
+      style={{
+        background: { fill: "pink" },
+        parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }
+      }}
+    />
+  ));

--- a/stories/victory-chart.js
+++ b/stories/victory-chart.js
@@ -4,10 +4,12 @@ import { storiesOf } from "@storybook/react";
 import { VictoryChart } from "../packages/victory-chart/src/index";
 import { VictoryAxis } from "../packages/victory-axis/src/index";
 import { VictoryBar } from "../packages/victory-bar/src/index";
+import { VictoryGroup } from "../packages/victory-group/src/index";
 import { VictoryScatter } from "../packages/victory-scatter/src/index";
 import { VictoryLine } from "../packages/victory-line/src/index";
 import { VictoryBoxPlot } from "../packages/victory-box-plot/src/index";
 import { VictoryPolarAxis } from "../packages/victory-polar-axis/src/index";
+import { VictoryStack } from "../packages/victory-stack/src/index";
 import { VictoryTheme } from "../packages/victory-core/src/index";
 import { getData, getFourQuadrantData, getArrayData } from "./data";
 
@@ -200,4 +202,31 @@ storiesOf("VictoryChart.style", module)
         parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }
       }}
     />
+  ))
+  .add("with background on group", () => (
+    <VictoryChart style={{ background: { fill: "pink" } }}>
+      <VictoryGroup labels={["a", "b", "c"]} horizontal offset={20} colorScale={"qualitative"}>
+        <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }]} />
+        <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }]} />
+        <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }]} />
+      </VictoryGroup>
+    </VictoryChart>
+  ))
+  .add("with background on stacked chart", () => (
+    <VictoryChart style={{ background: { fill: "pink" } }}>
+      <VictoryStack colorScale={"qualitative"}>
+        <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }]} />
+        <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }]} />
+        <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }]} />
+      </VictoryStack>
+    </VictoryChart>
+  ))
+  .add("with background on horizontal chart", () => (
+    <VictoryChart horizontal style={{ background: { fill: "pink" } }}>
+      <VictoryStack colorScale={"qualitative"}>
+        <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }]} />
+        <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }]} />
+        <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }]} />
+      </VictoryStack>
+    </VictoryChart>
   ));

--- a/stories/victory-chart.js
+++ b/stories/victory-chart.js
@@ -181,14 +181,6 @@ storiesOf("VictoryChart.style", module)
       }}
     />
   ))
-  .add("with background and parent styles", () => (
-    <VictoryChart
-      style={{
-        background: { fill: "pink" },
-        parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }
-      }}
-    />
-  ))
   .add("with background and parent styles on circle component", () => (
     <VictoryChart
       polar

--- a/stories/victory-chart.js
+++ b/stories/victory-chart.js
@@ -7,6 +7,7 @@ import { VictoryBar } from "../packages/victory-bar/src/index";
 import { VictoryScatter } from "../packages/victory-scatter/src/index";
 import { VictoryLine } from "../packages/victory-line/src/index";
 import { VictoryBoxPlot } from "../packages/victory-box-plot/src/index";
+import { VictoryPolarAxis } from "../packages/victory-polar-axis/src/index";
 import { VictoryTheme } from "../packages/victory-core/src/index";
 import { getData, getFourQuadrantData, getArrayData } from "./data";
 
@@ -182,6 +183,26 @@ storiesOf("VictoryChart.style", module)
   ))
   .add("with background and parent styles", () => (
     <VictoryChart
+      style={{
+        background: { fill: "pink" },
+        parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }
+      }}
+    />
+  ))
+  .add("with background and parent styles on circle component", () => (
+    <VictoryChart
+      polar
+      style={{
+        background: { fill: "pink" },
+        parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }
+      }}
+    >
+      <VictoryPolarAxis />
+    </VictoryChart>
+  ))
+  .add("with background and parent styles on rect component", () => (
+    <VictoryChart
+      domain={[-1, 1]}
       style={{
         background: { fill: "pink" },
         parent: { border: "2px solid #000", margin: 20, backgroundColor: "cyan" }


### PR DESCRIPTION
### VictoryChart
* Adds a new `Background` primitive component
* Adds the background primitive to `VictoryChart` to allow an option for adding background for just the chart area
* Updates typed definitions for `VictoryChartProps` interface
* Updates the helper-methods in `VictoryChart` to accept a `background` prop
* Adds additional stories to `VictoryChart` storybook to visually check that the background color is rendered correctly 

#### Storybook Screenshots 
<img width="876" alt="Screen Shot 2020-05-07 at 12 04 09 PM" src="https://user-images.githubusercontent.com/25444364/81334448-e912c800-905a-11ea-89cd-047f45ac3d11.png">

<img width="879" alt="Screen Shot 2020-05-07 at 12 03 59 PM" src="https://user-images.githubusercontent.com/25444364/81334444-e7490480-905a-11ea-9cda-2b09b38f9549.png">

<img width="903" alt="Screen Shot 2020-05-07 at 12 03 50 PM" src="https://user-images.githubusercontent.com/25444364/81334431-e3b57d80-905a-11ea-81d5-250f1e1abd1e.png">

<img width="906" alt="Screen Shot 2020-05-08 at 3 36 40 PM" src="https://user-images.githubusercontent.com/25444364/81454659-c5767d00-9141-11ea-8fe6-6d1c9b2ecd52.png">

<img width="942" alt="Screen Shot 2020-05-08 at 3 36 50 PM" src="https://user-images.githubusercontent.com/25444364/81454666-c90a0400-9141-11ea-9fd0-67056c921bb0.png">

<img width="967" alt="Screen Shot 2020-05-08 at 3 53 12 PM" src="https://user-images.githubusercontent.com/25444364/81455426-0ff8f900-9144-11ea-842d-3b9a0105965d.png">
