### PR TITLE
add `preserveAspectRatio` prop

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -247,6 +247,7 @@ export interface VictoryContainerProps {
   polar?: boolean;
   portalComponent?: React.ReactElement;
   portalZIndex?: number;
+  preserveAspectRatio?: string;
   responsive?: boolean;
   style?: React.CSSProperties;
   tabIndex?: number;

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -162,7 +162,16 @@ export default class VictoryContainer extends React.Component {
   }
 
   render() {
-    const { width, height, responsive, events, title, desc, tabIndex, preserveAspectRatio } = this.props;
+    const {
+      width,
+      height,
+      responsive,
+      events,
+      title,
+      desc,
+      tabIndex,
+      preserveAspectRatio
+    } = this.props;
     const style = responsive
       ? this.props.style
       : Helpers.omit(this.props.style, ["height", "width"]);

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -115,7 +115,7 @@ export default class VictoryContainer extends React.Component {
       responsive
     } = props;
     const children = this.getChildren(props);
-    const dimensions = responsive ? { width: "100%", height: "auto" } : { width, height };
+    const dimensions = responsive ? { width: "100%", height: "100%" } : { width, height };
     const divStyle = assign(
       { pointerEvents: "none", touchAction: "none", position: "relative" },
       dimensions

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -26,6 +26,7 @@ export default class VictoryContainer extends React.Component {
     polar: PropTypes.bool,
     portalComponent: PropTypes.element,
     portalZIndex: CustomPropTypes.integer,
+    preserveAspectRatio: PropTypes.string,
     responsive: PropTypes.bool,
     style: PropTypes.object,
     tabIndex: PropTypes.number,
@@ -130,6 +131,7 @@ export default class VictoryContainer extends React.Component {
       width,
       height,
       viewBox: svgProps.viewBox,
+      preserveAspectRatio: svgProps.preserveAspectRatio,
       style: portalSvgStyle
     };
     return (
@@ -160,7 +162,7 @@ export default class VictoryContainer extends React.Component {
   }
 
   render() {
-    const { width, height, responsive, events, title, desc, tabIndex } = this.props;
+    const { width, height, responsive, events, title, desc, tabIndex, preserveAspectRatio } = this.props;
     const style = responsive
       ? this.props.style
       : Helpers.omit(this.props.style, ["height", "width"]);
@@ -172,7 +174,8 @@ export default class VictoryContainer extends React.Component {
         role: "img",
         "aria-labelledby": title ? this.getIdForElement("title") : undefined,
         "aria-describedby": desc ? this.getIdForElement("desc") : undefined,
-        viewBox: responsive ? `0 0 ${width} ${height}` : undefined
+        viewBox: responsive ? `0 0 ${width} ${height}` : undefined,
+        preserveAspectRatio: responsive ? preserveAspectRatio : undefined
       },
       events
     );

--- a/stories/victory-container.stories.js
+++ b/stories/victory-container.stories.js
@@ -1,0 +1,89 @@
+/*eslint-disable no-magic-numbers*/
+/*eslint-disable react/no-multi-comp*/
+import React from "react";
+import { VictoryChart } from "../packages/victory-chart/src/index";
+import { VictoryLine } from "../packages/victory-line/src/index";
+import { VictoryLabel, VictoryContainer } from "../packages/victory-core/src/index";
+
+const containerStyle = {
+  display: "flex",
+  flexDirection: "row",
+  flexWrap: "wrap",
+  alignItems: "center",
+  justifyContent: "center"
+};
+
+const style = {
+  parent: { border: "1px solid #ccc", margin: "1%", maxWidth: "45%" },
+};
+
+const responsiveStyle = {
+  parent: { border: "1px solid #ccc", margin: "1%", maxWidth: "30%" },
+};
+
+export default {
+  title: "VictoryContainer",
+  component: VictoryContainer
+};
+
+export const PreserveAspectRatio = () => {
+  return (
+    <div style={{...containerStyle, height: "400px"}}>
+      <VictoryChart style={style}>
+        <VictoryLine />
+        <VictoryLabel x={50} y={20}
+          text="default (undefined)"
+        />
+      </VictoryChart>
+      <VictoryChart
+        style={style}
+        containerComponent={<VictoryContainer preserveAspectRatio="none" />}
+      >
+        <VictoryLine />
+        <VictoryLabel x={50} y={20}
+          text={`preserveAspectRatio="none"`}
+        />
+      </VictoryChart>
+      <VictoryChart
+        style={style}
+        containerComponent={<VictoryContainer preserveAspectRatio="xMinYMin meet" />}
+      >
+        <VictoryLine />
+        <VictoryLabel x={50} y={20}
+          text={`preserveAspectRatio="xMinYMin meet"`}
+        />
+      </VictoryChart>
+      <VictoryChart
+        style={style}
+        containerComponent={<VictoryContainer preserveAspectRatio="xMinYMin slice" />}
+      >
+        <VictoryLine />
+        <VictoryLabel x={50} y={20}
+          text={`preserveAspectRatio="xMinYMin slice"`}
+        />
+      </VictoryChart>
+    </div>
+  );
+};
+
+export const Responsive = () => {
+  return (
+    <div style={{...containerStyle}}>
+      <VictoryChart style={responsiveStyle}>
+        <VictoryLine />
+        <VictoryLabel x={50} y={20}
+          text="default responsive={true}"
+        />
+      </VictoryChart>
+      <VictoryChart
+        style={responsiveStyle}
+        containerComponent={<VictoryContainer responsive={false} />}
+      >
+        <VictoryLine />
+        <VictoryLabel x={50} y={20}
+          text={`responsive={false}`}
+        />
+      </VictoryChart>
+    </div>
+  );
+};

--- a/stories/victory-container.stories.js
+++ b/stories/victory-container.stories.js
@@ -14,11 +14,11 @@ const containerStyle = {
 };
 
 const style = {
-  parent: { border: "1px solid #ccc", margin: "1%", maxWidth: "45%" },
+  parent: { border: "1px solid #ccc", margin: "1%", maxWidth: "45%" }
 };
 
 const responsiveStyle = {
-  parent: { border: "1px solid #ccc", margin: "1%", maxWidth: "30%" },
+  parent: { border: "1px solid #ccc", margin: "1%", maxWidth: "30%" }
 };
 
 export default {
@@ -28,39 +28,31 @@ export default {
 
 export const PreserveAspectRatio = () => {
   return (
-    <div style={{...containerStyle, height: "400px"}}>
+    <div style={{ ...containerStyle, height: "400px" }}>
       <VictoryChart style={style}>
         <VictoryLine />
-        <VictoryLabel x={50} y={20}
-          text="default (undefined)"
-        />
+        <VictoryLabel x={50} y={20} text="default (undefined)" />
       </VictoryChart>
       <VictoryChart
         style={style}
         containerComponent={<VictoryContainer preserveAspectRatio="none" />}
       >
         <VictoryLine />
-        <VictoryLabel x={50} y={20}
-          text={`preserveAspectRatio="none"`}
-        />
+        <VictoryLabel x={50} y={20} text={`preserveAspectRatio="none"`} />
       </VictoryChart>
       <VictoryChart
         style={style}
         containerComponent={<VictoryContainer preserveAspectRatio="xMinYMin meet" />}
       >
         <VictoryLine />
-        <VictoryLabel x={50} y={20}
-          text={`preserveAspectRatio="xMinYMin meet"`}
-        />
+        <VictoryLabel x={50} y={20} text={`preserveAspectRatio="xMinYMin meet"`} />
       </VictoryChart>
       <VictoryChart
         style={style}
         containerComponent={<VictoryContainer preserveAspectRatio="xMinYMin slice" />}
       >
         <VictoryLine />
-        <VictoryLabel x={50} y={20}
-          text={`preserveAspectRatio="xMinYMin slice"`}
-        />
+        <VictoryLabel x={50} y={20} text={`preserveAspectRatio="xMinYMin slice"`} />
       </VictoryChart>
     </div>
   );
@@ -68,21 +60,17 @@ export const PreserveAspectRatio = () => {
 
 export const Responsive = () => {
   return (
-    <div style={{...containerStyle}}>
+    <div style={{ ...containerStyle }}>
       <VictoryChart style={responsiveStyle}>
         <VictoryLine />
-        <VictoryLabel x={50} y={20}
-          text="default responsive={true}"
-        />
+        <VictoryLabel x={50} y={20} text="default responsive={true}" />
       </VictoryChart>
       <VictoryChart
         style={responsiveStyle}
         containerComponent={<VictoryContainer responsive={false} />}
       >
         <VictoryLine />
-        <VictoryLabel x={50} y={20}
-          text={`responsive={false}`}
-        />
+        <VictoryLabel x={50} y={20} text={`responsive={false}`} />
       </VictoryChart>
     </div>
   );

--- a/test/client/spec/victory-area/victory-area.spec.js
+++ b/test/client/spec/victory-area/victory-area.spec.js
@@ -18,7 +18,7 @@ describe("components/victory-area", () => {
       const wrapper = mount(<VictoryArea />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewbox", () => {

--- a/test/client/spec/victory-axis/victory-axis.spec.js
+++ b/test/client/spec/victory-axis/victory-axis.spec.js
@@ -19,7 +19,7 @@ describe("components/victory-axis", () => {
       const wrapper = mount(<VictoryAxis />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-bar/victory-bar.spec.js
+++ b/test/client/spec/victory-bar/victory-bar.spec.js
@@ -17,7 +17,7 @@ describe("components/victory-bar", () => {
       const wrapper = mount(<VictoryBar />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-box-plot/victory-box-plot.spec.js
+++ b/test/client/spec/victory-box-plot/victory-box-plot.spec.js
@@ -23,7 +23,7 @@ describe("components/victory-box-plot", () => {
       const wrapper = mount(<VictoryBoxPlot data={dataset} />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/victory-candlestick/victory-candlestick.spec.js
@@ -24,7 +24,7 @@ describe("components/victory-candlestick", () => {
       const wrapper = mount(<VictoryCandlestick data={dataSet} />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-chart/victory-chart.spec.js
+++ b/test/client/spec/victory-chart/victory-chart.spec.js
@@ -16,7 +16,7 @@ describe("components/victory-chart", () => {
       const wrapper = mount(<VictoryChart />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-errorbars/victory-errorbars.spec.js
+++ b/test/client/spec/victory-errorbars/victory-errorbars.spec.js
@@ -22,7 +22,7 @@ describe("components/victory-errorbar", () => {
       const wrapper = mount(<VictoryErrorBar />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-group/victory-group.spec.js
+++ b/test/client/spec/victory-group/victory-group.spec.js
@@ -19,7 +19,7 @@ describe("components/victory-group", () => {
       );
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-histogram/victory-histogram.spec.js
+++ b/test/client/spec/victory-histogram/victory-histogram.spec.js
@@ -17,7 +17,7 @@ describe("components/victory-histogram", () => {
       const wrapper = mount(<VictoryHistogram />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-line/victory-line.spec.js
+++ b/test/client/spec/victory-line/victory-line.spec.js
@@ -23,7 +23,7 @@ describe("components/victory-line", () => {
       const wrapper = mount(<VictoryLine />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-pie/victory-pie.spec.js
+++ b/test/client/spec/victory-pie/victory-pie.spec.js
@@ -20,7 +20,7 @@ describe("components/victory-pie", () => {
       const wrapper = mount(<VictoryPie />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-scatter/victory-scatter.spec.js
+++ b/test/client/spec/victory-scatter/victory-scatter.spec.js
@@ -21,7 +21,7 @@ describe("components/victory-scatter", () => {
       const wrapper = mount(<VictoryScatter />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-stack/victory-stack.spec.js
+++ b/test/client/spec/victory-stack/victory-stack.spec.js
@@ -22,7 +22,7 @@ describe("components/victory-stack", () => {
       );
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/client/spec/victory-voronoi/victory-voronoi.spec.js
+++ b/test/client/spec/victory-voronoi/victory-voronoi.spec.js
@@ -17,7 +17,7 @@ describe("components/victory-voronoi", () => {
       const wrapper = mount(<VictoryVoronoi />);
       const svg = wrapper.find("svg").at(0);
       expect(svg.prop("style").width).to.equal("100%");
-      expect(svg.prop("style").height).to.equal("auto");
+      expect(svg.prop("style").height).to.equal("100%");
     });
 
     it("renders an svg with the correct viewbox", () => {


### PR DESCRIPTION
This PR switches to `height: "100%"` from `height: "auto"` on `VictoryContainer`'s outermost div, and adds support for a `preserveAspectRatio` prop that can be added to `VictoryContainer` to give users more control over how the chart fills its container:

<img width="939" alt="Screen Shot 2020-09-24 at 3 36 57 PM" src="https://user-images.githubusercontent.com/3719995/94207183-eaaf2200-fe7b-11ea-9ac1-b67040040069.png">
<img width="936" alt="Screen Shot 2020-09-24 at 3 37 16 PM" src="https://user-images.githubusercontent.com/3719995/94207189-ee42a900-fe7b-11ea-852a-ba7b0b6a8992.png">


closes https://github.com/FormidableLabs/victory/issues/1684