### PR TITLE
Add aria attributes to VictoryContainer

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -232,6 +232,8 @@ export class VictoryLabel extends React.Component<VictoryLabelProps, any> {}
 // #region Victory Container
 
 export interface VictoryContainerProps {
+  "aria-describedby"?: string;
+  "aria-labelledby"?: string;
   children?: React.ReactElement | React.ReactElement[];
   className?: string;
   containerId?: number | string;

--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -11,6 +11,8 @@ export default class VictoryContainer extends React.Component {
   static displayName = "VictoryContainer";
   static role = "container";
   static propTypes = {
+    "aria-describedby": PropTypes.string,
+    "aria-labelledby": PropTypes.string,
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
     className: PropTypes.string,
     containerId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -19,7 +21,10 @@ export default class VictoryContainer extends React.Component {
     events: PropTypes.object,
     height: CustomPropTypes.nonNegative,
     name: PropTypes.string,
-    origin: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
+    origin: PropTypes.shape({
+      x: CustomPropTypes.nonNegative,
+      y: CustomPropTypes.nonNegative
+    }),
     ouiaId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     ouiaSafe: PropTypes.bool,
     ouiaType: PropTypes.string,
@@ -154,7 +159,10 @@ export default class VictoryContainer extends React.Component {
             {children}
           </svg>
           <div style={portalDivStyle}>
-            {React.cloneElement(portalComponent, { ...portalProps, ref: this.savePortalRef })}
+            {React.cloneElement(portalComponent, {
+              ...portalProps,
+              ref: this.savePortalRef
+            })}
           </div>
         </div>
       </PortalContext.Provider>
@@ -181,8 +189,14 @@ export default class VictoryContainer extends React.Component {
         height,
         tabIndex,
         role: "img",
-        "aria-labelledby": title ? this.getIdForElement("title") : undefined,
-        "aria-describedby": desc ? this.getIdForElement("desc") : undefined,
+        "aria-labelledby":
+          [title && this.getIdForElement("title"), this.props["aria-labelledby"]]
+            .filter(Boolean)
+            .join(" ") || undefined,
+        "aria-describedby":
+          [desc && this.getIdForElement("desc"), this.props["aria-describedby"]]
+            .filter(Boolean)
+            .join(" ") || undefined,
         viewBox: responsive ? `0 0 ${width} ${height}` : undefined,
         preserveAspectRatio: responsive ? preserveAspectRatio : undefined
       },

--- a/test/client/spec/victory-core/victory-container/victory-container.spec.js
+++ b/test/client/spec/victory-core/victory-container/victory-container.spec.js
@@ -28,6 +28,18 @@ describe("components/victory-container", () => {
     expect(output.html()).to.contain("description");
   });
 
+  it("renders an svg with an aria-describedby attribute", () => {
+    const wrapper = shallow(<VictoryContainer aria-describedby="testid" desc="description" />);
+    const describedElement = wrapper.find(`[aria-describedby~="testid"]`).at(0);
+    expect(describedElement.type()).to.equal("svg");
+  });
+
+  it("renders an svg with an aria-labelledby attribute", () => {
+    const wrapper = shallow(<VictoryContainer aria-labelledby="testid" title="title" />);
+    const describedElement = wrapper.find(`[aria-labelledby~="testid"]`).at(0);
+    expect(describedElement.type()).to.equal("svg");
+  });
+
   it("renders an svg with the correct viewbox", () => {
     const width = 300;
     const height = 300;


### PR DESCRIPTION
Added aria-labelledby and aria-describedby props to the VictoryContainer
component. Unlike the existing title and desc props which accept strings,
these props accept ids so that the container can be labelled by other
elements in the DOM. This is especially important when the container may
be labelled or described by complex markup (e.g. labelled by a link or described by a table) instead of
something that can be easily reduced to a plain string.

A demo page might be a good idea, but I don't want to conflict with #1687. Maybe we add some container aria attributes to that when both of these are merged?