### PR TITLE
voronoiPadding type to accept PaddingProps

### DIFF
--- a/demo/js/components/victory-voronoi-container-demo.js
+++ b/demo/js/components/victory-voronoi-container-demo.js
@@ -576,6 +576,48 @@ class App extends React.Component {
               }}
             />
           </VictoryChart>
+
+          <VictoryChart
+            height={450}
+            padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
+            style={chartStyle}
+            domain={{ y: [0, 6] }}
+            containerComponent={
+              <VictoryVoronoiContainer
+                voronoiDimension="x"
+                labels={({ datum }) => `y: ${datum.y}`}
+                labelComponent={<VictoryTooltip />}
+                voronoiPadding={{
+                  bottom: 50,
+                  left: 50,
+                  right: 50,
+                  top: 100
+                }}
+              />
+            }
+          >
+            <VictoryLegend
+              x={165}
+              y={10}
+              title="Voronoi padding"
+              centerTitle
+              orientation="horizontal"
+              gutter={20}
+              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
+              data={[
+                { name: "One", symbol: { fill: "tomato" } },
+                { name: "Two", symbol: { fill: "orange" } }
+              ]}
+            />
+            <VictoryScatter
+              style={{ data: { fill: "tomato" }, labels: { fill: "tomato" } }}
+              data={[{ x: 0, y: 2 }, { x: 2, y: 3 }, { x: 4, y: 4 }, { x: 6, y: 5 }]}
+            />
+            <VictoryScatter
+              style={{ data: { fill: "orange" }, labels: { fill: "orange" } }}
+              data={[{ x: 2, y: 2 }, { x: 4, y: 3 }, { x: 6, y: 4 }, { x: 8, y: 5 }]}
+            />
+          </VictoryChart>
         </div>
       </div>
     );

--- a/demo/ts/components/victory-voronoi-container-demo.tsx
+++ b/demo/ts/components/victory-voronoi-container-demo.tsx
@@ -590,6 +590,48 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               }}
             />
           </VictoryChart>
+
+          <VictoryChart
+            height={450}
+            padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
+            style={chartStyle}
+            domain={{ y: [0, 6] }}
+            containerComponent={
+              <VictoryVoronoiContainer
+                voronoiDimension="x"
+                labels={({ datum }) => `y: ${datum.y}`}
+                labelComponent={<VictoryTooltip />}
+                voronoiPadding={{
+                  bottom: 50,
+                  left: 50,
+                  right: 50,
+                  top: 100
+                }}
+              />
+            }
+          >
+            <VictoryLegend
+              x={165}
+              y={10}
+              title="Voronoi padding"
+              centerTitle
+              orientation="horizontal"
+              gutter={20}
+              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
+              data={[
+                { name: "One", symbol: { fill: "tomato" } },
+                { name: "Two", symbol: { fill: "orange" } }
+              ]}
+            />
+            <VictoryScatter
+              style={{ data: { fill: "tomato" }, labels: { fill: "tomato" } }}
+              data={[{ x: 0, y: 2 }, { x: 2, y: 3 }, { x: 4, y: 4 }, { x: 6, y: 5 }]}
+            />
+            <VictoryScatter
+              style={{ data: { fill: "orange" }, labels: { fill: "orange" } }}
+              data={[{ x: 2, y: 2 }, { x: 4, y: 3 }, { x: 6, y: 4 }, { x: 8, y: 5 }]}
+            />
+          </VictoryChart>
         </div>
       </div>
     );

--- a/packages/victory-voronoi-container/src/index.d.ts
+++ b/packages/victory-voronoi-container/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { VictoryContainerProps } from "victory-core";
+import { PaddingProps, VictoryContainerProps } from "victory-core";
 
 export interface VictoryVoronoiContainerProps extends VictoryContainerProps {
   activateData?: boolean;
@@ -13,7 +13,7 @@ export interface VictoryVoronoiContainerProps extends VictoryContainerProps {
   radius?: number;
   voronoiBlacklist?: string[];
   voronoiDimension?: "x" | "y";
-  voronoiPadding?: number;
+  voronoiPadding?: PaddingProps;
 }
 
 export class VictoryVoronoiContainer extends React.Component<VictoryVoronoiContainerProps, any> {}

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -23,7 +23,15 @@ export const voronoiContainerMixin = (base) =>
         PropTypes.oneOfType([PropTypes.string, CustomPropTypes.regExp])
       ),
       voronoiDimension: PropTypes.oneOf(["x", "y"]),
-      voronoiPadding: PropTypes.number
+      voronoiPadding: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.shape({
+          top: PropTypes.number,
+          bottom: PropTypes.number,
+          left: PropTypes.number,
+          right: PropTypes.number
+        })
+      ])
     };
     static defaultProps = {
       ...VictoryContainer.defaultProps,

--- a/packages/victory-voronoi-container/src/voronoi-helpers.js
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.js
@@ -6,15 +6,20 @@ import React from "react";
 
 const VoronoiHelpers = {
   withinBounds(props, point) {
-    const { width, height, voronoiPadding, polar, origin, scale } = props;
-    const padding = voronoiPadding || 0;
+    const { width, height, polar, origin, scale } = props;
+    const padding = Helpers.getPadding(props, "voronoiPadding");
     const { x, y } = point;
     if (polar) {
       const distanceSquared = Math.pow(x - origin.x, 2) + Math.pow(y - origin.y, 2);
       const radius = Math.max(...scale.y.range());
       return distanceSquared < Math.pow(radius, 2);
     } else {
-      return x >= padding && x <= width - padding && y >= padding && y <= height - padding;
+      return (
+        x >= padding.left &&
+        x <= width - padding.right &&
+        y >= padding.top &&
+        y <= height - padding.bottom
+      );
     }
   },
 


### PR DESCRIPTION
Instead of the `voronoiPadding` reducing voronoi trigger events via the same amount on every side, it can now behave more like the `padding` prop. This change allows a chart to have different `voronoiPadding` for the bottom, left, right, and top areas.

See https://github.com/FormidableLabs/victory/issues/1619

![chrome-capture (2)](https://user-images.githubusercontent.com/17481322/85218533-6b382100-b369-11ea-95d0-d27d995d0781.gif)
