### PR TITLE
add onFocus and onBlur events for VictoryTooltip

### DIFF
--- a/demo/js/components/victory-tooltip-demo.js
+++ b/demo/js/components/victory-tooltip-demo.js
@@ -26,9 +26,9 @@ class App extends React.Component {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryBar
-            style={{ parent: parentStyle }}
             labelComponent={
               <VictoryTooltip
+                activateData
                 constrainToVisibleArea
                 flyoutStyle={{ stroke: "red" }}
                 cornerRadius={0}
@@ -36,6 +36,7 @@ class App extends React.Component {
               />
             }
             labels={({ datum }) => `hello0000000000 #${datum.x}`}
+            style={{ parent: parentStyle, data: { fill: ({ active }) => active ? "red" : "black" }}}
             data={[
               { x: 1, y: 1 },
               { x: 2, y: -2 },

--- a/demo/js/components/victory-tooltip-demo.js
+++ b/demo/js/components/victory-tooltip-demo.js
@@ -36,7 +36,10 @@ class App extends React.Component {
               />
             }
             labels={({ datum }) => `hello0000000000 #${datum.x}`}
-            style={{ parent: parentStyle, data: { fill: ({ active }) => active ? "red" : "black" }}}
+            style={{
+              parent: parentStyle,
+              data: { fill: ({ active }) => (active ? "red" : "black") }
+            }}
             data={[
               { x: 1, y: 1 },
               { x: 2, y: -2 },

--- a/packages/victory-tooltip/src/victory-tooltip.js
+++ b/packages/victory-tooltip/src/victory-tooltip.js
@@ -96,42 +96,28 @@ export default class VictoryTooltip extends React.Component {
   };
 
   static defaultEvents = (props) => {
+    const activate = props.activateData
+      ? [
+          { target: "labels", mutation: () => ({ active: true }) },
+          { target: "data", mutation: () => ({ active: true }) }
+        ]
+      : [{ target: "labels", mutation: () => ({ active: true }) }];
+    const deactivate = props.activateData
+      ? [
+          { target: "labels", mutation: () => ({ active: undefined }) },
+          { target: "data", mutation: () => ({ active: undefined }) }
+        ]
+      : [{ target: "labels", mutation: () => ({ active: undefined }) }];
     return [
       {
         target: "data",
         eventHandlers: {
-          onMouseOver: () => {
-            return props.activateData
-              ? [
-                  { target: "labels", mutation: () => ({ active: true }) },
-                  { target: "data", mutation: () => ({ active: true }) }
-                ]
-              : [{ target: "labels", mutation: () => ({ active: true }) }];
-          },
-          onTouchStart: () => {
-            return props.activateData
-              ? [
-                  { target: "labels", mutation: () => ({ active: true }) },
-                  { target: "data", mutation: () => ({ active: true }) }
-                ]
-              : [{ target: "labels", mutation: () => ({ active: true }) }];
-          },
-          onMouseOut: () => {
-            return props.activateData
-              ? [
-                  { target: "labels", mutation: () => ({ active: undefined }) },
-                  { target: "data", mutation: () => ({ active: undefined }) }
-                ]
-              : [{ target: "labels", mutation: () => ({ active: undefined }) }];
-          },
-          onTouchEnd: () => {
-            return props.activateData
-              ? [
-                  { target: "labels", mutation: () => ({ active: undefined }) },
-                  { target: "data", mutation: () => ({ active: undefined }) }
-                ]
-              : [{ target: "labels", mutation: () => ({ active: undefined }) }];
-          }
+          onMouseOver: () => activate,
+          onFocus: () => activate,
+          onTouchStart: () => activate,
+          onMouseOut: () => deactivate,
+          onBlur: () => deactivate,
+          onTouchEnd: () => deactivate
         }
       }
     ];


### PR DESCRIPTION
This PR adds `onFocus` and `onBlur` event handlers for `VictoryTooltip` to enable showing tooltips when users tab through rather than mouse over a chart. This work goes along with the recent addition of `tabIndex` to all primitive components.