### PR TITLE
Fix VictoryGroup offset with VictoryStack and VictoryBar

### DIFF
--- a/packages/victory-group/src/helper-methods.js
+++ b/packages/victory-group/src/helper-methods.js
@@ -67,7 +67,7 @@ function pixelsToValue(props, axis, calculatedProps) {
 }
 
 function getX0(props, calculatedProps, index) {
-  const center = (calculatedProps.datasets.length - 1) / 2;
+  const center = (calculatedProps.datasets[0].length - 1) / 2;
   const totalWidth = pixelsToValue(props, "x", calculatedProps);
   return (index - center) * totalWidth;
 }


### PR DESCRIPTION
The issue https://github.com/FormidableLabs/victory/issues/1315
The issue can be reproduced in sandbox https://formidable.com/open-source/victory/gallery/stacked-grouped-bars/ just increasing number of stack bars