### PR TITLE
Don't override all tooltip props in VictoryVoronoiContainer

### DIFF
--- a/demo/js/components/victory-voronoi-container-demo.js
+++ b/demo/js/components/victory-voronoi-container-demo.js
@@ -89,7 +89,13 @@ class App extends React.Component {
               <VictoryVoronoiContainer
                 voronoiDimension="x"
                 labels={({ datum }) => `y: ${datum.y}`}
-                labelComponent={<VictoryTooltip />}
+                labelComponent={
+                  <VictoryTooltip
+                    text={({ activePoints }) => {
+                      return activePoints.map(({ y }) => `value: ${y}`).join(" - ");
+                    }}
+                  />
+                }
               />
             }
           >

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -177,7 +177,7 @@ export const voronoiContainerMixin = (base) =>
           width,
           height,
           style: this.getStyle(props, points, "labels"),
-          flyoutStyle: this.getStyle(props, points, "flyout")[0],
+          flyoutStyle: this.getStyle(props, points, "flyout")[0]
         },
         this.getDefaultLabelProps(props, points)
       );

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -165,18 +165,20 @@ export const voronoiContainerMixin = (base) =>
           key: `${name}-${eventKey}-voronoi-tooltip`,
           id: `${name}-${eventKey}-voronoi-tooltip`,
           active: true,
-          flyoutStyle: this.getStyle(props, points, "flyout")[0],
           renderInPortal: false,
-          style: this.getStyle(props, points, "labels"),
           activePoints: points,
           datum,
           scale,
-          theme,
-          text,
-          width,
-          height
+          theme
         },
         componentProps,
+        {
+          text,
+          width,
+          height,
+          style: this.getStyle(props, points, "labels"),
+          flyoutStyle: this.getStyle(props, points, "flyout")[0],
+        },
         this.getDefaultLabelProps(props, points)
       );
       const labelPosition = this.getLabelPosition(props, labelProps, points);


### PR DESCRIPTION
This PR corrects a bug that was causing `VictoryVoronoiContainer` to override the `text` prop provided directly to `VictoryTooltip`. 

Closes https://github.com/FormidableLabs/victory/issues/1681

Also respects `style`, `flyoutStyle`, `width` and `height` when they are given as explicit props on `VictoryTooltip`