### PR TITLE
Fix cursor not disappearing on mouse leave

### DIFF
--- a/packages/victory-cursor-container/src/cursor-helpers.js
+++ b/packages/victory-cursor-container/src/cursor-helpers.js
@@ -86,5 +86,6 @@ export default {
     32, // eslint-disable-line no-magic-numbers
     { leading: true, trailing: false }
   ),
+  onMouseLeave: CursorHelpers.onMouseMove.bind(CursorHelpers),
   onTouchEnd: CursorHelpers.onTouchEnd.bind(CursorHelpers)
 };

--- a/packages/victory-cursor-container/src/victory-cursor-container.js
+++ b/packages/victory-cursor-container/src/victory-cursor-container.js
@@ -44,8 +44,8 @@ export const cursorContainerMixin = (base) =>
         {
           target: "parent",
           eventHandlers: {
-            onMouseLeave: () => {
-              return [];
+            onMouseLeave: (evt, targetProps) => {
+              return props.disable ? {} : CursorHelpers.onMouseLeave(evt, targetProps);
             },
             onTouchCancel: () => {
               return [];


### PR DESCRIPTION
This fixes #1276, where the cursor wasn't disappearing after your mouse leaves `VictoryCursorContainer`.

This issue can be reproduced by putting your mouse inside a `VictoryCursorContainer` and then quickly moving it outside the container.