### PR TITLE
Add missing dependencies in victory-histogram

### DIFF
--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -20,8 +20,10 @@
   "license": "MIT",
   "dependencies": {
     "d3-array": "^2.4.0",
+    "d3-scale": "^1.0.0",
     "lodash": "^4.17.15",
     "prop-types": "^15.5.8",
+    "react-fast-compare": "^2.0.0",
     "victory-bar": "^34.3.0",
     "victory-core": "^34.3.0"
   },


### PR DESCRIPTION
https://github.com/FormidableLabs/victory/blob/master/packages/victory-histogram/src/helper-methods.js

Requires both `d3-scale` and `react-fast-compare` without including them in the package.json.

This works by coincidence in some codebases but will fail in any using Yarn v2.

This has happened a couple of times before:

https://github.com/FormidableLabs/victory/pull/1478
https://github.com/FormidableLabs/victory/pull/1496
https://github.com/FormidableLabs/victory/pull/1570

I would recommend adding a test to your CI that installs and runs some tests of the package using Yarn v2 to catch these errors before release, given these patch / minor changes break downstream dependencies.