### PR TITLE
Add OUIA props to VictoryContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ storybook-static
 build-storybook.log*
 artifacts
 tmp
+.idea

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -37,6 +37,7 @@ import VictoryPieDemo from "./components/victory-pie-demo";
 import VictoryDemo from "./components/victory-demo";
 import HorizontalDemo from "./components/horizontal-demo";
 import DraggableDemo from "./components/draggable-demo";
+import OuiaDemo from "./components/ouia-demo";
 
 const MAP = {
   "/axis": { component: AxisDemo, name: "AxisDemo" },
@@ -71,7 +72,8 @@ const MAP = {
   "/pie": { component: VictoryPieDemo, name: "PieDemo" },
   "/victory": { component: VictoryDemo, name: "VictoryDemo" },
   "/horizontal": { component: HorizontalDemo, name: "HorizontalDemo" },
-  "/draggable": { component: DraggableDemo, name: "DraggableDemo" }
+  "/draggable": { component: DraggableDemo, name: "DraggableDemo" },
+  "/ouia": { component: OuiaDemo, name: "OuiaDemo" }
 };
 
 class Home extends React.Component {

--- a/demo/js/components/ouia-demo.js
+++ b/demo/js/components/ouia-demo.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { VictoryChart } from "Packages/victory-chart/src/index";
+import { VictoryLine } from "Packages/victory-line/src/index";
+import { VictoryContainer } from "Packages/victory-core/src/index";
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+    const chartStyle = {
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
+    };
+
+    return (
+      <div className="demo">
+        <h1>Open UI Automation (OUIA)</h1>
+        <div style={containerStyle}>
+          <VictoryChart
+            containerComponent={
+              <VictoryContainer
+                ouiaId="victory-container-ouia"
+                ouiaType="Victory/container"
+                ouiaSafe
+              />
+            }
+            style={chartStyle}
+          >
+            <VictoryLine />
+          </VictoryChart>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/demo/ts/app.tsx
+++ b/demo/ts/app.tsx
@@ -33,6 +33,7 @@ import VictorySharedEventsDemo from "./components/victory-shared-events-demo";
 import VoronoiContainerDemo from "./components/victory-voronoi-container-demo";
 import VoronoiDemo from "./components/victory-voronoi-demo";
 import ZoomContainerDemo from "./components/victory-zoom-container-demo";
+import OuiaDemo from "./components/ouia-demo";
 
 const MAP = {
   "/area": { component: AreaDemo, name: "AreaDemo" },
@@ -68,7 +69,8 @@ const MAP = {
   "/victory-shared-events": { component: VictorySharedEventsDemo, name: "VictorySharedEventsDemo" },
   "/voronoi": { component: VoronoiDemo, name: "VoronoiDemo" },
   "/voronoi-container": { component: VoronoiContainerDemo, name: "VoronoiContainerDemo" },
-  "/zoom-container": { component: ZoomContainerDemo, name: "ZoomContainerDemo" }
+  "/zoom-container": { component: ZoomContainerDemo, name: "ZoomContainerDemo" },
+  "/ouia-demo": { component: OuiaDemo, name: "OuiaDemo" }
 };
 
 class Home extends React.Component {

--- a/demo/ts/components/ouia-demo.tsx
+++ b/demo/ts/components/ouia-demo.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { VictoryChart } from "@packages/victory-chart";
+import { VictoryLine } from "@packages/victory-line";
+import { VictoryContainer } from "victory-core/src";
+
+class OuiaDemo extends React.Component<any> {
+  constructor(props: any) {
+    super(props);
+  }
+
+  render() {
+    const containerStyle: React.CSSProperties = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+    const chartStyle: { [key: string]: React.CSSProperties } = {
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
+    };
+
+    return (
+      <div className="demo">
+        <h1>Open UI Automation (OUIA)</h1>
+        <div style={containerStyle}>
+          <VictoryChart
+            containerComponent={
+              <VictoryContainer
+                ouiaId="victory-container-ouia"
+                ouiaType="Victory/container"
+                ouiaSafe
+              />
+            }
+            style={chartStyle}
+          >
+            <VictoryLine />
+          </VictoryChart>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default OuiaDemo;

--- a/docs/src/content/docs/common-container-props.md
+++ b/docs/src/content/docs/common-container-props.md
@@ -65,6 +65,34 @@ The `height` prop determines the height of the containing `<svg>`. By default Vi
 
 _example:_ `height={350}`
 
+## ouiaId
+
+`type: number || string`
+
+The `ouiaId` prop outputs an id attribute called `data-ouia-component-id`, which must be unique within the surrounding context of the component.
+
+This prop is used by the Open UI Automation 1.0-RC spec to help maintain automated testing environments. Components that are OUIA compliant must provide the following props; `ouiaId`, `ouiaSafe`, and `ouiaType`.
+
+## ouiaSafe
+
+`type: boolean`
+
+The `ouiaSafe` outputs an attribute called `data-ouia-safe`, which indicates that the component is in a static state.
+
+This prop is used by the Open UI Automation 1.0-RC spec to help maintain automated testing environments. Components that are OUIA compliant must provide the following props; `ouiaId`, `ouiaSafe`, and `ouiaType`.
+
+_default:_ `ouiaId={true}`
+
+## ouiaType
+
+`type: string`
+
+The `ouiaType` prop outputs an attribute called `data-ouia-component-type`, which specifies a unique name identifying the root level HTML element.
+
+This prop is used by the Open UI Automation 1.0-RC spec to help maintain automated testing environments. Components that are OUIA compliant must provide the following props; `ouiaId`, `ouiaSafe`, and `ouiaType`.
+
+_example:_ A page that has a special container could choose to name that container as `FrameworkA/CustomContainer`.
+
 ## portalComponent
 
 `type: element`

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -241,6 +241,9 @@ export interface VictoryContainerProps {
   height?: number;
   name?: string;
   origin?: OriginType;
+  ouiaId?: number | string;
+  ouiaSafe?: boolean;
+  ouiaType?: string;
   polar?: boolean;
   portalComponent?: React.ReactElement;
   portalZIndex?: number;

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -20,6 +20,9 @@ export default class VictoryContainer extends React.Component {
     height: CustomPropTypes.nonNegative,
     name: PropTypes.string,
     origin: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
+    ouiaId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    ouiaSafe: PropTypes.boolean,
+    ouiaType: PropTypes.string,
     polar: PropTypes.bool,
     portalComponent: PropTypes.element,
     portalZIndex: CustomPropTypes.integer,
@@ -89,6 +92,17 @@ export default class VictoryContainer extends React.Component {
     return props.children;
   }
 
+  // Get props defined by the Open UI Automation (OUIA) 1.0-RC spec
+  // See https://ouia.readthedocs.io/en/latest/README.html#ouia-component
+  getOUIAProps(props) {
+    const { ouiaId, ouiaSafe, ouiaType } = props;
+    return {
+      ...(ouiaId && { "data-ouia-component-id": ouiaId }),
+      ...(ouiaType && { "data-ouia-component-type": ouiaType }),
+      ...(ouiaSafe !== undefined && { "data-ouia-safe": ouiaSafe })
+    };
+  }
+
   renderContainer(props, svgProps, style) {
     const {
       title,
@@ -130,6 +144,7 @@ export default class VictoryContainer extends React.Component {
           style={defaults({}, style, divStyle)}
           className={className}
           ref={this.saveContainerRef}
+          {...this.getOUIAProps(props)}
         >
           <svg {...svgProps} style={svgStyle}>
             {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}


### PR DESCRIPTION
In order to better support automated testing, we would like to add the properties below to the root HTML element output by `VictoryContainer`.

These properties are defined by the Open UI Automation (OUIA) 1.0-RC spec.
https://ouia.readthedocs.io/en/latest/README.html#ouia-component

```
data-ouia-component-type
data-ouia-component-id
data-ouia-safe
```

Fixes https://github.com/FormidableLabs/victory/issues/1624