### PR TITLE
Approximate text size typing fix

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -159,22 +159,22 @@ export interface VictoryAxisCommonProps {
   invertAxis?: boolean;
   style?: {
     parent?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
     };
     axis?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
     };
     axisLabel?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
     };
     grid?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
     };
     ticks?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
     };
     tickLabels?: {
-      [K in keyof TickLabelProps]: string | number | ((tick?: any) => string | number)
+      [K in keyof TickLabelProps]: string | number | ((tick?: any) => string | number);
     };
   };
   tickComponent?: React.ReactElement;
@@ -680,7 +680,10 @@ export interface TextSizeStyleInterface {
 }
 
 export namespace TextSize {
-  export function approximateTextSize(text: string, style: TextSizeStyleInterface): number;
+  export function approximateTextSize(
+    text: string,
+    style: TextSizeStyleInterface
+  ): { width: number; height: number };
   export function convertLengthToPixels(length: string, fontSize: number): number;
 }
 

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -682,7 +682,7 @@ export interface TextSizeStyleInterface {
 export namespace TextSize {
   export function approximateTextSize(
     text: string,
-    style: TextSizeStyleInterface
+    style?: TextSizeStyleInterface
   ): { width: number; height: number };
   export function convertLengthToPixels(length: string, fontSize: number): number;
 }

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -159,22 +159,22 @@ export interface VictoryAxisCommonProps {
   invertAxis?: boolean;
   style?: {
     parent?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
     };
     axis?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
     };
     axisLabel?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
     };
     grid?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
     };
     ticks?: {
-      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
+      [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number)
     };
     tickLabels?: {
-      [K in keyof TickLabelProps]: string | number | ((tick?: any) => string | number);
+      [K in keyof TickLabelProps]: string | number | ((tick?: any) => string | number)
     };
   };
   tickComponent?: React.ReactElement;


### PR DESCRIPTION
The typing is incorrect for the approximateTextSize utility function. This PR corrects the return shape to be `{width:number, height:number}`.
Also, based on the code and tests for the function, it appears that calling without the second style object is allowed so I marked it optional.