### PR TITLE
Fix axes paddings for different orientation options

### DIFF
--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -226,8 +226,14 @@ const getAxisOffset = (props, calculatedProps, orientation) => {
   const { scale, origin, domain, padding } = calculatedProps;
   const { top, bottom, left, right } = padding;
   const orientations = {
-    x: orientation === "bottom" || orientation === "top" ? orientation : calculatedProps.orientations.x,
-    y: orientation === "left" || orientation === "right" ? orientation : calculatedProps.orientations.y
+    x:
+      orientation === "bottom" || orientation === "top"
+        ? orientation
+        : calculatedProps.orientations.x,
+    y:
+      orientation === "left" || orientation === "right"
+        ? orientation
+        : calculatedProps.orientations.y
   };
   // make the axes line up, and cross when appropriate
   const orientationOffset = {
@@ -254,8 +260,14 @@ const getHorizontalAxisOffset = (props, calculatedProps, orientation) => {
   const { scale, origin, domain, padding } = calculatedProps;
   const { top, bottom, left, right } = padding;
   const orientations = {
-    y: orientation === "bottom" || orientation === "top" ? orientation : calculatedProps.orientations.x,
-    x: orientation === "left" || orientation === "right" ? orientation : calculatedProps.orientations.y
+    y:
+      orientation === "bottom" || orientation === "top"
+        ? orientation
+        : calculatedProps.orientations.x,
+    x:
+      orientation === "left" || orientation === "right"
+        ? orientation
+        : calculatedProps.orientations.y
   };
   // make the axes line up, and cross when appropriate
   const orientationOffset = {

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -15,11 +15,11 @@ function getAxisProps(child, props, calculatedProps) {
   const { domain, scale, stringMap, categories, horizontal, orientations } = calculatedProps;
   const childProps = Axis.modifyProps(defaults({ horizontal, theme: props.theme }, child.props));
   const axis = child.type.getAxis(childProps);
-  const axisOffset = horizontal
-    ? getHorizontalAxisOffset(props, calculatedProps)
-    : getAxisOffset(props, calculatedProps);
   const crossAxis = childProps.crossAxis === false ? false : true;
   const orientation = childProps.orientation || orientations[axis];
+  const axisOffset = horizontal
+    ? getHorizontalAxisOffset(props, calculatedProps, orientation)
+    : getAxisOffset(props, calculatedProps, orientation);
   return {
     stringMap,
     horizontal,
@@ -222,9 +222,13 @@ const getDomain = (props, axis, childComponents) => {
   return invertDomain ? domain.concat().reverse() : domain;
 };
 
-const getAxisOffset = (props, calculatedProps) => {
-  const { scale, origin, domain, padding, orientations } = calculatedProps;
+const getAxisOffset = (props, calculatedProps, orientation) => {
+  const { scale, origin, domain, padding } = calculatedProps;
   const { top, bottom, left, right } = padding;
+  const orientations = {
+    x: orientation === "bottom" || orientation === "top" ? orientation : calculatedProps.orientations.x,
+    y: orientation === "left" || orientation === "right" ? orientation : calculatedProps.orientations.y
+  };
   // make the axes line up, and cross when appropriate
   const orientationOffset = {
     y: orientations.x === "bottom" ? bottom : top,
@@ -246,9 +250,13 @@ const getAxisOffset = (props, calculatedProps) => {
   };
 };
 
-const getHorizontalAxisOffset = (props, calculatedProps) => {
-  const { scale, origin, domain, padding, orientations } = calculatedProps;
+const getHorizontalAxisOffset = (props, calculatedProps, orientation) => {
+  const { scale, origin, domain, padding } = calculatedProps;
   const { top, bottom, left, right } = padding;
+  const orientations = {
+    y: orientation === "bottom" || orientation === "top" ? orientation : calculatedProps.orientations.x,
+    x: orientation === "left" || orientation === "right" ? orientation : calculatedProps.orientations.y
+  };
   // make the axes line up, and cross when appropriate
   const orientationOffset = {
     x: orientations.y === "bottom" ? bottom : top,

--- a/stories/victory-chart.js
+++ b/stories/victory-chart.js
@@ -47,9 +47,7 @@ storiesOf("VictoryChart.axes", module)
     </VictoryChart>
   ))
   .add("Paddings with different orientations", () => (
-    <VictoryChart
-      padding={{ left: 20, right: 30, top: 15, bottom: 40 }}
-    >
+    <VictoryChart padding={{ left: 20, right: 30, top: 15, bottom: 40 }}>
       <VictoryAxis tickValues={[1, 2, 3, 4, 5]} />
       <VictoryAxis orientation="left" dependentAxis tickValues={[1, 2, 3, 4, 5, 6, 7, 8]} />
       <VictoryAxis orientation="right" dependentAxis tickValues={[1, 2, 3, 4, 5, 6, 7, 8, 9]} />

--- a/stories/victory-chart.js
+++ b/stories/victory-chart.js
@@ -45,6 +45,19 @@ storiesOf("VictoryChart.axes", module)
     <VictoryChart theme={dependentAxisTheme}>
       <VictoryAxis dependentAxis />
     </VictoryChart>
+  ))
+  .add("Paddings with different orientations", () => (
+    <VictoryChart
+      padding={{ left: 20, right: 30, top: 15, bottom: 40 }}
+    >
+      <VictoryAxis tickValues={[1, 2, 3, 4, 5]} />
+      <VictoryAxis orientation="left" dependentAxis tickValues={[1, 2, 3, 4, 5, 6, 7, 8]} />
+      <VictoryAxis orientation="right" dependentAxis tickValues={[1, 2, 3, 4, 5, 6, 7, 8, 9]} />
+      <VictoryBar
+        style={{ data: { fill: "#c43a31" } }}
+        data={[{ x: 1, y: 1 }, { x: 2, y: 7 }, { x: 3, y: 4 }, { x: 4, y: 5 }, { x: 5, y: 2 }]}
+      />
+    </VictoryChart>
   ));
 
 storiesOf("VictoryChart.domainPadding", module)


### PR DESCRIPTION
Found bug with paddings when axis "orientation" prop is set.
![image](https://user-images.githubusercontent.com/26081310/84134614-82197200-aa51-11ea-84da-68360a577f80.png)
The trick is to take padding for axis depend on "orientation" prop if it is set. Also add story for reproduction and check.
