### PR TITLE
Docs/notes on continuous data

### DIFF
--- a/docs/src/content/common-props/common-props.md
+++ b/docs/src/content/common-props/common-props.md
@@ -165,9 +165,9 @@ _default:_ `containerComponent={<VictoryContainer/>}`
 
 Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x][] and [y][] data accessor props to define a custom data format. The `data` prop must be given as an array. Data objects may also include information about ~~styles~~, labels, and props that may be applied to individual data components.
 
-**Note:** All values stored on the data object will be interpolated during animation. Do not store functions on data objects.
+*note:* All values stored on the data object will be interpolated during animation. Do not store functions on data objects.
 
-**Note:** As of `victory@0.26.0` styles provided via the `data` prop are no longer automatically applied. To use styles from the data object, add functional styles as in the example below.
+*note* As of `victory@0.26.0` styles provided via the `data` prop are no longer automatically applied. To use styles from the data object, add functional styles as in the example below.
 
 ```playground
 <VictoryScatter
@@ -260,7 +260,7 @@ _examples:_
 - `domainPadding={20}`
 - `domainPadding={{x: [20, 0]}}`
 
-**note:** Values supplied for `domainPadding` will be coerced so that padding a domain will never result in charts including an additional quadrant. For example, if an original domain included only positive values, `domainPadding` will be coerced so that the resulted padded domain will not include negative values.
+*note* Values supplied for `domainPadding` will be coerced so that padding a domain will never result in charts including an additional quadrant. For example, if an original domain included only positive values, `domainPadding` will be coerced so that the resulted padded domain will not include negative values.
 
 ```playground
 <VictoryChart
@@ -824,11 +824,11 @@ style={{
 }}
 ```
 
-**note:** The `style` prop used by `VictoryAxis` has a different format than the standard `style` prop.
+*note* The `style` prop used by `VictoryAxis` has a different format than the standard `style` prop.
 
-**note:** When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
+*note* When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
 
-**note:** custom `angle` and `verticalAnchor` properties maybe included in labels styles.
+*note* custom `angle` and `verticalAnchor` properties maybe included in labels styles.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/create-container.md
+++ b/docs/src/content/docs/create-container.md
@@ -33,7 +33,7 @@ The resulting container uses the events from both behaviors.
 For example, if both behaviors use the click event (like zoom and selection) the combined container
 will trigger both behaviors' events on each click.
 
-**Note**: Order of the behaviors matters in a few cases.
+*Note*: Order of the behaviors matters in a few cases.
 It is recommended to use `"zoom"` before any other behaviors: for example,
 `createContainer("zoom", "voronoi")` instead of `createContainer("voronoi", "zoom")`.
 

--- a/docs/src/content/docs/victory-area.md
+++ b/docs/src/content/docs/victory-area.md
@@ -418,7 +418,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryArea` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryArea` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryArea` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-area.md
+++ b/docs/src/content/docs/victory-area.md
@@ -9,7 +9,7 @@ scope:
 
 # VictoryArea
 
-VictoryArea renders a dataset as a single area. VictoryArea can be composed with [`VictoryChart`][] to create area charts.
+VictoryArea renders a dataset as a single area path. Since VictoryArea renders only a single element to represent a dataset rather than individual elements for each data point, some of its behavior is different from other Victory components. Pay special attention to [style](/docs/victory-area#style) and [events](/docs/victory-area#events) props, and take advantage of [`VictoryVoronoiContainer`](/docs/victory-voronoi-container) to enable tooltips. VictoryArea can be composed with [`VictoryChart`][] to create area charts.
 
 ```playground
 <VictoryChart
@@ -87,6 +87,8 @@ See the [Data Accessors Guide][] for more detail on formatting and processing da
 
 `VictoryArea` supplies the following props to its `dataComponent`: `data`, `events`, `groupComponent`, `interpolation`, `origin` (for polar charts), `polar`, `scale`, `style`
 
+*note:* Because `VictoryArea` renders a single element to represent the entire dataset, the `dataComponent` it renders will not have access to `datum` like the `dataComponent` elements rendered by other Victory components such as `VictoryScatter`.
+
 See the [Custom Components Guide][] for more detail on creating your own `dataComponents`
 
 _default:_ `<Area/>`
@@ -121,7 +123,7 @@ domainPadding={{x: [10, -10], y: 5}}
 
 `VictoryArea` uses the standard `eventKey` prop. **This prop is not commonly used.** [Read about the `eventKey` prop in more detail here](/docs/common-props#eventkey)
 
-**note:** `VictoryArea` only renders one element per dataset, so only one event key will be generated.
+*note:* `VictoryArea` only renders one element per dataset, so only one event key will be generated.
 
 ```jsx
 eventKey = "x";
@@ -135,7 +137,7 @@ eventKey = "x";
 
 See the [Events Guide][] for more information on defining events.
 
-**note:** `VictoryArea` will use the special `eventKey` "all" rather than referring to data by index, as it renders only one element for an entire dataset
+*note:* `VictoryArea` will use the special `eventKey` "all" rather than referring to data by index, as it renders only one element for an entire dataset
 
 ```playground
 <div style={{ margin: 50 }}>
@@ -177,7 +179,7 @@ See the [Events Guide][] for more information on defining events.
 
 `VictoryArea` uses the standard `groupComponent` prop. [Read about it in detail](/docs/common-props#groupcomponent)
 
-**note:** `VictoryArea` uses [`VictoryClipContainer`][] as its default `groupComponent` `VictoryClipContainer` renders a `<g>` tag with a `clipPath` `def`. This allows continuous data components to transition smoothly when new data points enter and exit. **Supplying a custom `groupComponent` to `VictoryArea` may result in broken animations.**
+*note:* `VictoryArea` uses [`VictoryClipContainer`][] as its default `groupComponent` `VictoryClipContainer` renders a `<g>` tag with a `clipPath` `def`. This allows continuous data components to transition smoothly when new data points enter and exit. **Supplying a custom `groupComponent` to `VictoryArea` may result in broken animations.**
 
 _default:_ `<VictoryClipContainer/>`
 
@@ -243,6 +245,8 @@ _default:_ `"linear"`
 `type: element`
 
 `VictoryArea` uses the standard `labelComponent` prop. [Read about it in detail](/docs/common-props#labelcomponent)
+
+*note:* To enable tooltips on `VictoryArea`, it is necessary to use [`VictoryVoronoiContainer`](docs/victory-voronoi-container)
 
 _default:_ `<VictoryLabel renderInPortal/>`
 
@@ -434,6 +438,8 @@ _default:_ `standalone={true}`
 `type: { parent: object, data: object, labels: object }`
 
 `VictoryArea` uses the standard `style` prop. [Read about it here](/docs/common-props#style)
+
+*note:* Since `VictoryArea` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of individual `datum`. Instead, try using [gradient fills](/docs/faq/#how-can-i-use-gradient-fills-in-victory) for styling continuous data.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-axis.md
+++ b/docs/src/content/docs/victory-axis.md
@@ -162,7 +162,7 @@ domainPadding={{x: [10, -10], y: 5}}
 
 See the [Events Guide][] for more information on defining events.
 
-**note:** valid event targets for `VictoryAxis` are "axis", "axisLabel", "grid", "ticks", and "tickLabels".
+*note:* valid event targets for `VictoryAxis` are "axis", "axisLabel", "grid", "ticks", and "tickLabels".
 Targets that correspond to only one element {"axis" and "axisLabel") should use the special eventKey "all".
 
 ## externalEventMutations
@@ -279,7 +279,7 @@ name = "series-1";
 
 The `offsetX` prop defines how far from the edge of its permitted area an axis should be offset in the x direction. If this prop is not given, the offset will be calculated based on font size, axis orientation, and label padding. When `VictoryAxis` is used with `VictoryChart`, `VictoryChart` will determine a value for `offsetX` that makes the axes line up correctly, but this value may be overridden by supplying an `offsetX` prop directly to the `VictoryAxis` child component.
 
-**note:** The `offsetX` prop is relative to the edge corresponding to the orientation of the axis, _e.g._ the left edge when `orientation="left"`.
+*note:* The `offsetX` prop is relative to the edge corresponding to the orientation of the axis, _e.g._ the left edge when `orientation="left"`.
 
 ```playground
 <VictoryAxis dependentAxis
@@ -293,7 +293,7 @@ The `offsetX` prop defines how far from the edge of its permitted area an axis s
 
 The `offsetY` prop defines how far from the edge of its permitted area an axis should be offset in the y direction. If this prop is not given, the offset will be calculated based on font size, axis orientation, and label padding. When `VictoryAxis` is used with `VictoryChart`, `VictoryChart` will determine a value for `offsetY` that makes the axes line up correctly, but this value may be overridden by supplying an `offsetY` prop directly to the `VictoryAxis` child component.
 
-**note:** The `offsetY` prop is relative to the edge corresponding to the orientation of the axis, _e.g._ the bottom edge when `orientation="bottom"`.
+*note:* The `offsetY` prop is relative to the edge corresponding to the orientation of the axis, _e.g._ the bottom edge when `orientation="bottom"`.
 
 ```playground
 <VictoryAxis
@@ -340,7 +340,7 @@ padding={{ top: 20, bottom: 60 }}
 `VictoryAxis` uses the standard `scale` prop. [Read about it here](/docs/common-props#scale)
 Options for scale include "linear", "time", "log", "sqrt" and the `d3-scale` functions that correspond to these options.
 
-**note:** Though `VictoryAxis` can take a `scale` prop with scales defined for both `x` and `y`, only the scale that corresponds the given axis will be used.
+*note:* Though `VictoryAxis` can take a `scale` prop with scales defined for both `x` and `y`, only the scale that corresponds the given axis will be used.
 
 _default:_ `scale="linear"`
 
@@ -364,7 +364,7 @@ scale={{ x: "time" }}
 
 `VictoryAxis` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryAxis` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryAxis` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 
@@ -395,9 +395,9 @@ _default:_ `standalone={true}`
 
 The `style` prop defines the style of the component. The style prop should be given as an object with styles defined for `parent`, `axis`, `axisLabel`, `grid`, `ticks`, and `tickLabels`. Any valid svg styles are supported, but `width`, `height`, and `padding` should be specified via props as they determine relative layout for components in VictoryChart. Functional styles may be defined for `grid`, `tick`, and `tickLabel` style properties, and they will be evaluated with the props corresponding to each of these elements, such as `tick`, `index`, and `text`.
 
-**note:** When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
+*note:* When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
 
-**note:** custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
+*note:* custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-bar.md
+++ b/docs/src/content/docs/victory-bar.md
@@ -477,7 +477,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryBar` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryBar` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryBar` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-boxplot.md
+++ b/docs/src/content/docs/victory-boxplot.md
@@ -162,7 +162,7 @@ eventKey = "x";
 
 See the [Events Guide][] for more information on defining events.
 
-**note:** valid event targets for `VictoryBoxPlot` are:
+*note:* valid event targets for `VictoryBoxPlot` are:
 "min", "minLabels", "grid", "ticks", and "tickLabels".
 
 ```playground
@@ -570,7 +570,7 @@ padding={{ top: 20, bottom: 60 }}
 
 `VictoryBoxPlot` uses the standard `polar` prop. [Read about it here](/docs/common-props#polar)
 
-**Note:** Polar Charts are not yet supported for `VictoryBoxPlot`
+*note:* Polar Charts are not yet supported for `VictoryBoxPlot`
 
 ## q1
 
@@ -791,7 +791,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryBoxPlot` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryBoxPlot` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryBoxPlot` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 
@@ -815,9 +815,9 @@ type: {
 
 The `style` prop defines the style of the component. The style prop should be given as an object with styles defined for `parent`, `max`, `maxLabels`, `min`, `minLabels`,`median`, `medianLabels`,`q1`, `q1Labels`,`q3`, `q3Labels`. Any valid svg styles are supported, but `width`, `height`, and `padding` should be specified via props as they determine relative layout for components in VictoryChart. Functional styles may be defined for style properties, and they will be evaluated with the props corresponding to each element.
 
-**note:** When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
+*note:* When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
 
-**note:** custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
+*note:* custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-brush-line.md
+++ b/docs/src/content/docs/victory-brush-line.md
@@ -67,7 +67,7 @@ an object of SVG style attributes. Styles supplied to `brushAreaStyle` are assig
 }
 ```
 
-**Note:** `cursor` styles should not be applied via this prop, as they are dynamically assigned
+*Note:* `cursor` styles should not be applied via this prop, as they are dynamically assigned
 
 ## brushAreaWidth
 

--- a/docs/src/content/docs/victory-candlestick.md
+++ b/docs/src/content/docs/victory-candlestick.md
@@ -620,7 +620,7 @@ padding={{ top: 20, bottom: 60 }}
 
 `VictoryCandlestick` uses the standard `polar` prop. [Read about it here](/docs/common-props#polar)
 
-**Note:** Polar Charts are not yet supported for `VictoryCandlestick`
+*note:* Polar Charts are not yet supported for `VictoryCandlestick`
 
 ## range
 
@@ -691,7 +691,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryCandlestick` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryCandlestick` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryCandlestick` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 
@@ -722,9 +722,9 @@ type: {
 
 The `style` prop defines the style of the component. The style prop should be given as an object with styles defined for `parent`, `data`, `labels`, `closeLabels`, `highLabels`,`lowLabels`, and `openLabels`. Any valid svg styles are supported, but `width`, `height`, and `padding` should be specified via props as they determine relative layout for components in VictoryChart. Functional styles may be defined for style properties, and they will be evaluated with the props corresponding to each element.
 
-**note:** When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
+*note:* When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
 
-**note:** custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
+*note:* custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-chart.md
+++ b/docs/src/content/docs/victory-chart.md
@@ -36,7 +36,7 @@ scope:
 
 See the [Animations Guide][] for more detail on animations and transitions
 
-**note: `VictoryChart` controls the `animate` prop of its children when set. To animate individual children of `VictoryChart`, set the `animate` prop only on children, and not on the `VictoryChart` wrapper.**
+*note:* `VictoryChart` controls the `animate` prop of its children when set. To animate individual children of `VictoryChart`, set the `animate` prop only on children, and not on the `VictoryChart` wrapper.
 
 ```jsx
 animate={{
@@ -75,7 +75,7 @@ backgroundComponent={<Background/>}
 
 `VictoryChart` works with any combination of the following children: [VictoryArea][], [VictoryAxis][] / [VictoryPolarAxis][], [VictoryBar][], [VictoryCandlestick][], [VictoryErrorBar][], [VictoryGroup][], [VictoryLine][], [VictoryScatter][], [VictoryHistogram][], [VictoryStack][], and [VictoryVoronoi][]. Children supplied to `VictoryChart` will be cloned and rendered with new props so that all children share common props such as `domain` and `scale`.
 
-**Note: polar charts must use `VictoryPolarAxis` rather than `VictoryAxis`**
+*note:* polar charts must use `VictoryPolarAxis` rather than `VictoryAxis`
 
 ## containerComponent
 
@@ -93,7 +93,7 @@ containerComponent={<VictoryVoronoiContainer/>}
 
 `VictoryChart` uses the standard `domain` prop. [Read about it in detail here](/docs/common-props/#domain)
 
-**note: `VictoryChart` controls the `domain` prop of its children.**
+*note:* `VictoryChart` controls the `domain` prop of its children.
 
 ```jsx
 domain={{x: [0, 100], y: [0, 1]}}
@@ -105,7 +105,7 @@ domain={{x: [0, 100], y: [0, 1]}}
 
 `VictoryChart` uses the standard `domainPadding` prop. [Read about it in detail here](/docs/common-props#domainpadding)
 
-**note: `VictoryChart` controls the `domainPadding` prop of its children.**
+*note: `VictoryChart` controls the `domainPadding` prop of its children.*
 
 ```jsx
 domainPadding={{x: [10, -10], y: 5}}
@@ -172,7 +172,7 @@ _default:_ `endAngle={360}`
 
 See the [Events Guide][] for more information on defining events.
 
-**Note: `VictoryChart` coordinates events between children using the `VictorySharedEvents` and the `sharedEvents` prop**
+*note:* `VictoryChart` coordinates events between children using the `VictorySharedEvents` and the `sharedEvents` prop
 
 ```playground
 <VictoryChart
@@ -233,7 +233,7 @@ groupComponent={<g transform="translate(10, 10)" />}
 
 `VictoryChart` uses the standard `height` prop. [Read about it in detail here](/docs/common-props/#height)
 
-**note: `VictoryChart` controls the `height` prop of its children.**
+*note:* `VictoryChart` controls the `height` prop of its children.
 
 _default (provided by default theme):_ `height={300}`
 
@@ -309,7 +309,7 @@ When the `innerRadius` prop is set, polar charts will be hollow rather than circ
 
 `VictoryChart` uses the standard `padding` prop. [Read about it in detail here](/docs/common-props/#padding)
 
-**note: `VictoryChart` controls the `padding` prop of its children.**
+*note:* `VictoryChart` controls the `padding` prop of its children.
 
 _default (provided by default theme):_ `padding={50}`
 
@@ -323,7 +323,7 @@ padding={{ top: 20, bottom: 60 }}
 
 `VictoryChart` uses the standard `polar` prop. [Read about it in detail here](/docs/common-props/#polar)
 
-**Notes:**
+*Notes:*
 
 - `VictoryChart` controls the `polar` prop of its children
 - Polar charts should use `VictoryPolarAxis` rather than `VictoryAxis`
@@ -358,7 +358,7 @@ padding={{ top: 20, bottom: 60 }}
 
 **The `range` prop is usually calculated based on other props. It will not typically be necessary to set a `range` prop manually**
 
-**note: `VictoryChart` controls the `range` prop of its children.**
+*note:* `VictoryChart` controls the `range` prop of its children.
 
 [Read about the `range` prop in detail](/docs/common-props/#range)
 
@@ -369,7 +369,7 @@ padding={{ top: 20, bottom: 60 }}
 `VictoryChart` uses the standard `scale` prop. [Read about it here](/docs/common-props/#scale)
 Options for scale include "linear", "time", "log", "sqrt" and the `d3-scale` functions that correspond to these options.
 
-**note: `VictoryChart` controls the `scale` prop of its children.**
+*note:* `VictoryChart` controls the `scale` prop of its children.
 
 _default:_ `scale="linear"`
 
@@ -393,7 +393,7 @@ scale={{x: "linear", y: "log"}}
 
 `VictoryChart` uses the standard `standalone` prop. [Read about it in detail here](/docs/common-props/#standalone)
 
-**note:** `VictoryChart` sets `standalone={false} for all of its children.
+*note:* `VictoryChart` sets `standalone={false} for all of its children.
 
 _default:_ `standalone={true}`
 
@@ -503,7 +503,7 @@ theme={VictoryTheme.material}
 
 `VictoryChart` uses the standard `width` prop. [Read about it in detail here](/docs/common-props/#width)
 
-**note: `VictoryChart` controls the `width` prop of its children.**
+*note:* `VictoryChart` controls the `width` prop of its children.
 
 _default (provided by default theme):_ `width={450}`
 

--- a/docs/src/content/docs/victory-errorbar.md
+++ b/docs/src/content/docs/victory-errorbar.md
@@ -348,7 +348,7 @@ padding={{ top: 20, bottom: 60 }}
 
 `VictoryErrorBar` uses the standard `polar` prop. [Read about it here](/docs/common-props#polar)
 
-**Note:** Polar Charts are not yet supported for `VictoryErrorBar`
+*note:* Polar Charts are not yet supported for `VictoryErrorBar`
 
 ## range
 
@@ -419,7 +419,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryErrorBar` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryErrorBar` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryErrorBar` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-group.md
+++ b/docs/src/content/docs/victory-group.md
@@ -42,7 +42,7 @@ scope:
 
 See the [Animations Guide][] for more detail on animations and transitions
 
-**note: `VictoryGroup` controls the `animate` prop of its children when set**
+*note:* `VictoryGroup` controls the `animate` prop of its children when set
 
 ```jsx
   animate={{
@@ -57,7 +57,7 @@ See the [Animations Guide][] for more detail on animations and transitions
 
 `VictoryGroup` uses the standard `categories` prop. [Read about it here](/docs/common-props#categories)
 
-**note: When this prop is set, `VictoryGroup` controls the `categories` prop of its children.**
+*note:* When this prop is set, `VictoryGroup` controls the `categories` prop of its children.
 
 ```jsx
 categories={["dogs", "cats", "mice"]}
@@ -146,7 +146,7 @@ When `data` is provided for `VictoryGroup` it will be passed to every child in t
 
 `VictoryGroup` uses the standard `domain` prop. [Read about it in detail here](/docs/common-props#domain)
 
-**note: `VictoryGroup` controls the `domain` prop of its children.**
+*note:* `VictoryGroup` controls the `domain` prop of its children.
 
 ```jsx
 domain={{x: [0, 100], y: [0, 1]}}
@@ -158,7 +158,7 @@ domain={{x: [0, 100], y: [0, 1]}}
 
 `VictoryGroup` uses the standard `domainPadding` prop. [Read about it in detail here](/docs/common-props#domainpadding)
 
-**note: `VictoryGroup` controls the `domainPadding` prop of its children.**
+*note:* `VictoryGroup` controls the `domainPadding` prop of its children.
 
 ```jsx
 domainPadding={{x: [10, -10], y: 5}}
@@ -182,7 +182,7 @@ eventKey = "x";
 
 See the [Events Guide][] for more information on defining events.
 
-**Note: `VictoryGroup` coordinates events between children using the `VictorySharedEvents` and the `sharedEvents` prop**
+*note:* `VictoryGroup` coordinates events between children using the `VictorySharedEvents` and the `sharedEvents` prop
 
 ```playground
 <VictoryGroup
@@ -381,7 +381,7 @@ samples={100}
 `VictoryGroup` uses the standard `scale` prop. [Read about it here](/docs/common-props#scale)
 Options for scale include "linear", "time", "log", "sqrt" and the `d3-scale` functions that correspond to these options.
 
-**note: `VictoryGroup` controls the `scale` prop of its children.**
+*note:* `VictoryGroup` controls the `scale` prop of its children.
 
 _default:_ `scale="linear"`
 
@@ -425,7 +425,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryGroup` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryGroup` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryGroup` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-histogram.md
+++ b/docs/src/content/docs/victory-histogram.md
@@ -408,7 +408,7 @@ padding={{ top: 20, bottom: 60 }}
 
 `type: boolean`
 
-**Note:** Polar Charts are not yet supported for `VictoryHistogram`
+*note:* Polar Charts are not yet supported for `VictoryHistogram`
 
 ## range
 
@@ -467,7 +467,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryHistogram` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryHistogram` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryHistogram` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-legend.md
+++ b/docs/src/content/docs/victory-legend.md
@@ -100,7 +100,7 @@ The `colorScale` prop defines a color scale to be applied to each data symbol in
 
 `VictoryLegend` uses the standard `containerComponent` prop. [Read about it here](/docs/common-props#containercomponent)
 
-**Note:** `VictoryLegend` only works with the `VictoryContainer` component
+*note:* `VictoryLegend` only works with the `VictoryContainer` component
 
 _default:_ `containerComponent={<VictoryContainer/>}`
 
@@ -335,9 +335,9 @@ _default:_ `standalone={true}`
 
 The `style` prop defines the style of the component. The style prop should be given as an object with styles defined for `parent`, `data`, `labels`, `title`, and `border`. Any valid svg styles are supported, but `width`, `height`, and `padding` should be specified via props as they determine relative layout for components in VictoryChart. Functional styles may be defined for `data`, and `labels` style properties, and they will be evaluated with the props corresponding to each element.
 
-**note:** When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
+*note:* When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
 
-**note:** custom `angle` and `verticalAnchor` properties may be included in `labels` and `title` styles.
+*note:* custom `angle` and `verticalAnchor` properties may be included in `labels` and `title` styles.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-line.md
+++ b/docs/src/content/docs/victory-line.md
@@ -10,7 +10,7 @@ scope:
 
 # VictoryLine
 
-VictoryLine renders a dataset as a single line. VictoryLine can be composed with [`VictoryChart`][] to create line charts.
+VictoryLine renders a dataset as a single line path. Since VictoryLine renders only a single element to represent a dataset rather than individual elements for each data point, some of its behavior is different from other Victory components. Pay special attention to [style](/docs/victory-line#style) and [events](/docs/victory-line#events) props, and take advantage of [`VictoryVoronoiContainer`](/docs/victory-voronoi-container) to enable tooltips. VictoryLine can be composed with [`VictoryChart`][] to create line charts.
 
 ```playground
 <VictoryChart
@@ -97,6 +97,8 @@ See the [Data Accessors Guide][] for more detail on formatting and processing da
 
 `VictoryLine` supplies the following props to its `dataComponent`: `data`, `events`, `groupComponent`, `interpolation`, `origin` (for polar charts), `polar`, `scale`, `style`
 
+_note:_ Because `VictoryLine` renders a single element to represent the entire dataset, the `dataComponent` it renders will not have access to `datum` like the `dataComponent` elements rendered by other Victory components such as `VictoryScatter`.
+
 See the [Custom Components Guide][] for more detail on creating your own `dataComponents`
 
 _default:_ `<Curve/>`
@@ -131,7 +133,7 @@ domainPadding={{x: [10, -10], y: 5}}
 
 `VictoryLine` uses the standard `eventKey` prop. **This prop is not commonly used.** [Read about the `eventKey` prop in more detail here](/docs/common-props#eventkey)
 
-**note:** `VictoryLine` only renders one element per dataset, so only one event key will be generated.
+*note:* `VictoryLine` only renders one element per dataset, so only one event key will be generated.
 
 ```jsx
 eventKey = "x";
@@ -189,7 +191,7 @@ See the [Events Guide][] for more information on defining events.
 
 `VictoryLine` uses the standard `groupComponent` prop. [Read about it here](/docs/common-props#groupcomponent)
 
-**note:** `VictoryLine` uses [`VictoryClipContainer`][] as its default `groupComponent` `VictoryClipContainer` renders a `<g>` tag with a `clipPath` `def`. This allows continuous data components to transition smoothly when new data points enter and exit. **Supplying a completely custom `groupComponent` to `VictoryLine` may result in broken animations.**
+*note:* `VictoryLine` uses [`VictoryClipContainer`][] as its default `groupComponent` `VictoryClipContainer` renders a `<g>` tag with a `clipPath` `def`. This allows continuous data components to transition smoothly when new data points enter and exit. **Supplying a completely custom `groupComponent` to `VictoryLine` may result in broken animations.**
 
 _default:_ `<VictoryClipContainer/>`
 
@@ -255,6 +257,8 @@ _default:_ `"linear"`
 `type: element`
 
 `VictoryLine` uses the standard `labelComponent` prop. [Read about it here](/docs/common-props#labelcomponent)
+
+*note:* To enable tooltips on `VictoryLine`, it is necessary to use [`VictoryVoronoiContainer`](docs/victory-voronoi-container)
 
 _default:_ `<VictoryLabel renderInPortal/>`
 
@@ -462,6 +466,8 @@ _default:_ `standalone={true}`
 `type: { parent: object, data: object, labels: object }`
 
 `VictoryLine` uses the standard `style` prop. [Read about it here](/docs/common-props#style)
+
+*note:* Since `VictoryLine` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of individual `datum`. Instead, try using [gradient fills](/docs/faq/#how-can-i-use-gradient-fills-in-victory) for styling continuous data.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-line.md
+++ b/docs/src/content/docs/victory-line.md
@@ -147,7 +147,7 @@ eventKey = "x";
 
 See the [Events Guide][] for more information on defining events.
 
-**note:** `VictoryLine` will use the special `eventKey` "all" rather than referring to data by index, as it renders only one element for an entire dataset
+*note:* `VictoryLine` will use the special `eventKey` "all" rather than referring to data by index, as it renders only one element for an entire dataset
 
 ```playground
 <div>
@@ -446,7 +446,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryLine` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryLine` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryLine` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-pie.md
+++ b/docs/src/content/docs/victory-pie.md
@@ -66,7 +66,7 @@ _default (provided by default theme):_ `colorScale="grayscale"`
 
 `VictoryPie` uses the standard `containerComponent` prop. [Read about it here](/docs/common-props#containercomponent)
 
-**Note:** `VictoryPie` only works with the `VictoryContainer` component
+*Note:* `VictoryPie` only works with the `VictoryContainer` component
 
 _default:_ `containerComponent={<VictoryContainer/>}`
 

--- a/docs/src/content/docs/victory-polar-axis.md
+++ b/docs/src/content/docs/victory-polar-axis.md
@@ -76,7 +76,7 @@ axisComponent={<LineSegment events={{ onClick: handleClick }}/>}
 
 The `axisLabelComponent` prop takes a component instance which will be used to render the axis label. The new element created from the passed `axisLabelComponent` will be supplied with the following props: `x`, `y`, `verticalAnchor`, `textAnchor`, `angle`, `transform`, `style` and `events`. Any of these props may be overridden by passing in props to the supplied component, or modified or ignored within the custom component itself. If `axisLabelComponent` is omitted, a new [`VictoryLabel`][] will be created with props described above.
 
-**Note:** Axis labels are only rendered with the dependent axis in polar charts.
+*note:* Axis labels are only rendered with the dependent axis in polar charts.
 
 _default:_ `axisLabelComponent={<VictoryLabel/>}`
 
@@ -225,7 +225,7 @@ _default:_ `endAngle={360}`
 
 See the [Events Guide][]for more information on defining events.
 
-**note:** valid event targets for `VictoryPolarAxis` are "axis", "axisLabel", "grid", "ticks", and "tickLabels".
+*note:* valid event targets for `VictoryPolarAxis` are "axis", "axisLabel", "grid", "ticks", and "tickLabels".
 Targets that correspond to only one element {"axis" and "axisLabel") should use the special eventKey "all".
 
 ## externalEventMutations
@@ -390,7 +390,7 @@ padding={{ top: 20, bottom: 60 }}
 `VictoryPolarAxis` uses the standard `scale` prop. [Read about it here](/docs/common-props#scale)
 Options for scale include "linear", "time", "log", "sqrt" and the `d3-scale` functions that correspond to these options.
 
-**note:** Though `VictoryPolarAxis` can take a `scale` prop with scales defined for both `x` and `y`, only the scale that corresponds the given axis will be used.
+*note:* Though `VictoryPolarAxis` can take a `scale` prop with scales defined for both `x` and `y`, only the scale that corresponds the given axis will be used.
 
 _default:_ `scale="linear"`
 
@@ -414,7 +414,7 @@ scale={{x: "linear", y: "log"}}
 
 `VictoryPolarAxis` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryPolarAxis` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryPolarAxis` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 
@@ -463,9 +463,9 @@ _default:_ `startAngle={0}`
 
 The `style` prop defines the style of the component. The style prop should be given as an object with styles defined for `parent`, `axis`, `axisLabel`, `grid`, `ticks`, and `tickLabels`. Any valid svg styles are supported, but `width`, `height`, and `padding` should be specified via props as they determine relative layout for components in VictoryChart. Functional styles may be defined for `grid`, `tick`, and `tickLabel` style properties, and they will be evaluated with the props corresponding to each axis element, such as `tick` and `index`.
 
-**note:** When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
+*note:* When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
 
-**note:** custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
+*note:* custom `angle` and `verticalAnchor` properties may be included in `labels` styles.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-primitives.md
+++ b/docs/src/content/docs/victory-primitives.md
@@ -210,7 +210,8 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 ### Box
 
 [VictoryLegend][] uses the `Box` component to draw a border around a legend area. `Box` renders a `<Rect/>` element. [View the source][border]
-**Note** `Box` also exported as `Border`
+
+*note* `Box` also exported as `Border`
 
 **Props**
 

--- a/docs/src/content/docs/victory-scatter.md
+++ b/docs/src/content/docs/victory-scatter.md
@@ -485,7 +485,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryScatter` uses the standard `standalone` prop. [Read about it in detail here](/docs/common-props#standalone)
 
-**note:** When `VictoryScatter` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryScatter` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-stack.md
+++ b/docs/src/content/docs/victory-stack.md
@@ -40,7 +40,7 @@ scope:
 
 See the [Animations Guide][] for more detail on animations and transitions
 
-**note: `VictoryStack` controls the `animate` prop of its children when set**
+*note:* `VictoryStack` controls the `animate` prop of its children when set
 
 ```jsx
 animate={{
@@ -55,7 +55,7 @@ animate={{
 
 `VictoryStack` uses the standard `categories` prop. [Read about it here](/docs/common-props#categories)
 
-**note: When this prop is set, `VictoryGroup` controls the `categories` prop of its children.**
+*note:* When this prop is set, `VictoryGroup` controls the `categories` prop of its children.
 
 ```jsx
 categories={["dogs", "cats", "mice"]}
@@ -107,7 +107,7 @@ containerComponent={<VictoryVoronoiContainer/>}
 
 `VictoryStack` uses the standard `domain` prop. [Read about it in detail here](/docs/common-props#domain)
 
-**note: `VictoryStack` controls the `domain` prop of its children.**
+*note:* `VictoryStack` controls the `domain` prop of its children.
 
 ```jsx
 domain={{x: [0, 100], y: [0, 1]}}
@@ -119,7 +119,7 @@ domain={{x: [0, 100], y: [0, 1]}}
 
 `VictoryStack` uses the standard `domainPadding` prop. [Read about it in detail here](/docs/common-props#domainpadding)
 
-**note: `VictoryStack` controls the `domainPadding` prop of its children.**
+*note:* `VictoryStack` controls the `domainPadding` prop of its children.
 
 ```jsx
 domainPadding={{x: [10, -10], y: 5}}
@@ -143,7 +143,7 @@ eventKey = "x";
 
 See the [Events Guide][] for more information on defining events.
 
-**Note: `VictoryStack` coordinates events between children using the `VictorySharedEvents` and the `sharedEvents` prop**
+*note:* `VictoryStack` coordinates events between children using the `VictorySharedEvents` and the `sharedEvents` prop
 
 ```playground
 <VictoryStack
@@ -299,7 +299,7 @@ padding={{ top: 20, bottom: 60 }}
 `VictoryStack` uses the standard `scale` prop. [Read about it here](/docs/common-props#scale)
 Options for scale include "linear", "time", "log", "sqrt" and the `d3-scale` functions that correspond to these options.
 
-**note: `VictoryStack` controls the `scale` prop of its children.**
+*note:* `VictoryStack` controls the `scale` prop of its children.
 
 _default:_ `scale="linear"`
 
@@ -323,7 +323,7 @@ scale={{x: "linear", y: "log"}}
 
 `VictoryStack` uses the standard `standalone` prop. [Read about it here](/docs/common-props#standalone)
 
-**note:** When `VictoryGroup` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryGroup` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/docs/victory-tooltip.md
+++ b/docs/src/content/docs/victory-tooltip.md
@@ -11,6 +11,8 @@ scope:
 
 `VictoryTooltip` renders a tooltip component with a set of default events. When `VictoryTooltip` is used as a label component for any Victory component that renders data, it will attach events to rendered data components that will activate the tooltip when hovered. `VictoryTooltip` renders text as well as a configurable [Flyout][] container.
 
+*note:* When providing tooltips for `VictoryLine` or `VictoryArea`, it is necessary to use [`VictoryVoronoiContainer`](/docs/victory-voronoi-container), as these components only render a single element for the entire dataset.
+
 ## active
 
 `type: boolean`

--- a/docs/src/content/docs/victory-tooltip.md
+++ b/docs/src/content/docs/victory-tooltip.md
@@ -260,7 +260,9 @@ The `orientation` prop determines which side of the (x, y) coordinate the toolti
 
 `type: number || function`
 
-The `pointerLength` prop determines the length of the triangular pointer extending from the flyout. This prop may be given as a positive number or a function of datum. **Note: When `center`, `centerOffset` or `constrainToVisibleArea` props are used, non-zero `pointerLength` values are not guaranteed.**
+The `pointerLength` prop determines the length of the triangular pointer extending from the flyout. This prop may be given as a positive number or a function of datum.
+
+*note:* When `center`, `centerOffset` or `constrainToVisibleArea` props are used, non-zero `pointerLength` values are not guaranteed.
 
 ```playground
 <VictoryBar

--- a/docs/src/content/docs/victory-voronoi.md
+++ b/docs/src/content/docs/victory-voronoi.md
@@ -288,7 +288,7 @@ padding={{ top: 20, bottom: 60 }}
 
 `VictoryVoronoi` uses the standard `polar` prop. [Read about it in detail here](/docs/common-props#polar)
 
-**Note:** Polar Charts are not yet supported for `VictoryVoronoi`
+*note:* Polar Charts are not yet supported for `VictoryVoronoi`
 
 ## range
 
@@ -373,7 +373,7 @@ _default:_ `sortOrder="ascending"`
 
 `VictoryVoronoi` uses the standard `standalone` prop. [Read about it in detail here](/docs/common-props#standalone)
 
-**note:** When `VictoryVoronoi` is nested within a component like `VictoryChart`, this prop will be set to `false`
+*note:* When `VictoryVoronoi` is nested within a component like `VictoryChart`, this prop will be set to `false`
 
 _default:_ `standalone={true}`
 

--- a/docs/src/content/guides/animations.md
+++ b/docs/src/content/guides/animations.md
@@ -80,7 +80,7 @@ ReactDOM.render(<App/>, mountNode)
 
 Victory components define default transitions for entering and exiting nodes, but these may be overridden with the `onEnter` and `onExit` properties of the `animate` object. The `before` and `after` properties take functions whose return values alter the datum of the transitioning node before or after the transition. These functions are called with the original datum of the transitioning node, the index of that datum, and the entire data array.
 
-**Note:** Use private variables `_x`, `_y`, `_y0` and `_y1` when altering position data during transitions.
+*note:* Use private variables `_x`, `_y`, `_y0` and `_y1` when altering position data during transitions.
 
 ```playground_norender
 class App extends React.Component {

--- a/docs/src/content/introduction/native.md
+++ b/docs/src/content/introduction/native.md
@@ -33,7 +33,7 @@ This step is not required if you are using Expo (SDK 23.0.0 or higher) as it is 
 $ react-native install react-native-svg
 ```
 
-**Note:** If you run the iOS app and see a linker error for `-lRNSVG-tvOS` you will need to remove `libRNSVG-tvOS.a` from the “Link Binary with Libraries” section within your iOS app’s target’s properties.
+*note:* If you run the iOS app and see a linker error for `-lRNSVG-tvOS` you will need to remove `libRNSVG-tvOS.a` from the “Link Binary with Libraries” section within your iOS app’s target’s properties.
 
 #### 3. Using Victory Native in your React Native app
 
@@ -105,6 +105,6 @@ it("renders correctly", () => {
 });
 ```
 
-**Note:** `renderer` must be imported _after_ `react-native` for tests to work.
+*note:* `renderer` must be imported _after_ `react-native` for tests to work.
 
 [getting started guide]: /docs/


### PR DESCRIPTION
Docs only

This PR adds notes about limitations on continuous data components (`VictoryArea` and `VictoryLine`), and cleans up formatting for `*notes:*` generally for consistency.