### PR TITLE
Feature/VictoryBar & Bar components ariaLabel and tabIndex [ready]

### DIFF
--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { keys } from "lodash";
 
+import AccessibilityDemo from "./components/accessibility-demo";
 import AreaDemo from "./components/victory-area-demo";
 import AxisDemo from "./components/victory-axis-demo";
 import BarDemo from "./components/victory-bar-demo";
@@ -40,6 +41,7 @@ import DraggableDemo from "./components/draggable-demo";
 import OuiaDemo from "./components/ouia-demo";
 
 const MAP = {
+  "/accessibility": { component: AccessibilityDemo, name: "AccessibilityDemo" },
   "/axis": { component: AxisDemo, name: "AxisDemo" },
   "/area": { component: AreaDemo, name: "AreaDemo" },
   "/bar": { component: BarDemo, name: "BarDemo" },

--- a/demo/js/components/accessibility-demo.js
+++ b/demo/js/components/accessibility-demo.js
@@ -1,5 +1,3 @@
-/*global window:false*/
-/*eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import { VictoryChart } from "Packages/victory-chart/src/index";
 import { VictoryBar } from "Packages/victory-bar/src/index";

--- a/demo/js/components/accessibility-demo.js
+++ b/demo/js/components/accessibility-demo.js
@@ -1,0 +1,47 @@
+/*global window:false*/
+/*eslint-disable no-magic-numbers,react/no-multi-comp */
+import React from "react";
+import { VictoryChart } from "Packages/victory-chart/src/index";
+import { VictoryBar } from "Packages/victory-bar/src/index";
+
+export default class App extends React.Component {
+  render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center",
+      maxWidth: "40%",
+      margin: "3%"
+    };
+
+    const chartContainerStyle = {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      width: "100%",
+      height: "100%"
+    };
+
+    return (
+      <div className="demo" style={containerStyle}>
+        <div style={chartContainerStyle}>
+          <h3>Tabbable with aria-labels: bar chart</h3>
+          <VictoryChart domainPadding={{ x: 40, y: 40 }}>
+            <VictoryBar
+              data={[
+                { x: "A", y: 1 },
+                { x: "B", y: 3 },
+                { x: "C", y: 5 },
+                { x: "D", y: 7 }
+              ]}
+              ariaLabel={({ datum }) => `bar-value-${datum.x}`}
+              tabIndex={({ index }) => index + 1}
+            />
+          </VictoryChart>
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/ts/app.tsx
+++ b/demo/ts/app.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { keys } from "lodash";
 
+import AccessibilityDemo from "./components/accessibility-demo";
 import AreaDemo from "./components/victory-area-demo";
 import AxisDemo from "./components/victory-axis-demo";
 import BarDemo from "./components/victory-bar-demo";
@@ -36,6 +37,7 @@ import ZoomContainerDemo from "./components/victory-zoom-container-demo";
 import OuiaDemo from "./components/ouia-demo";
 
 const MAP = {
+  "/accessibility": { component: AccessibilityDemo, name: "AccessibilityDemo" },
   "/area": { component: AreaDemo, name: "AreaDemo" },
   "/axis": { component: AxisDemo, name: "AxisDemo" },
   "/bar": { component: BarDemo, name: "BarDemo" },

--- a/demo/ts/components/accessibility-demo.tsx
+++ b/demo/ts/components/accessibility-demo.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { VictoryChart } from "@packages/victory-chart";
+import { VictoryBar } from "@packages/victory-bar";
+
+export default class VictoryAccessibilityDemo extends React.Component<any> {
+  render() {
+    const containerStyle: React.CSSProperties = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "flex-start"
+    };
+    const chartContainerStyle: React.CSSProperties = {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      width: "50%",
+      height: "50%"
+    };
+
+    return (
+      <div className="demo" style={containerStyle}>
+        <div style={chartContainerStyle} data-testid="bar-accessibility-chart">
+          <h3>Tabbable with aria-labels: bar chart</h3>
+          <VictoryChart domainPadding={{ x: 40, y: 40 }}>
+            <VictoryBar
+              data={[
+                { x: "A", y: 1 },
+                { x: "B", y: 3 },
+                { x: "C", y: 5 },
+                { x: "D", y: 7 }
+              ]}
+              ariaLabel={({ datum }) => `bar-value-${datum.x}`}
+              tabIndex={({ index }) => index + 1}
+            />
+          </VictoryChart>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -95,8 +95,9 @@ const evaluateProps = (props) => {
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
+  const ariaLabel = Helpers.evaluateProp(props.ariaLabel, props);
 
-  return assign({}, props, { style, barWidth, cornerRadius, desc, id, tabIndex });
+  return assign({}, props, { style, barWidth, cornerRadius, desc, id, tabIndex, ariaLabel });
 };
 
 const Bar = (props) => {
@@ -107,17 +108,18 @@ const Bar = (props) => {
     ? getPolarBarPath(props, cornerRadius)
     : getBarPath(props, barWidth, cornerRadius);
   const defaultTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
-
   return React.cloneElement(props.pathComponent, {
     ...props.events,
     style,
     d: path,
-    transform: props.transform || defaultTransform,
+    "aria-label": props.ariaLabel,
     className: props.className,
-    role: props.role,
-    shapeRendering: props.shapeRendering,
     clipPath: props.clipPath,
     desc: props.desc,
+    index: props.index,
+    role: props.role,
+    shapeRendering: props.shapeRendering,
+    transform: props.transform || defaultTransform,
     tabIndex: props.tabIndex
   });
 };

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -50,9 +50,9 @@ const getCalculatedValues = (props) => {
 const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "bar");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
-
   const {
     alignment,
+    ariaLabel,
     barRatio,
     cornerRadius,
     data,
@@ -67,6 +67,7 @@ const getBaseProps = (props, fallbackProps) => {
     sharedEvents,
     standalone,
     style,
+    tabIndex,
     theme,
     width,
     labels,
@@ -97,11 +98,14 @@ const getBaseProps = (props, fallbackProps) => {
     const { x, y, y0, x0 } = getBarPosition(props, datum);
 
     const dataProps = {
+      ariaLabel,
       alignment,
       barRatio,
+      barWidth,
       cornerRadius,
       data,
       datum,
+      getPath,
       horizontal,
       index,
       polar,
@@ -110,12 +114,11 @@ const getBaseProps = (props, fallbackProps) => {
       style: style.data,
       width,
       height,
+      tabIndex,
       x,
       y,
       y0,
-      x0,
-      barWidth,
-      getPath
+      x0
     };
 
     childProps[eventKey] = {

--- a/packages/victory-bar/src/index.d.ts
+++ b/packages/victory-bar/src/index.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import {
   EventPropTypeInterface,
   NumberOrCallback,
+  StringOrCallback,
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryCommonPrimitiveProps,
@@ -18,6 +19,7 @@ export interface VictoryBarProps
     VictoryDatableProps,
     VictoryMultiLabelableProps {
   alignment?: VictoryBarAlignmentType;
+  ariaLabel?: StringOrCallback;
   barRatio?: number;
   barWidth?: NumberOrCallback;
   cornerRadius?:
@@ -33,7 +35,9 @@ export interface VictoryBarProps
   events?: EventPropTypeInterface<VictoryBarTTargetType, number | string | number[] | string[]>[];
   eventKey?: StringOrNumberOrCallback;
   horizontal?: boolean;
+  index?: number;
   style?: VictoryStyleInterface;
+  tabIndex?: NumberOrCallback;
 }
 
 /**
@@ -60,6 +64,7 @@ export interface BarProps extends VictoryCommonPrimitiveProps {
   datum?: any;
   getPath?: Function;
   horizontal?: boolean;
+  index?: number;
   pathComponent?: React.ReactElement;
   width?: number;
   x?: number;

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -88,6 +88,7 @@ export interface CallbackArgs {
   active: boolean;
   datum: any;
   horizontal: boolean;
+  index: number;
   x: number;
   y: number;
   scale?: {
@@ -98,9 +99,11 @@ export interface CallbackArgs {
 
 export type VictoryStringOrNumberCallback = (args: CallbackArgs) => string | number;
 export type VictoryNumberCallback = (args: CallbackArgs) => number;
+export type VictoryStringCallback = (args: CallbackArgs) => string;
 export type VictoryPaddingCallback = (args: CallbackArgs) => number | BlockProps;
 export type StringOrNumberOrCallback = string | number | VictoryStringOrNumberCallback;
 export type NumberOrCallback = number | VictoryNumberCallback;
+export type StringOrCallback = string | VictoryStringCallback;
 export type PaddingOrCallback = number | BlockProps | VictoryPaddingCallback;
 
 export type SliceNumberOrCallback<T, P = null> = number | ((props: Omit<T, P>) => number);
@@ -614,6 +617,7 @@ export interface VictoryCommonProps {
 
 export interface VictoryCommonPrimitiveProps {
   active?: boolean;
+  ariaLabel?: StringOrCallback;
   className?: string;
   clipPath?: string;
   data?: any;
@@ -627,7 +631,7 @@ export interface VictoryCommonPrimitiveProps {
   scale?: any;
   shapeRendering?: string;
   style?: any;
-  tabIndex?: number | Function;
+  tabIndex?: NumberOrCallback;
   transform?: string;
 }
 

--- a/packages/victory-core/src/victory-util/common-props.js
+++ b/packages/victory-core/src/victory-util/common-props.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "./prop-types";
 
 const dataProps = {
+  ariaLabel: PropTypes.oneOfType([PropTypes.func, PropTypes.arrayOf(PropTypes.string)]),
   categories: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.shape({
@@ -26,6 +27,7 @@ const dataProps = {
     data: PropTypes.object,
     labels: PropTypes.object
   }),
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   x: PropTypes.oneOfType([
     PropTypes.func,
     CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
@@ -146,6 +148,7 @@ const baseProps = {
 
 const primitiveProps = {
   active: PropTypes.bool,
+  ariaLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   className: PropTypes.string,
   clipPath: PropTypes.string,
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),

--- a/test/client/spec/victory-bar/victory-bar.spec.js
+++ b/test/client/spec/victory-bar/victory-bar.spec.js
@@ -200,5 +200,61 @@ describe("components/victory-bar", () => {
         expect(roleValue).to.equal("presentation");
       });
     });
+    it("adds a tabIndex and aria-label to each bar in the series", () => {
+      const data = range(10).map((y, x) => ({ x, y }));
+      const wrapper = mount(<VictoryBar data={data} tabIndex={1} ariaLabel={"test-label"} />);
+      wrapper.find("path").forEach((p) => {
+        // tabIndex
+        const tabIndex = p.prop("tabIndex");
+        expect(tabIndex).to.be.a("number");
+        expect(tabIndex).to.equal(1);
+        // aria-label
+        const ariaLabel = p.prop("aria-label");
+        expect(ariaLabel).to.be.a("string");
+        expect(ariaLabel).to.equal("test-label");
+      });
+    });
+
+    it("adds a data specific aria-label and tabIndex to each bar in the series", () => {
+      const data = range(5, 11).map((y, x) => ({ y, x }));
+      const wrapper = mount(
+        <VictoryBar
+          data={data}
+          tabIndex={({ index }) => index + 2}
+          ariaLabel={({ datum }) => `bar-value-${datum.y}`}
+        />
+      );
+
+      wrapper.find("path").forEach((p, i) => {
+        // tabIndex
+        const index = p.prop("index");
+        const tabIndex = p.prop("tabIndex");
+        expect(tabIndex).to.not.be.a("string");
+        expect(tabIndex).to.equal(index + 2);
+        // aria-label
+        const ariaLabel = p.prop("aria-label");
+        expect(ariaLabel).to.equal(`bar-value-${data[i].y}`);
+      });
+    });
+
+    it("aria-label and tabIndex can be applied to the Bar primitive", () => {
+      const data = range(5, 11).map((y, x) => ({ y, x }));
+      const wrapper = mount(
+        <VictoryBar
+          data={data}
+          dataComponent={
+            <Bar ariaLabel={({ datum }) => `x: ${datum.x}`} tabIndex={({ index }) => index + 1} />
+          }
+        />
+      );
+      wrapper.find("path").forEach((b, i) => {
+        const index = b.prop("index");
+        const tabIndex = b.prop("tabIndex");
+        expect(tabIndex).to.equal(index + 1);
+        // aria-label
+        const ariaLabel = b.prop("aria-label");
+        expect(ariaLabel).to.equal(`x: ${data[i].x}`);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds the following props to the `VictoryBar` component:
  `ariaLabel`: string or callback
  `tabindex`: number or callback

Bars can now be tabbed individually with a unique aria-label applied to each (using the props available in the `CallbackArgs`:
```
export interface CallbackArgs {
  active: boolean;
  datum: any;
  horizontal: boolean;
  index: number;
  x: number;
  y: number;
  scale?: {
    x?: D3Scale;
    y?: D3Scale;
  };
}
``` 
This new feature is demo-able by running this branch, visiting localhost:3000 and clicking the new AccessibilityDemo link (both ts and standard js)
![Screen Shot 2020-09-24 at 4 53 33 PM](https://user-images.githubusercontent.com/27159818/94208223-90678e80-fe86-11ea-9dc4-654da146a4f2.png)
![Screen Shot 2020-09-24 at 5 01 58 PM](https://user-images.githubusercontent.com/27159818/94208721-bfcacb00-fe87-11ea-97f4-790c53fca17e.png)



From there you can click anywhere on the bar graph space, hit tab, and you should see the focus move from one bar to the next. Inspecting the elements via devtools should show the aria-labels on each path component.

Todo: 
- [x] tests
- [x] see if documentation needs updating - will do this at the end
- [x] fix tab formatting/indentation

I would like to PR a change like this for each of the component packages, adding the newly accessible chart (if it isn't already) to the accessibility demo.

