### PR TITLE
per dimension domain prop checking

### DIFF
--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -29,9 +29,9 @@ const getCalculatedValues = (props) => {
     x: Helpers.getRange(props, "x"),
     y: Helpers.getRange(props, "y")
   };
-  const domain = props.domain || {
-    x: Domain.getDomainWithZero(props, "x"),
-    y: Domain.getDomainWithZero(props, "y")
+  const domain = {
+    x: Domain.getDomainFromProps(props, "x") || Domain.getDomainWithZero(props, "x"),
+    y: Domain.getDomainFromProps(props, "y") || Domain.getDomainWithZero(props, "y")
   };
   const scale = {
     x: Scale.getBaseScale(props, "x")

--- a/packages/victory-group/src/helper-methods.js
+++ b/packages/victory-group/src/helper-methods.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-use-before-define */
 import { assign } from "lodash";
 import React from "react";
-import { Helpers, Scale, Data, Wrapper } from "victory-core";
+import { Helpers, Scale, Data, Domain, Wrapper } from "victory-core";
 
 const fallbackProps = {
   width: 450,
@@ -19,9 +19,13 @@ function getCalculatedProps(props, childComponents) {
   const { offset, colorScale, color, polar, horizontal } = props;
   const categories = props.categories || Wrapper.getCategories(props, childComponents);
   const datasets = props.datasets || Wrapper.getDataFromChildren(props);
-  const domain = props.domain || {
-    x: Wrapper.getDomain(assign({}, props, { categories }), "x", childComponents),
-    y: Wrapper.getDomain(assign({}, props, { categories }), "y", childComponents)
+  const domain = {
+    x:
+      Domain.getDomainFromProps(props, "x") ||
+      Wrapper.getDomain(assign({}, props, { categories }), "x", childComponents),
+    y:
+      Domain.getDomainFromProps(props, "y") ||
+      Wrapper.getDomain(assign({}, props, { categories }), "y", childComponents)
   };
   const range = props.range || {
     x: Helpers.getRange(props, "x"),

--- a/packages/victory-stack/src/helper-methods.js
+++ b/packages/victory-stack/src/helper-methods.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-use-before-define */
 import { assign, keys, orderBy } from "lodash";
 import React from "react";
-import { Helpers, Scale, Wrapper } from "victory-core";
+import { Domain, Helpers, Scale, Wrapper } from "victory-core";
 
 const fallbackProps = {
   width: 450,
@@ -116,9 +116,13 @@ function getCalculatedProps(props, childComponents) {
   const children = childComponents.map((c, i) => {
     return React.cloneElement(c, { data: datasets[i] });
   });
-  const domain = props.domain || {
-    x: Wrapper.getDomain(assign({}, props, { categories }), "x", children),
-    y: Wrapper.getDomain(assign({}, props, { categories }), "y", children)
+  const domain = {
+    x:
+      Domain.getDomainFromProps(props, "x") ||
+      Wrapper.getDomain(assign({}, props, { categories }), "x", children),
+    y:
+      Domain.getDomainFromProps(props, "y") ||
+      Wrapper.getDomain(assign({}, props, { categories }), "y", children)
   };
   const range = props.range || {
     x: Helpers.getRange(props, "x"),


### PR DESCRIPTION
A regression was introduced in `34.1.3` when a check was added for `props.domain`. This PR corrects the regression by individually checking for domain props for each dimension.
Fixes https://github.com/FormidableLabs/victory/issues/1562