### PR TITLE
Adds backgroundComponent prop to VictoryChartProps interface

### DIFF
--- a/packages/victory-chart/src/index.d.ts
+++ b/packages/victory-chart/src/index.d.ts
@@ -15,6 +15,7 @@ export type AxesType = {
 };
 
 export interface VictoryChartProps extends VictoryCommonProps {
+  backgroundComponent?: React.ReactElement;
   categories?: CategoryPropType;
   children?: React.ReactNode | React.ReactNode[];
   defaultAxes?: AxesType;


### PR DESCRIPTION
Adds the missing `backgroundComponent` prop to `VictoryChartProps` interface #1558 