### PR TITLE
Task/add customization for id prop

### DIFF
--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -93,7 +93,25 @@ const getAreaFunction = (props) => {
     : getCartesianArea(props, interpolation);
 };
 
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `desc`
+   * 2) `id`
+   * 3) `style`
+   * 4) `tabIndex`
+   * 5) everything else
+   */
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const style = Helpers.evaluateStyle(assign({ fill: "black" }, props.style), props);
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { desc, id, style, tabIndex });
+};
+
 const Area = (props) => {
+  props = evaluateProps(props);
   const {
     role,
     shapeRendering,
@@ -105,9 +123,11 @@ const Area = (props) => {
     events,
     groupComponent,
     clipPath,
-    id
+    id,
+    style,
+    desc,
+    tabIndex
   } = props;
-  const style = Helpers.evaluateStyle(assign({ fill: "black" }, props.style), props);
   const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
   const transform = props.transform || defaultTransform;
   const renderLine = style.stroke && style.stroke !== "none" && style.stroke !== "transparent";
@@ -124,8 +144,8 @@ const Area = (props) => {
         key: `${id}-area`,
         style: assign({}, style, { stroke: areaStroke }),
         d: areaFunction(data),
-        desc: Helpers.evaluateProp(props.desc, props),
-        tabIndex: Helpers.evaluateProp(props.tabIndex, props)
+        desc,
+        tabIndex
       },
       sharedProps
     )

--- a/packages/victory-area/src/area.js
+++ b/packages/victory-area/src/area.js
@@ -95,12 +95,11 @@ const getAreaFunction = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `desc`
-   * 2) `id`
-   * 3) `style`
-   * 4) `tabIndex`
-   * 5) everything else
+   * Potential evaluated props are:
+   * `desc`
+   * `id`
+   * `style`
+   * `tabIndex`
    */
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -78,18 +78,20 @@ const getStyle = (style = {}, props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
+   * Potential evaluated props of following must be evaluated in this order:
    * 1) `style`
    * 2) `barWidth`
    * 3) `cornerRadius`
-   * 4) `desc`
-   * 5) `id`
-   * 6) `tabIndex`
-   * 7) everything else
+   *
+   * Everything else does not have to be evaluated in a particular order:
+   * `desc`
+   * `id`
+   * `tabIndex`
    */
   const style = getStyle(props.style, props);
   const barWidth = getBarWidth(props.barWidth, assign({}, props, { style }));
   const cornerRadius = getCornerRadius(props.cornerRadius, assign({}, props, { style, barWidth }));
+
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -77,11 +77,24 @@ const getStyle = (style = {}, props) => {
 };
 
 const evaluateProps = (props) => {
-  // Potential evaluated props are 1) `style`, 2) `barWidth` and 3) `cornerRadius`
+  /**
+   * Potential evaluated props are
+   * 1) `style`
+   * 2) `barWidth`
+   * 3) `cornerRadius`
+   * 4) `desc`
+   * 5) `id`
+   * 6) `tabIndex`
+   * 7) everything else
+   */
   const style = getStyle(props.style, props);
   const barWidth = getBarWidth(props.barWidth, assign({}, props, { style }));
   const cornerRadius = getCornerRadius(props.cornerRadius, assign({}, props, { style, barWidth }));
-  return assign({}, props, { style, barWidth, cornerRadius });
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { style, barWidth, cornerRadius, desc, id, tabIndex });
 };
 
 const Bar = (props) => {
@@ -102,8 +115,8 @@ const Bar = (props) => {
     role: props.role,
     shapeRendering: props.shapeRendering,
     clipPath: props.clipPath,
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props)
+    desc: props.desc,
+    tabIndex: props.tabIndex
   });
 };
 

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -52,10 +52,22 @@ const getLowWickProps = (props, style) => {
 };
 
 const evaluateProps = (props) => {
-  // Potential evaluated props are 1) `style`, 2) `candleWidth`
+  /**
+   * Potential evaulated props are
+   * 1) `style`
+   * 2) `candleWidth`
+   * 3) `desc`
+   * 4) `id`
+   * 5) `tabIndex`
+   * 6) everything else
+   */
   const style = Helpers.evaluateStyle(assign({ stroke: "black" }, props.style), props);
   const candleWidth = getCandleWidth(props.candleWidth, assign({}, props, { style }));
-  return assign({}, props, { style, candleWidth });
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { style, candleWidth, desc, id, tabIndex });
 };
 
 const Candle = (props) => {
@@ -71,7 +83,9 @@ const Candle = (props) => {
     className,
     wickStrokeWidth,
     transform,
-    style
+    style,
+    desc,
+    tabIndex
   } = props;
   const wickStyle = defaults({ strokeWidth: wickStrokeWidth }, style);
   const sharedProps = {
@@ -81,8 +95,8 @@ const Candle = (props) => {
     className,
     transform,
     clipPath,
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props)
+    desc,
+    tabIndex
   };
   const candleProps = assign(getCandleProps(props, style), sharedProps);
   const highWickProps = assign(getHighWickProps(props, wickStyle), sharedProps);

--- a/packages/victory-candlestick/src/candle.js
+++ b/packages/victory-candlestick/src/candle.js
@@ -53,16 +53,18 @@ const getLowWickProps = (props, style) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaulated props are
+   * Potential evaluated props of following must be evaluated in this order:
    * 1) `style`
-   * 2) `candleWidth`
-   * 3) `desc`
-   * 4) `id`
-   * 5) `tabIndex`
-   * 6) everything else
+   * 2) `cornerRadius`
+   *
+   * Everything else does not have to be evaluated in a particular order:
+   * `desc`
+   * `id`
+   * `tabIndex`
    */
   const style = Helpers.evaluateStyle(assign({ stroke: "black" }, props.style), props);
   const candleWidth = getCandleWidth(props.candleWidth, assign({}, props, { style }));
+
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -577,7 +577,7 @@ export interface VictoryCommonPrimitiveProps {
   data?: any;
   desc?: string | Function;
   events?: object;
-  id?: number | string;
+  id?: number | string | Function;
   index?: number | string;
   origin?: OriginType;
   polar?: boolean;

--- a/packages/victory-core/src/victory-primitives/arc.js
+++ b/packages/victory-core/src/victory-primitives/arc.js
@@ -27,12 +27,11 @@ const getArcPath = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `desc`
-   * 2) `id`
-   * 3) `style`
-   * 4) `tabIndex`
-   * 5) everything else
+   * Potential evaluated props are:
+   * `desc`
+   * `id`
+   * `style`
+   * `tabIndex`
    */
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);

--- a/packages/victory-core/src/victory-primitives/arc.js
+++ b/packages/victory-core/src/victory-primitives/arc.js
@@ -25,19 +25,42 @@ const getArcPath = (props) => {
   return `${arcStart} ${arc1} ${arc2} ${arcEnd}`;
 };
 
-const Arc = (props) =>
-  React.cloneElement(props.pathComponent, {
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `desc`
+   * 2) `id`
+   * 3) `style`
+   * 4) `tabIndex`
+   * 5) everything else
+   */
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const style = Helpers.evaluateStyle(
+    assign({ stroke: "black", fill: "none" }, props.style),
+    props
+  );
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { desc, id, style, tabIndex });
+};
+
+const Arc = (props) => {
+  props = evaluateProps(props);
+
+  return React.cloneElement(props.pathComponent, {
     ...props.events,
     d: getArcPath(props),
-    style: Helpers.evaluateStyle(assign({ stroke: "black", fill: "none" }, props.style), props),
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
+    style: props.style,
+    desc: props.desc,
+    tabIndex: props.tabIndex,
     className: props.className,
     role: props.role,
     shapeRendering: props.shapeRendering,
     transform: props.transform,
     clipPath: props.clipPath
   });
+};
 
 Arc.propTypes = {
   ...CommonProps.primitiveProps,

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -1,10 +1,25 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { assign } from "lodash";
+import Helpers from "../victory-util/helpers";
 import CommonProps from "../victory-util/common-props";
 import Rect from "./rect";
 import Circle from "./circle";
 
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `id`
+   * 2) everything else
+   */
+  const id = Helpers.evaluateProp(props.id, props);
+
+  return assign({}, props, { id });
+};
+
 const Background = (props) => {
+  props = evaluateProps(props);
+
   return props.polar
     ? React.cloneElement(props.circleComponent, {
         ...props.events,

--- a/packages/victory-core/src/victory-primitives/background.js
+++ b/packages/victory-core/src/victory-primitives/background.js
@@ -8,9 +8,8 @@ import Circle from "./circle";
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `id`
-   * 2) everything else
+   * Potential evaluated prop is:
+   * `id`
    */
   const id = Helpers.evaluateProp(props.id, props);
 

--- a/packages/victory-core/src/victory-primitives/border.js
+++ b/packages/victory-core/src/victory-primitives/border.js
@@ -7,12 +7,11 @@ import Rect from "./rect";
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `desc`
-   * 2) `id`
-   * 3) `style`
-   * 4) `tabIndex`
-   * 5) everything else
+   * Potential evaluated props are:
+   * `desc`
+   * `id`
+   * `style`
+   * `tabIndex`
    */
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);

--- a/packages/victory-core/src/victory-primitives/border.js
+++ b/packages/victory-core/src/victory-primitives/border.js
@@ -5,12 +5,31 @@ import { assign } from "lodash";
 import CommonProps from "../victory-util/common-props";
 import Rect from "./rect";
 
-const Border = (props) =>
-  React.cloneElement(props.rectComponent, {
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `desc`
+   * 2) `id`
+   * 3) `style`
+   * 4) `tabIndex`
+   * 5) everything else
+   */
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const style = Helpers.evaluateStyle(assign({ fill: "none" }, props.style), props);
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { desc, id, style, tabIndex });
+};
+
+const Border = (props) => {
+  props = evaluateProps(props);
+
+  return React.cloneElement(props.rectComponent, {
     ...props.events,
-    style: Helpers.evaluateStyle(assign({ fill: "none" }, props.style), props),
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
+    style: props.style,
+    desc: props.desc,
+    tabIndex: props.tabIndex,
     transform: props.transform,
     className: props.className,
     role: props.role,
@@ -21,6 +40,7 @@ const Border = (props) =>
     height: props.height,
     clipPath: props.clipPath
   });
+};
 
 Border.propTypes = {
   ...CommonProps.primitiveProps,

--- a/packages/victory-core/src/victory-primitives/line-segment.js
+++ b/packages/victory-core/src/victory-primitives/line-segment.js
@@ -7,12 +7,11 @@ import Line from "./line";
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `desc`
-   * 2) `id`
-   * 3) `style`
-   * 4) `tabIndex`
-   * 5) everything else
+   * Potential evaluated props are:
+   * `desc`
+   * `id`
+   * `style`
+   * `tabIndex`
    */
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);

--- a/packages/victory-core/src/victory-primitives/line-segment.js
+++ b/packages/victory-core/src/victory-primitives/line-segment.js
@@ -5,12 +5,31 @@ import { assign } from "lodash";
 import CommonProps from "../victory-util/common-props";
 import Line from "./line";
 
-const LineSegment = (props) =>
-  React.cloneElement(props.lineComponent, {
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `desc`
+   * 2) `id`
+   * 3) `style`
+   * 4) `tabIndex`
+   * 5) everything else
+   */
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const style = Helpers.evaluateStyle(assign({ stroke: "black" }, props.style), props);
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { desc, id, style, tabIndex });
+};
+
+const LineSegment = (props) => {
+  props = evaluateProps(props);
+
+  return React.cloneElement(props.lineComponent, {
     ...props.events,
-    style: Helpers.evaluateStyle(assign({ stroke: "black" }, props.style), props),
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
+    style: props.style,
+    desc: props.desc,
+    tabIndex: props.tabIndex,
     className: props.className,
     role: props.role,
     shapeRendering: props.shapeRendering,
@@ -21,6 +40,7 @@ const LineSegment = (props) =>
     transform: props.transform,
     clipPath: props.clipPath
   });
+};
 
 LineSegment.propTypes = {
   ...CommonProps.primitiveProps,

--- a/packages/victory-core/src/victory-primitives/point.js
+++ b/packages/victory-core/src/victory-primitives/point.js
@@ -28,14 +28,13 @@ const getPath = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `desc`
-   * 2) `id`
-   * 3) `size`
-   * 4) `style`
-   * 5) `symbol`
-   * 6) `tabIndex`
-   * 7) everything else
+   * Potential evaluated props are:
+   * `desc`
+   * `id`
+   * `size`
+   * `style`
+   * `symbol`
+   * `tabIndex`
    */
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);

--- a/packages/victory-core/src/victory-primitives/point.js
+++ b/packages/victory-core/src/victory-primitives/point.js
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { assign } from "lodash";
 import Helpers from "../victory-util/helpers";
 import pathHelpers from "./path-helpers";
 import CommonProps from "../victory-util/common-props";
 import Path from "./path";
 
 const getPath = (props) => {
-  const { x, y } = props;
-  const size = Helpers.evaluateProp(props.size, props);
+  const { x, y, size, symbol } = props;
   if (props.getPath) {
     return props.getPath(x, y, size);
   }
@@ -21,25 +21,48 @@ const getPath = (props) => {
     minus: pathHelpers.minus,
     star: pathHelpers.star
   };
-  const symbol = Helpers.evaluateProp(props.symbol, props);
   const symbolFunction =
     typeof pathFunctions[symbol] === "function" ? pathFunctions[symbol] : pathFunctions.circle;
   return symbolFunction(x, y, size);
 };
 
-const Point = (props) =>
-  React.cloneElement(props.pathComponent, {
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `desc`
+   * 2) `id`
+   * 3) `size`
+   * 4) `style`
+   * 5) `symbol`
+   * 6) `tabIndex`
+   * 7) everything else
+   */
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const size = Helpers.evaluateProp(props.size, props);
+  const style = Helpers.evaluateStyle(props.style, props);
+  const symbol = Helpers.evaluateProp(props.symbol, props);
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { desc, id, size, style, symbol, tabIndex });
+};
+
+const Point = (props) => {
+  props = evaluateProps(props);
+
+  return React.cloneElement(props.pathComponent, {
     ...props.events,
     d: getPath(props),
-    style: Helpers.evaluateStyle(props.style, props),
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
+    style: props.style,
+    desc: props.desc,
+    tabIndex: props.tabIndex,
     role: props.role,
     shapeRendering: props.shapeRendering,
     className: props.className,
     transform: props.transform,
     clipPath: props.clipPath
   });
+};
 
 Point.propTypes = {
   ...CommonProps.primitiveProps,

--- a/packages/victory-core/src/victory-primitives/whisker.js
+++ b/packages/victory-core/src/victory-primitives/whisker.js
@@ -7,12 +7,11 @@ import Line from "./line";
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `desc`
-   * 2) `id`
-   * 3) `style`
-   * 4) `tabIndex`
-   * 5) everything else
+   * Potential evaluated props are:
+   * `desc`
+   * `id`
+   * `style`
+   * `tabIndex`
    */
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);

--- a/packages/victory-core/src/victory-primitives/whisker.js
+++ b/packages/victory-core/src/victory-primitives/whisker.js
@@ -1,11 +1,29 @@
 import React from "react";
+import { assign } from "lodash";
 import PropTypes from "prop-types";
 import Helpers from "../victory-util/helpers";
 import CommonProps from "../victory-util/common-props";
 import Line from "./line";
-import { assign } from "lodash";
+
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `desc`
+   * 2) `id`
+   * 3) `style`
+   * 4) `tabIndex`
+   * 5) everything else
+   */
+  const desc = Helpers.evaluateProp(props.desc, props);
+  const id = Helpers.evaluateProp(props.id, props);
+  const style = Helpers.evaluateStyle(props.style, props);
+  const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+
+  return assign({}, props, { desc, id, style, tabIndex });
+};
 
 const Whisker = (props) => {
+  props = evaluateProps(props);
   const {
     groupComponent,
     lineComponent,
@@ -16,19 +34,23 @@ const Whisker = (props) => {
     transform,
     clipPath,
     role,
-    shapeRendering
+    shapeRendering,
+    style,
+    desc,
+    tabIndex
   } = props;
   const baseProps = {
     ...events,
-    style: Helpers.evaluateStyle(props.style, props),
-    desc: Helpers.evaluateProp(props.desc, props),
-    tabIndex: Helpers.evaluateProp(props.tabIndex, props),
+    style,
+    desc,
+    tabIndex,
     className,
     transform,
     clipPath,
     role,
     shapeRendering
   };
+
   return React.cloneElement(groupComponent, {}, [
     React.cloneElement(lineComponent, assign({ key: "major-whisker" }, baseProps, majorWhisker)),
     React.cloneElement(lineComponent, assign({ key: "minor-whisker" }, baseProps, minorWhisker))

--- a/packages/victory-core/src/victory-util/common-props.js
+++ b/packages/victory-core/src/victory-util/common-props.js
@@ -151,7 +151,7 @@ const primitiveProps = {
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   desc: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   events: PropTypes.object,
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.func]),
   index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
   polar: PropTypes.bool,

--- a/packages/victory-errorbar/src/error-bar.js
+++ b/packages/victory-errorbar/src/error-bar.js
@@ -59,9 +59,22 @@ const calculateError = (props) => {
   return result;
 };
 
-const ErrorBar = (props) => {
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `id`
+   * 2) `style`
+   * 3) everything else
+   */
+  const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(assign({ stroke: "black" }, props.style), props);
-  props = assign({}, props, { style });
+
+  return assign({}, props, { id, style });
+};
+
+const ErrorBar = (props) => {
+  props = evaluateProps(props);
+
   const error = calculateError(props);
   const children = [
     error.right ? renderBorder(props, error, "right") : null,

--- a/packages/victory-errorbar/src/error-bar.js
+++ b/packages/victory-errorbar/src/error-bar.js
@@ -61,10 +61,9 @@ const calculateError = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `id`
-   * 2) `style`
-   * 3) everything else
+   * Potential evaluated props are:
+   * `id`
+   * `style`
    */
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(assign({ stroke: "black" }, props.style), props);

--- a/packages/victory-line/src/curve.js
+++ b/packages/victory-line/src/curve.js
@@ -54,14 +54,32 @@ const getLineFunction = (props) => {
         .y(horizontal ? getXAccessor(scale) : getYAccessor(scale));
 };
 
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `id`
+   * 2) `style`
+   * 3) everything else
+   */
+  const id = Helpers.evaluateProp(props.id, props);
+  const style = Helpers.evaluateStyle(
+    assign({ fill: "none", stroke: "black" }, props.style),
+    props
+  );
+
+  return assign({}, props, { id, style });
+};
+
 const Curve = (props) => {
+  props = evaluateProps(props);
   const { polar, origin } = props;
   const lineFunction = getLineFunction(props);
   const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+
   return React.cloneElement(props.pathComponent, {
     ...props.events,
     d: lineFunction(props.data),
-    style: Helpers.evaluateStyle(assign({ fill: "none", stroke: "black" }, props.style), props),
+    style: props.style,
     transform: props.transform || defaultTransform,
     className: props.className,
     role: props.role,

--- a/packages/victory-line/src/curve.js
+++ b/packages/victory-line/src/curve.js
@@ -56,10 +56,9 @@ const getLineFunction = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `id`
-   * 2) `style`
-   * 3) everything else
+   * Potential evaluated props are:
+   * `id`
+   * `style`
    */
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(

--- a/packages/victory-pie/src/slice.js
+++ b/packages/victory-pie/src/slice.js
@@ -22,20 +22,22 @@ const getPath = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
+   * * Potential evaluated props of following must be evaluated in this order:
    * 1) `style`
    * 2) `radius`
    * 3) `innerRadius`
-   * 4) `id`
-   * 5) `cornerRadius`
-   * 6) `padAngle`
-   * 7) `sliceStartAngle`
-   * 8) `sliceEndAngle`
-   * 9) everything else
+   *
+   * Everything else does not have to be evaluated in a particular order:
+   * `id`
+   * `cornerRadius`
+   * `padAngle`
+   * `sliceStartAngle`
+   * `sliceEndAngle`
    */
   const style = Helpers.evaluateStyle(props.style, props);
   const radius = Helpers.evaluateProp(props.radius, assign({}, props, { style }));
   const innerRadius = Helpers.evaluateProp(props.innerRadius, assign({}, props, { style, radius }));
+
   const id = Helpers.evaluateProp(props.id, props);
   const cornerRadius = Helpers.evaluateProp(props.cornerRadius, props);
   const padAngle = Helpers.evaluateProp(props.padAngle, props);

--- a/packages/victory-pie/src/slice.js
+++ b/packages/victory-pie/src/slice.js
@@ -5,14 +5,13 @@ import { defaults, isFunction, assign } from "lodash";
 import * as d3Shape from "d3-shape";
 
 const getPath = (props) => {
-  const { slice, radius, innerRadius } = props;
+  const { slice, radius, innerRadius, cornerRadius } = props;
   if (isFunction(props.pathFunction)) {
     return props.pathFunction(slice);
   }
-  const cornerRadius = Helpers.evaluateProp(props.cornerRadius, props);
-  const padAngle = Helpers.degreesToRadians(Helpers.evaluateProp(props.padAngle, props));
-  const startAngle = Helpers.degreesToRadians(Helpers.evaluateProp(props.sliceStartAngle, props));
-  const endAngle = Helpers.degreesToRadians(Helpers.evaluateProp(props.sliceEndAngle, props));
+  const padAngle = Helpers.degreesToRadians(props.padAngle);
+  const startAngle = Helpers.degreesToRadians(props.sliceStartAngle);
+  const endAngle = Helpers.degreesToRadians(props.sliceEndAngle);
   const pathFunction = d3Shape
     .arc()
     .cornerRadius(cornerRadius)
@@ -22,16 +21,37 @@ const getPath = (props) => {
 };
 
 const evaluateProps = (props) => {
-  /* Potential evaluated props are
-    1) style
-    2) radius
-    3) innerRadius
-    4) everything else
-  */
+  /**
+   * Potential evaluated props are
+   * 1) `style`
+   * 2) `radius`
+   * 3) `innerRadius`
+   * 4) `id`
+   * 5) `cornerRadius`
+   * 6) `padAngle`
+   * 7) `sliceStartAngle`
+   * 8) `sliceEndAngle`
+   * 9) everything else
+   */
   const style = Helpers.evaluateStyle(props.style, props);
   const radius = Helpers.evaluateProp(props.radius, assign({}, props, { style }));
   const innerRadius = Helpers.evaluateProp(props.innerRadius, assign({}, props, { style, radius }));
-  return assign({}, props, { style, radius, innerRadius });
+  const id = Helpers.evaluateProp(props.id, props);
+  const cornerRadius = Helpers.evaluateProp(props.cornerRadius, props);
+  const padAngle = Helpers.evaluateProp(props.padAngle, props);
+  const sliceStartAngle = Helpers.evaluateProp(props.sliceStartAngle, props);
+  const sliceEndAngle = Helpers.evaluateProp(props.sliceEndAngle, props);
+
+  return assign({}, props, {
+    style,
+    radius,
+    innerRadius,
+    id,
+    cornerRadius,
+    padAngle,
+    sliceStartAngle,
+    sliceEndAngle
+  });
 };
 
 const Slice = (props) => {
@@ -39,6 +59,7 @@ const Slice = (props) => {
   const defaultTransform = props.origin
     ? `translate(${props.origin.x}, ${props.origin.y})`
     : undefined;
+
   return React.cloneElement(props.pathComponent, {
     ...props.events,
     d: getPath(props),

--- a/packages/victory-tooltip/src/flyout.js
+++ b/packages/victory-tooltip/src/flyout.js
@@ -2,7 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Helpers, CommonProps, Path } from "victory-core";
-import { isPlainObject } from "lodash";
+import { isPlainObject, assign } from "lodash";
 
 const getVerticalPath = (props) => {
   const { pointerWidth, cornerRadius, orientation, width, height, center } = props;
@@ -67,10 +67,25 @@ const getFlyoutPath = (props) => {
     : getVerticalPath(props);
 };
 
-const Flyout = (props) =>
-  React.cloneElement(props.pathComponent, {
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `id`
+   * 2) `style`
+   * 3) everything else
+   */
+  const id = Helpers.evaluateProp(props.id, props);
+  const style = Helpers.evaluateStyle(props.style, props);
+
+  return assign({}, props, { id, style });
+};
+
+const Flyout = (props) => {
+  props = evaluateProps(props);
+
+  return React.cloneElement(props.pathComponent, {
     ...props.events,
-    style: Helpers.evaluateStyle(props.style, props),
+    style: props.style,
     d: getFlyoutPath(props),
     className: props.className,
     shapeRendering: props.shapeRendering,
@@ -78,6 +93,7 @@ const Flyout = (props) =>
     transform: props.transform,
     clipPath: props.clipPath
   });
+};
 
 Flyout.propTypes = {
   ...CommonProps.primitiveProps,

--- a/packages/victory-tooltip/src/flyout.js
+++ b/packages/victory-tooltip/src/flyout.js
@@ -69,10 +69,9 @@ const getFlyoutPath = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `id`
-   * 2) `style`
-   * 3) everything else
+   * Potential evaluated props are:
+   * `id`
+   * `style`
    */
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(props.style, props);

--- a/packages/victory-voronoi/src/voronoi.js
+++ b/packages/victory-voronoi/src/voronoi.js
@@ -11,11 +11,10 @@ const getVoronoiPath = (props) => {
 
 const evaluateProps = (props) => {
   /**
-   * Potential evaluated props are
-   * 1) `id`
-   * 2) `size`
-   * 3) `style`
-   * 4) everything else
+   * Potential evaluated props are:
+   * `id`
+   * `size`
+   * `style`
    */
   const id = Helpers.evaluateProp(props.id, props);
   const size = Helpers.evaluateProp(props.size, props);

--- a/packages/victory-voronoi/src/voronoi.js
+++ b/packages/victory-voronoi/src/voronoi.js
@@ -1,6 +1,7 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
+import { assign } from "lodash";
 import { Helpers, CommonProps, ClipPath, Path, Circle } from "victory-core";
 
 const getVoronoiPath = (props) => {
@@ -8,12 +9,26 @@ const getVoronoiPath = (props) => {
   return Array.isArray(polygon) && polygon.length ? `M ${props.polygon.join("L")} Z` : "";
 };
 
-const Voronoi = (props) => {
-  const { role, shapeRendering, className, events, transform } = props;
-
-  const voronoiPath = getVoronoiPath(props);
-  const style = Helpers.evaluateStyle(props.style, props);
+const evaluateProps = (props) => {
+  /**
+   * Potential evaluated props are
+   * 1) `id`
+   * 2) `size`
+   * 3) `style`
+   * 4) everything else
+   */
+  const id = Helpers.evaluateProp(props.id, props);
   const size = Helpers.evaluateProp(props.size, props);
+  const style = Helpers.evaluateStyle(props.style, props);
+
+  return assign({}, props, { id, size, style });
+};
+
+const Voronoi = (props) => {
+  props = evaluateProps(props);
+
+  const { role, shapeRendering, className, events, transform, style, size } = props;
+  const voronoiPath = getVoronoiPath(props);
   const sharedProps = { className, role, shapeRendering, style, transform, ...events };
 
   if (size) {


### PR DESCRIPTION
This PR: 
* Creates/Refactors the `evaluateProps` method to allow support for passing a function for the `id` props
* Updates proptype definition for `id` in `primitiveProps`
* Updates type definition for `id` in `VictoryCommonPrimitiveProps` interface
