### PR TITLE
Fix Histogram Tooltip Positioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ before_install:
 script:
 - yarn --version
 - yarn nps check.ci
-# disable chromatic until billing issues are resolved
-# - if [ "${TRAVIS_NODE_VERSION}" = "8" ]; then CI=true yarn run chromatic-ci || echo "Chromatic tests failed. Please investigate"; fi
+- if [ "${TRAVIS_NODE_VERSION}" = "8" ]; then CI=true yarn run chromatic-ci || echo "Chromatic tests failed. Please investigate"; fi
 after_success:
 - yarn config delete ignore-engines
 env:

--- a/demo/js/components/victory-histogram-demo.js
+++ b/demo/js/components/victory-histogram-demo.js
@@ -9,6 +9,7 @@ import { VictoryScatter } from "Packages/victory-scatter/src/index";
 import { VictoryTheme } from "Packages/victory-core/src/index";
 import { VictoryTooltip } from "Packages/victory-tooltip/src/index";
 import { VictoryStack } from "Packages/victory-stack/src/index";
+import { VictoryVoronoiContainer } from "Packages/victory-voronoi-container/src/index";
 
 const randomDate = (start, end) => {
   return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
@@ -24,6 +25,7 @@ const getData = ({ length = 100, min = 0, max = 10, dates = false } = {}) => {
 export default class App extends React.Component {
   data = getData();
   data2 = getData({ max: 100 });
+  dateData = getData({ dates: true, min: new Date(2012, 0, 1), max: new Date(2014, 0, 1) });
 
   constructor() {
     super();
@@ -318,7 +320,16 @@ export default class App extends React.Component {
           labelComponent={<VictoryTooltip active />}
         />
 
-        <VictoryChart style={{ parent: parentStyle }}>
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          containerComponent={
+            <VictoryVoronoiContainer
+              labels={() => "hi"}
+              voronoiDimension="x"
+              labelComponent={<VictoryTooltip />}
+            />
+          }
+        >
           <VictoryHistogram
             bins={[0, 20, 50, 70, 100]}
             style={{
@@ -338,6 +349,43 @@ export default class App extends React.Component {
               { x: 80, y: 50 },
               { x: 120, y: 8 }
             ]}
+          />
+        </VictoryChart>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          containerComponent={
+            <VictoryVoronoiContainer
+              labels={() => "hi"}
+              voronoiDimension="x"
+              labelComponent={<VictoryTooltip />}
+            />
+          }
+        >
+          <VictoryHistogram
+            style={{
+              data: { stroke: "#f67280", strokeWidth: 3, fill: "#355c7d" }
+            }}
+            data={this.dateData}
+          />
+        </VictoryChart>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          containerComponent={
+            <VictoryVoronoiContainer
+              labels={() => "hi"}
+              voronoiDimension="x"
+              labelComponent={<VictoryTooltip />}
+            />
+          }
+        >
+          <VictoryHistogram
+            horizontal
+            style={{
+              data: { stroke: "#f67280", strokeWidth: 3, fill: "#355c7d" }
+            }}
+            data={this.dateData}
           />
         </VictoryChart>
 

--- a/demo/ts/components/victory-histogram-demo.tsx
+++ b/demo/ts/components/victory-histogram-demo.tsx
@@ -7,6 +7,7 @@ import { VictoryScatter } from "@packages/victory-scatter";
 import { VictoryTheme } from "@packages/victory-core";
 import { VictoryTooltip } from "@packages/victory-tooltip";
 import { VictoryStack } from "@packages/victory-stack";
+import { VictoryVoronoiContainer } from "@packages/victory-voronoi-container";
 
 const randomDate = (start: Date, end: Date) => {
   return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
@@ -54,6 +55,7 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
 
   data = getData();
   data2 = getData({ max: 100 });
+  dateData = getData({ dates: true, min: new Date(2012, 0, 1), max: new Date(2014, 0, 1) });
 
   constructor(props: any) {
     super(props);
@@ -348,7 +350,16 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
           labelComponent={<VictoryTooltip active />}
         />
 
-        <VictoryChart style={{ parent: parentStyle }}>
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          containerComponent={
+            <VictoryVoronoiContainer
+              labels={() => "hi"}
+              voronoiDimension="x"
+              labelComponent={<VictoryTooltip />}
+            />
+          }
+        >
           <VictoryHistogram
             bins={[0, 20, 50, 70, 100]}
             style={{
@@ -368,6 +379,43 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
               { x: 80, y: 50 },
               { x: 120, y: 8 }
             ]}
+          />
+        </VictoryChart>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          containerComponent={
+            <VictoryVoronoiContainer
+              labels={() => "hi"}
+              voronoiDimension="x"
+              labelComponent={<VictoryTooltip />}
+            />
+          }
+        >
+          <VictoryHistogram
+            style={{
+              data: { stroke: "#f67280", strokeWidth: 3, fill: "#355c7d" }
+            }}
+            data={this.dateData}
+          />
+        </VictoryChart>
+
+        <VictoryChart
+          style={{ parent: parentStyle }}
+          containerComponent={
+            <VictoryVoronoiContainer
+              labels={() => "hi"}
+              voronoiDimension="x"
+              labelComponent={<VictoryTooltip />}
+            />
+          }
+        >
+          <VictoryHistogram
+            horizontal
+            style={{
+              data: { stroke: "#f67280", strokeWidth: 3, fill: "#355c7d" }
+            }}
+            data={this.dateData}
           />
         </VictoryChart>
 

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -10,15 +10,14 @@ import {
   getCustomBarPath
 } from "./path-helper-methods";
 
-// eslint-disable-next-line max-params
-const getBarPath = (props, width, cornerRadius, barOffset) => {
+const getBarPath = (props, width, cornerRadius) => {
   if (props.getPath) {
     return getCustomBarPath(props, width);
   }
 
   return props.horizontal
-    ? getHorizontalBarPath(props, width, cornerRadius, barOffset)
-    : getVerticalBarPath(props, width, cornerRadius, barOffset);
+    ? getHorizontalBarPath(props, width, cornerRadius)
+    : getVerticalBarPath(props, width, cornerRadius);
 };
 
 const getPolarBarPath = (props, cornerRadius) => {
@@ -77,26 +76,21 @@ const getStyle = (style = {}, props) => {
   return Helpers.evaluateStyle(assign(baseStyle, style), props);
 };
 
-const getBarOffset = (barOffset, props) => {
-  return Helpers.evaluateProp(barOffset, props);
-};
-
 const evaluateProps = (props) => {
   // Potential evaluated props are 1) `style`, 2) `barWidth` and 3) `cornerRadius`
   const style = getStyle(props.style, props);
   const barWidth = getBarWidth(props.barWidth, assign({}, props, { style }));
   const cornerRadius = getCornerRadius(props.cornerRadius, assign({}, props, { style, barWidth }));
-  const barOffset = getBarOffset(props.barOffset, props);
-  return assign({}, props, { style, barWidth, cornerRadius, barOffset });
+  return assign({}, props, { style, barWidth, cornerRadius });
 };
 
 const Bar = (props) => {
   props = evaluateProps(props);
-  const { polar, origin, style, barWidth, cornerRadius, barOffset } = props;
+  const { polar, origin, style, barWidth, cornerRadius } = props;
 
   const path = polar
     ? getPolarBarPath(props, cornerRadius)
-    : getBarPath(props, barWidth, cornerRadius, barOffset);
+    : getBarPath(props, barWidth, cornerRadius);
   const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
 
   return React.cloneElement(props.pathComponent, {
@@ -116,7 +110,6 @@ const Bar = (props) => {
 Bar.propTypes = {
   ...CommonProps.primitiveProps,
   alignment: PropTypes.oneOf(["start", "middle", "end"]),
-  barOffset: PropTypes.arrayOf(PropTypes.number),
   barRatio: PropTypes.number,
   barWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   cornerRadius: PropTypes.oneOfType([

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -72,7 +72,6 @@ const getBaseProps = (props, fallbackProps) => {
     labels,
     name,
     barWidth,
-    barOffset,
     getPath
   } = props;
   const initialChildProps = {
@@ -116,7 +115,6 @@ const getBaseProps = (props, fallbackProps) => {
       y0,
       x0,
       barWidth,
-      barOffset,
       getPath
     };
 

--- a/packages/victory-bar/src/path-helper-methods.js
+++ b/packages/victory-bar/src/path-helper-methods.js
@@ -2,9 +2,7 @@ import * as d3Shape from "d3-shape";
 
 import { circle, point } from "./geometry-helper-methods";
 
-const getPosition = (props, width, barOffset = [0, 0]) => {
-  const barOffsetX = barOffset[0];
-
+const getPosition = (props, width) => {
   const { x, x0, y, y0, horizontal } = props;
   const alignment = props.alignment || "middle";
   const size = alignment === "middle" ? width / 2 : width;
@@ -13,14 +11,14 @@ const getPosition = (props, width, barOffset = [0, 0]) => {
     return {
       x0,
       x1: x,
-      y0: (alignment === "start" ? y : y - sign * size) - barOffsetX,
-      y1: (alignment === "end" ? y : y + sign * size) - barOffsetX
+      y0: alignment === "start" ? y : y - sign * size,
+      y1: alignment === "end" ? y : y + sign * size
     };
   }
 
   return {
-    x0: (alignment === "start" ? x : x - sign * size) + barOffsetX,
-    x1: (alignment === "end" ? x : x + sign * size) + barOffsetX,
+    x0: alignment === "start" ? x : x - sign * size,
+    x1: alignment === "end" ? x : x + sign * size,
     y0,
     y1: y
   };
@@ -204,8 +202,8 @@ const getHorizontalBarPoints = (position, sign, cr) => {
 };
 
 // eslint-disable-next-line max-params
-export const getVerticalBarPath = (props, width, cornerRadius, barOffset) => {
-  const position = getPosition(props, width, barOffset);
+export const getVerticalBarPath = (props, width, cornerRadius) => {
+  const position = getPosition(props, width);
 
   const sign = position.y0 > position.y1 ? 1 : -1;
   const direction = sign > 0 ? "0 0 1" : "0 0 0";
@@ -214,8 +212,8 @@ export const getVerticalBarPath = (props, width, cornerRadius, barOffset) => {
 };
 
 // eslint-disable-next-line max-params
-export const getHorizontalBarPath = (props, width, cornerRadius, barOffset) => {
-  const position = getPosition(props, width, barOffset);
+export const getHorizontalBarPath = (props, width, cornerRadius) => {
+  const position = getPosition(props, width);
 
   const sign = position.x0 < position.x1 ? 1 : -1;
   const direction = "0 0 1";

--- a/packages/victory-core/src/victory-util/label-helpers.js
+++ b/packages/victory-core/src/victory-util/label-helpers.js
@@ -49,17 +49,15 @@ function getPadding(props, datum) {
   };
 }
 
-function getOffset(props, datum, offset) {
+function getOffset(props, datum) {
   if (props.polar) {
     return {};
   }
   const padding = getPadding(props, datum);
-  const xOffset = props.horizontal ? -offset[1] : offset[0];
-  const yOffset = props.horizontal ? -offset[0] : offset[1];
 
   return {
-    dx: padding.x + xOffset,
-    dy: padding.y + yOffset
+    dx: padding.x,
+    dy: padding.y
   };
 }
 
@@ -166,7 +164,7 @@ function getDegrees(props, datum) {
   return Helpers.radiansToDegrees(props.scale.x(x));
 }
 
-function getProps(props, index, offset = [0, 0]) {
+function getProps(props, index) {
   const { scale, data, style, horizontal, polar, width, height } = props;
   const datum = data[index];
   const degrees = getDegrees(props, datum);
@@ -178,7 +176,7 @@ function getProps(props, index, offset = [0, 0]) {
   const text = getText(props, datum, index);
   const labelPlacement = getLabelPlacement(props);
   const { x, y } = getPosition(props, datum);
-  const { dx, dy } = getOffset(props, datum, offset);
+  const { dx, dy } = getOffset(props, datum);
   return {
     angle,
     data,

--- a/packages/victory-histogram/src/helper-methods.js
+++ b/packages/victory-histogram/src/helper-methods.js
@@ -82,12 +82,18 @@ export const getFormattedData = cacheLastValue(({ data = [], x, bins }) => {
     return x0 !== x1;
   });
 
-  const formattedData = binnedData.map((bin) => ({
-    x0: dataOrBinsContainsDates ? new Date(bin.x0) : bin.x0,
-    x1: dataOrBinsContainsDates ? new Date(bin.x1) : bin.x1,
-    y: bin.length,
-    binnedData: [...bin]
-  }));
+  const formattedData = binnedData.map((bin) => {
+    const x0 = dataOrBinsContainsDates ? new Date(bin.x0) : bin.x0;
+    const x1 = dataOrBinsContainsDates ? new Date(bin.x1) : bin.x1;
+
+    return {
+      x0,
+      x1,
+      x: dataOrBinsContainsDates ? new Date((x0.getTime() + x1.getTime()) / 2) : (x0 + x1) / 2,
+      y: bin.length,
+      binnedData: [...bin]
+    };
+  });
 
   return formattedData;
 });
@@ -97,7 +103,7 @@ const getData = (props) => {
   const dataIsPreformatted = data.some(({ _y }) => !isNil(_y));
 
   const formattedData = dataIsPreformatted ? data : getFormattedData({ data, x, bins });
-  return Data.getData({ ...props, data: formattedData, x: "x0" });
+  return Data.getData({ ...props, data: formattedData, x: "x" });
 };
 
 const getDomain = (props, axis) => {
@@ -218,7 +224,7 @@ const getBaseProps = (props, fallbackProps) => {
     const barWidth = getBarWidth(datum);
 
     const dataProps = {
-      alignment: "start",
+      alignment: "middle",
       barWidth,
       cornerRadius,
       data,
@@ -243,10 +249,7 @@ const getBaseProps = (props, fallbackProps) => {
 
     const text = LabelHelpers.getText(props, datum, index);
     if ((text !== undefined && text !== null) || (labels && (events || sharedEvents))) {
-      childProps[eventKey].labels = LabelHelpers.getProps(props, index, [
-        barWidth / 2 + barOffset[0],
-        0
-      ]);
+      childProps[eventKey].labels = LabelHelpers.getProps(props, index);
     }
 
     return childProps;

--- a/packages/victory-histogram/src/helper-methods.js
+++ b/packages/victory-histogram/src/helper-methods.js
@@ -208,16 +208,6 @@ const getBaseProps = (props, fallbackProps) => {
     return getDistance(datum);
   };
 
-  const barOffset = (() => {
-    if (binSpacing) {
-      // eslint-disable-next-line no-magic-numbers
-      const distance = binSpacing / 4;
-      return [distance, 0];
-    }
-
-    return [0, 0];
-  })();
-
   return data.reduce((childProps, datum, index) => {
     const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
 
@@ -240,7 +230,6 @@ const getBaseProps = (props, fallbackProps) => {
       y,
       y0,
       x0,
-      barOffset,
       getPath
     };
 

--- a/packages/victory-histogram/src/helper-methods.js
+++ b/packages/victory-histogram/src/helper-methods.js
@@ -210,7 +210,8 @@ const getBaseProps = (props, fallbackProps) => {
 
   const barOffset = (() => {
     if (binSpacing) {
-      const distance = binSpacing / 2;
+      // eslint-disable-next-line no-magic-numbers
+      const distance = binSpacing / 4;
       return [distance, 0];
     }
 


### PR DESCRIPTION
This fixes an issue that was occurring where tooltips being rendered by `VictoryVoronoiContainer`  for `VictoryHistogram` were being placed at the beginning of the bin (`x0`), which leads to a slightly weird positioning. To fix that, the middle of the bin is now used, so this should lead to a more intuitive positioning. 

![Screen Shot 2020-05-18 at 11 29 29 AM](https://user-images.githubusercontent.com/8966794/82247207-dae66680-98fa-11ea-88a5-5833b7f1917f.png)
