### PR TITLE
Add missing type for containerRef

### DIFF
--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -229,6 +229,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
             <VictoryZoomContainer
               zoomDomain={{ x: [new Date(1993, 1, 1), new Date(2005, 1, 1)] }}
               zoomDimension="x"
+              containerRef={(ref) => ref}
             />
           }
           scale={{

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -225,6 +225,7 @@ export interface VictoryContainerProps {
   children?: React.ReactElement | React.ReactElement[];
   className?: string;
   containerId?: number | string;
+  containerRef?: React.Ref<HTMLElement>;
   desc?: string;
   events?: React.DOMAttributes<any>;
   height?: number;


### PR DESCRIPTION
Adds a missing type to container props. Fix issue found here https://spectrum.chat/victory/general/how-do-i-use-the-containerref-prop~03f68b9e-6b08-4b5b-acd3-2d1a8b823ec0