### PR TITLE
Feature/accessibility documentation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -47,7 +47,7 @@
     "styled-components": "^5.1.0",
     "styled-normalize": "^8.0.6",
     "unist-util-visit": "^1.4.0",
-    "victory": "^35.1.1"
+    "victory": "^35.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/docs/src/content/docs/victory-accessible-group.md
+++ b/docs/src/content/docs/victory-accessible-group.md
@@ -1,0 +1,52 @@
+---
+id: 2
+title: VictoryAccessibleGroup
+category: more
+sidebar: true
+type: docs
+scope: null
+---
+
+# VictoryAccessibleGroup
+
+`VictoryAccessibleGroup` is a specialized group container that enables users to assign `aria-label`s, `desc`s and other props specified below which allow for improved access by screen readers. `VictoryAccessibleGroup` can be used as any `groupComponent` prop value. `VictoryAccessibleGroup` will render its children in a `<g>` element and includes a `desc` tag if provided as a prop.
+
+## aria-describedby
+
+`type: string`
+
+The `aria-describedby` prop applies to the `g` element rendered by `VictoryAccessibleGroup` as well as `descId` if a `desc` is provided. This prop should be given as a string corresponding to the id of an element that describes the chart.
+
+## aria-label
+
+`type: string`
+
+The `aria-label` prop applies to the `g` element rendered by `VictoryAccessibleGroup`.
+
+## children
+
+`type: element || array[element]`
+
+`VictoryAccessibleGroup` renders a single child, or an array of children in the group element.
+
+## className
+
+`type: string`
+
+The `className` prop specifies a className that will be applied to the `g` element rendered by `VictoryAccessibleGroup`. If this prop is not set, the className will default to "VictoryAccessibleGroup".
+
+_example:_ `className="myChartAccessibleGroup"`
+
+## desc
+
+`type: string`
+
+The `desc` prop specifies the description of the chart/SVG to assist with accessibility for screen readers. The more descriptive this title is, the more useful it will be for people using screen readers.
+
+_example:_ `desc="Golden retrievers make up 30%, Labs make up 25%, and other dog breeds are not represented above 5% each."`
+
+## tabIndex
+
+`type: number`
+
+The `tabIndex` will be applied to the `g` element.

--- a/docs/src/content/docs/victory-primitives.md
+++ b/docs/src/content/docs/victory-primitives.md
@@ -19,7 +19,7 @@ Each of these primitive components renders SVG elements. The following component
 Used by `Background`, `VictoryClipContainer`, and `Voronoi`
 
 ```jsx
-const Circle = props => <circle vectorEffect="non-scaling-stroke" {...props} />;
+const Circle = (props) => <circle vectorEffect="non-scaling-stroke" {...props} />;
 ```
 
 ### ClipPath
@@ -27,7 +27,7 @@ const Circle = props => <circle vectorEffect="non-scaling-stroke" {...props} />;
 Used by `VictoryClipContainer` and `Voronoi`
 
 ```jsx
-const ClipPath = props => (
+const ClipPath = (props) => (
   <defs>
     <clipPath id={props.clipId}>{props.children}</clipPath>
   </defs>
@@ -39,7 +39,7 @@ const ClipPath = props => (
 Used by `Axis`, `Candle`, and `ErrorBar`
 
 ```jsx
-const Line = props => <line vectorEffect="non-scaling-stroke" {...props} />;
+const Line = (props) => <line vectorEffect="non-scaling-stroke" {...props} />;
 ```
 
 ### Path
@@ -47,7 +47,7 @@ const Line = props => <line vectorEffect="non-scaling-stroke" {...props} />;
 Used by `Arc`, `Area`, `Bar`, `Curve`, `Flyout`, `Point`, `Slice`, and `Voronoi`
 
 ```jsx
-const Path = props => <path {...props} />;
+const Path = (props) => <path {...props} />;
 ```
 
 ### Rect
@@ -55,7 +55,7 @@ const Path = props => <path {...props} />;
 Used by `VictoryClipPath`, `Background`, `Border`, and `Candle`
 
 ```jsx
-const Rect = props => <rect vectorEffect="non-scaling-stroke" {...props} />;
+const Rect = (props) => <rect vectorEffect="non-scaling-stroke" {...props} />;
 ```
 
 ### Text
@@ -63,7 +63,7 @@ const Rect = props => <rect vectorEffect="non-scaling-stroke" {...props} />;
 Used by `VictoryLabel`
 
 ```jsx
-const Text = props => {
+const Text = (props) => {
   const { children, title, desc, ...rest } = props;
   return (
     <text {...rest}>
@@ -80,7 +80,7 @@ const Text = props => {
 Used by `VictoryLabel`
 
 ```jsx
-const TSpan = props => <tspan {...props} />;
+const TSpan = (props) => <tspan {...props} />;
 ```
 
 ## Simple Components
@@ -92,6 +92,7 @@ const TSpan = props => <tspan {...props} />;
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Arc`
 - `className` _string_ the class name that will be applied to the rendered path
 - `closedPath` _boolean_ a flag signifying whether this arc is should render a closed path
 - `cx` _number_ the x coordinate of the center of the arc path
@@ -108,6 +109,7 @@ const TSpan = props => <tspan {...props} />;
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered path
 - `startAngle` _number_ the start angle of the arc given in degrees
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Arc`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 
 ### Area
@@ -117,6 +119,7 @@ const TSpan = props => <tspan {...props} />;
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Area`
 - `className` _string_ the class name that will be applied to the rendered path
 - `data` _array_ the entire dataset used to define the area
 - `events` _object_ events to attach to the rendered element
@@ -130,6 +133,7 @@ const TSpan = props => <tspan {...props} />;
 - `scale` _object_ the x and y scale of the parent chart with `domain` and `range` applied
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered path
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ that will be applied to rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Area`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 
 ### LineSegment
@@ -139,6 +143,7 @@ The `LineSegment` component renders straight lines. This component is used to re
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered lineComponent. When this prop is given as a function it will be called with the rest of the props supplied to `LineSegment`
 - `className` _string_ the class name that will be applied to the rendered element
 - `data` _array_ the entire dataset
 - `datum` _object_ the data point corresponding to this line
@@ -149,6 +154,7 @@ The `LineSegment` component renders straight lines. This component is used to re
 - `role` _string_ the aria role to assign to the element
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered elements
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or funciton_ will be applied to the rendered lineComponent. When this prop is given as a function it will be called with the rest of the props supplied to `LineSegment`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 - `x1` _number_ the x coordinate of the beginning of the line
 - `x2` _number_ the x coordinate of the end of the line
@@ -185,6 +191,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 
 - `active` _boolean_ a flag signifying whether the component is active
 - `alignment` \*"start", "middle", or "end" specifies how a bar path should be aligned in relation to its data point
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Bar`
 - `barRatio` _number_ a number between zero and one that will be used to calculate bar width when an explicit width is not given
 - `barWidth` _number or function_ A prop defining the width of the bar. When this prop is given as a function, it will be called with the rest of the props supplied to `Bar`.
 - `className` _string_ the class name that will be applied to the rendered path
@@ -201,6 +208,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `scale` _object_ the x and y scale of the parent chart with `domain` and `range` applied
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered path
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ number applied to rendered path. When given as a function it will be called with the rest of the props supplied to `Bar`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 - `width` _number_ the width of parent chart (used to calculate default bar width `style.width` is not supplied)
 - `x` _number_ the x coordinate of the top of the bar
@@ -211,11 +219,12 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 
 [VictoryLegend][] uses the `Box` component to draw a border around a legend area. `Box` renders a `<Rect/>` element. [View the source][border]
 
-*note* `Box` also exported as `Border`
+_note_ `Box` also exported as `Border`
 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop that controls the a propcontrollings the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Box`
 - `className` _string_ the class name that will be applied to the rendered element
 - `events` _object_ events to attach to the rendered element
 - `height` _number_ the height of the `<rect/>` element
@@ -224,6 +233,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `role` _string_ the aria role to assign to the element
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered element
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ will be applied to the rendered path. When given as a function it will be called with the rest of the props supplied to `Box`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 - `width` _number_ the width of the `<rect/>` element
 - `x` _number_ the x coordinate of the upper-left corner of the `<rect/>` element
@@ -236,6 +246,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered `<Rect>` and `<Line>` elements. When this prop is given as a function it will be called with the rest of the props supplied to `Candle`
 - `candleRatio` _number_ a number between zero and one that will be used to calculate candle width when an explicit width is not given
 - `candleWidth` _number or function_ A prop defining the width of the candle. When this prop is given as a function, it will be called with the rest of the props supplied to `Candle`.
 - `className` _string_ the class name that will be applied to the rendered element
@@ -255,6 +266,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `scale` _object_ the x and y scale of the parent chart with `domain` and `range` applied
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered elements
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ a prop controlling the aria-label that will be applied to the rendered `<Rect>` and `<Line>` elements. When given as a function it will be called with the rest of the props supplied to `Candle`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 - `width` _number_ the width of parent chart (used to calculate default candle width `style.width` is not supplied)
 - `widthStrokeWidth` _number_ the stroke width of the candle wick. (style.strokeWidth will be used when this value is not given)
@@ -267,6 +279,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Curve`
 - `className` _string_ the class name that will be applied to the rendered element
 - `data` _array_ the entire dataset used to define the curve
 - `events` _object_ events to attach to the rendered element
@@ -280,6 +293,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `scale` _object_ the x and y scale of the parent chart with `domain` and `range` applied
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered path
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ will be applied to the rendered path. When given as a function it will be called with the rest of the props supplied to `Curve`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 
 ### ErrorBar
@@ -289,6 +303,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the group, `g`, containing the rendered `<Line>` elements. When this prop is given as a function it will be called with the rest of the props supplied to `ErrorBar`
 - `borderWidth` _number_ the width of the cross-hairs on the end of each error bar _default: 10_
 - `className` _string_ the class name that will be applied to the rendered element
 - `data` _array_ the entire dataset
@@ -306,6 +321,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `scale` _object_ the x and y scale of the parent chart with `domain` and `range` applied
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered elements
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ applies to the group, `g`, containing the `<Line>` elements. When this prop is given as a function it will be called with the rest of the props supplied to `ErrorBar`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 - `x` _number_ the x coordinate of the center of the error bar
 - `y` _number_ the y coordinate of the center of the error bar
@@ -349,6 +365,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Point`
 - `className` _string_ the class name that will be applied to the rendered element
 - `data` _array_ the entire dataset
 - `datum` _object_ the data point corresponding to this point
@@ -365,6 +382,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `size` _number or function_ the size of the point. When this prop is given as a function, it will be called with the rest of the props supplied to `Point`.
 - `style` _object_ the styles to apply to the rendered element
 - `symbol` _"circle", "diamond", "plus", "minus", "square", "star", "triangleDown", "triangleUp"_ which symbol the point should render. This prop may also be given as a function that returns one of the above options. When this prop is given as a function, it will be called with the rest of the props supplied to `Point`.
+- `tabIndex` _number or function_ number will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Point`
 - `transform` _string_ a transform that will be supplied to elements this component renders
 - `x` _number_ the x coordinate of the center of the point
 - `y` _number_ the y coordinate of the center of the point
@@ -376,6 +394,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`
 - `className` _string_ the class name that will be applied to the rendered element
 - `cornerRadius` _number or function_ the corner radius to apply to this slice. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
 - `data` _array_ the entire dataset
@@ -394,6 +413,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `sliceEndAngle` _number or function_ the end angle the slice. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
 - `sliceStartAngle` _number or function_ the start angle the slice. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ number will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
 - `transform` _string_ a transform that will be supplied to elements this component renders
 
 ### Voronoi
@@ -403,6 +423,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Voronoi`
 - `circleComponent` _element_ the rendered circle element _default_ `<Circle/>`
 - `className` _string_ the class name that will be applied to the rendered element
 - `clipPathComponent` _element_ the rendered clipPath element _default_ `<ClipPath/>`
@@ -420,6 +441,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered path
 - `size` _number_ the maximum size of the voronoi polygon
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Voronoi`
 - `transform` _string_ a transform that will be supplied to elements this component renders.
 - `x` _number_ the x coordinate of the data point
 - `y` _number_ the y coordinate of the data point
@@ -431,6 +453,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 **Props**
 
 - `active` _boolean_ a flag signifying whether the component is active
+- `ariaLabel` _string or function_ a prop controlling the aria-label that will be applied to the rendered `<Line>` elements. When this prop is given as a function it will be called with the rest of the props supplied to `Whisker`
 - `className` _string_ the class name that will be applied to the rendered element
 - `events` _object_ events to attach to the rendered element
 - `groupComponent` _element_ the rendered group element _default_ `<g/>`
@@ -441,6 +464,7 @@ The `Background` component is used to render an SVG background on VictoryChart. 
 - `role` _string_ the aria role to assign to the element
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered element
 - `style` _object_ the styles to apply to the rendered element
+- `tabIndex` _number or function_ will be applied to the rendered `<Line>`. When this prop is given as a function it will be called with the rest of the props supplied to `Whisker`
 - `transform` _string_ a transform that will be supplied to elements this component renders.
 
 [victorycontainer]: /docs/victory-container

--- a/docs/src/content/introduction/new.md
+++ b/docs/src/content/introduction/new.md
@@ -13,6 +13,27 @@ scope:
 
 Victory is actively developed. You can read about some of our newest feature here. For more information on improvements and bug fixes, check out our [changelog](https://github.com/FormidableLabs/victory/blob/main/CHANGELOG.md).
 
+## New Accessibility Features
+
+With improved chart and chart component accessibilty in mind, we've added a [`VictoryAccessibleGroup`](/docs/victory-accessible-group) for use with the [`groupComponent`](/docs/common-props#groupcomponent) prop. This component will wrap its children in a `g` tag with a user provided `aria-label` and optional description via the `desc` prop. Other available props can be found in the [docs](/docs/victory-accessible-group).
+
+We've also added `ariaLabel` and `tabIndex` props to all our primitives. Documentation on these can be found in under [`VictoryPrimitives`](/docs/victory-primitives#victory-primitives)
+
+```playground
+<VictoryChart domainPadding={{ x: 40, y: 40 }}>
+  <VictoryBar
+    style={{ data: { fill: "#c43a31" } }}
+    data={sampleData}
+    dataComponent={
+      <Bar
+        tabIndex={({ index }) => index + 2}
+        ariaLabel={({ datum }) => `x: ${datum.x}`}
+      />
+     }
+    />
+</VictoryChart>
+```
+
 ## Backgrounds for Victory Label
 
 `VictoryLabel` now supports backgrounds! The [`backgroundStyle`](/docs/victory-label#backgroundstyle) prop lets you render and style a `rect` element behind your label. The size of the `rect` is determined for you based on the size and style of the label. The [`backgroundPadding`](/docs/victory-label#backgroundpadding) prop may be used to adjust the size of the background `rect`.
@@ -294,27 +315,4 @@ const Matterhorn = props => {
 };
 
 ReactDOM.render(<Matterhorn/>, mountNode);
-```
-
-## VictoryAccessibleGroup and primitive accessible props
-
-With improved chart and chart component accessibilty in mind, we've added a [`VictoryAccessibleGroup`](/docs/victory-accessible-group) for use with the [`groupComponent`](/docs/common-props#groupcomponent) prop. This component will wrap is children in a `g` tag with a user provided `aria-label` and optional description via `desc` prop. Other available props can be found in the [docs](/docs/victory-accessible-group).
-
-We've also added an `ariaLabel` and `tabIndex` prop to all our primitives. Documentation on these can be found in under [`VictoryPrimitives`](/docs/victory-primitives#victory-primitives)
-
-A new `Accessiblity` page has been added to our demos as well and viewable when running the development server. More information on that [here](https://github.com/FormidableLabs/victory/blob/main/CONTRIBUTING.md)
-
-```playground
-<VictoryChart domainPadding={{ x: 40, y: 40 }}>
-  <VictoryBar
-    style={{ data: { fill: "#c43a31" } }}
-    data={sampleData}
-    dataComponent={
-      <Bar
-        tabIndex={({ index }) => index + 2}
-        ariaLabel={({ datum }) => `x: ${datum.x}`}
-      />
-     }
-    />
-</VictoryChart>
 ```

--- a/docs/src/content/introduction/new.md
+++ b/docs/src/content/introduction/new.md
@@ -34,6 +34,7 @@ Victory is actively developed. You can read about some of our newest feature her
   }
 />
 ```
+
 Label backgrounds also work with multi-line and inline labels:
 
 ```playground
@@ -81,9 +82,6 @@ Label backgrounds are also compatible with tooltips!
   }
 />
 ```
-
-
-
 
 ## Better label placement options for VictoryPie
 
@@ -296,4 +294,27 @@ const Matterhorn = props => {
 };
 
 ReactDOM.render(<Matterhorn/>, mountNode);
+```
+
+## VictoryAccessibleGroup and primitive accessible props
+
+With improved chart and chart component accessibilty in mind, we've added a [`VictoryAccessibleGroup`](/docs/victory-accessible-group) for use with the [`groupComponent`](/docs/common-props#groupcomponent) prop. This component will wrap is children in a `g` tag with a user provided `aria-label` and optional description via `desc` prop. Other available props can be found in the [docs](/docs/victory-accessible-group).
+
+We've also added an `ariaLabel` and `tabIndex` prop to all our primitives. Documentation on these can be found in under [`VictoryPrimitives`](/docs/victory-primitives#victory-primitives)
+
+A new `Accessiblity` page has been added to our demos as well and viewable when running the development server. More information on that [here](https://github.com/FormidableLabs/victory/blob/main/CONTRIBUTING.md)
+
+```playground
+<VictoryChart domainPadding={{ x: 40, y: 40 }}>
+  <VictoryBar
+    style={{ data: { fill: "#c43a31" } }}
+    data={sampleData}
+    dataComponent={
+      <Bar
+        tabIndex={({ index }) => index + 2}
+        ariaLabel={({ datum }) => `x: ${datum.x}`}
+      />
+     }
+    />
+</VictoryChart>
 ```

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -8789,91 +8789,91 @@ vfile@^2.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-victory-area@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.1.1.tgz#f85f44560523f12ad45203f98c5b304fdf84fbda"
-  integrity sha512-Ghh4x7GEhR8LQo1duy4mKzCMVpxOzlYf2H8Wwvh3TwOMitwbfBZ91P9bYOv3KEsVxfzmbuGM4fKfkJEFcwXQiA==
+victory-area@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.2.0.tgz#6e47a97d627e66da3609e08068802026aba29e21"
+  integrity sha512-07QHwpZtyLmJoUJjX3HNSE9fDHV9Z2vExEze4HO9MjBA9+zx7d5OgCsYJlPafU2Y1FFgIgLmgYTBW4OO9e/yIQ==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-axis@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.1.1.tgz#4e12f2aaaf7006709246f0d30feda33d9d32647f"
-  integrity sha512-HQkGTHKgk32vjPrGG/1LNvodnywnI7fMoNHwCvJVXy+C+2N3UKB828zvdkuDtq9Cc4GSPBWsMzPJxyi5kRjV6g==
+victory-axis@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.2.0.tgz#ae747d19c38dd30f2e80296cb11b944f6e99707c"
+  integrity sha512-6OlAMGtbBwkRcx8YyPqMjjS7JfoYWWZ2OPM2Zxm04dCy94LO2eZqC31IV7SHW3A0h/+j33JDnkLrbuaAWOf+hw==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-bar@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.1.1.tgz#e782985ea0b333e75f95ab53332bd20336aea956"
-  integrity sha512-VuY286MhccpqroedPOvjy7zJbZxtHsJ/VloywrOWjjcWIGRuh+Ln3zlT/8aJC1Vs4X9+WHwAdUKVR1FTufKjkQ==
+victory-bar@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.2.0.tgz#2cfde9d7f390cce24ddf82106d1220e0c81a9cce"
+  integrity sha512-QyLPhrL/8pFFGX04aq5hUsaIFcB9OOD5b+9PujpobHZjLICHlkkY25SBV1bKTBkzblxZF+kldNHS60EovCNNhw==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-box-plot@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-35.1.1.tgz#3f529256d2f8186d1d1c79d4d01e1b5d60fb4734"
-  integrity sha512-B9H9G5GmQvHM6Ydy+9vTaNNh+7DtNnUe5I7DNtJt9Ou8RWckI2F3sX1pudMLRy1LHV3d1fnxxBuOADxCTo6BcA==
+victory-box-plot@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-35.2.0.tgz#8691b5fb5449006532c6b887769c0f5678f0f60c"
+  integrity sha512-6HWVo/7QTnYiN6MExis9mmiCb45HRAfidW31CBQ8jCf6k//DOPYpKBPNJfChosdr2f5DUS42bQXlvraCdmDSRA==
   dependencies:
     d3-array "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-brush-container@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.1.1.tgz#0163732446417fab5eff02ca03a3e846603d339e"
-  integrity sha512-1e1Q2CJn2LMGmAwdtvDbKI6XicqLw8YSNLRcjeCBmxtMotY8yHK91G/7Wr5OwiwCkjzFDf3P4XRprHTK1t6hNg==
+victory-brush-container@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.2.0.tgz#cec3994a332490e1d6e9c756e5a1d71a93234d9c"
+  integrity sha512-KgfdxiP5/ka18uu+gvgDizTMa+RknKforIX6sE9Kx++BvX3QZZvS7N6wmiot7jud4Pyo90rtxJoRG4NigIxVWA==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-brush-line@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-35.1.1.tgz#494151fe0ba39b68ce4fafdd1158fd3f2a39a62b"
-  integrity sha512-kNCPUxzXij0fPkhfMkJDDHQ8N820suY5mC2Eh2g+lcwOdA3ha3w9UNxMwDNlbXOLqJs5Bw1QweWnRfIBbWNfZA==
+victory-brush-line@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-35.2.0.tgz#2657057eb8a48ed2ad847f86f2a24a4fe9fceeab"
+  integrity sha512-9NAszFUobuOE3cLIdXHQJJ5V41INo5iMJQg5lbhJRI83QQsw4gNIYpRPr3CBhjTaPBDvfVxwEubUBfwWAE/jWg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-candlestick@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-35.1.1.tgz#f56226b161f0fa643ddfc8863d299179d3ae6a84"
-  integrity sha512-4h/4+d9kHCPinK45HWgpO6+k0bYzHBWDoW0rZILCGQYCNSjy4UDHF0UiP6X1QLADrV7d47ZnK83lruVcQjgxKw==
+victory-candlestick@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-35.2.0.tgz#ca6cafd24b4ee9784cbef56a14eedfda225f9581"
+  integrity sha512-lYia+78umewrD5Rcl+YpBHweoyAf/OAWaCP164BWOCDrp8WQ7a4h6xD6FCk0btAvi8sC8WUsPeA5tIe+YtnFCQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-chart@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.1.1.tgz#fe82389e5024a1aec48ca89b7d5af4e17fa2509d"
-  integrity sha512-B8dixl5RmIxmh0CPVBv/0cSjZ31FNvQmFX9t352Df4VQ5fU23hvmqCUASE2QboIcIeAiH+Qj0NKycu+lr0GgjA==
+victory-chart@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.2.0.tgz#42deb6988c79ff2d3a1bd3c2c869666bb58c399b"
+  integrity sha512-Jn/hlSEJh6pOlSyBvVzoQti5gWilKmWR9qew2HsO7NyZSwkxUI41I9kh+0YlzbScT4ANIq2bJxgaQrH9qeGBFg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-axis "^35.1.1"
-    victory-core "^35.1.1"
-    victory-polar-axis "^35.1.1"
-    victory-shared-events "^35.1.1"
+    victory-axis "^35.2.0"
+    victory-core "^35.2.0"
+    victory-polar-axis "^35.2.0"
+    victory-shared-events "^35.2.0"
 
-victory-core@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.1.1.tgz#8e63509e0b343ae1c0e16da4eb834b86615f4572"
-  integrity sha512-DnWwTLPOpVLgnz52h4SY1CBUxkdxfX14cDPC4Ly8rWY7I3OXuEhzE3Wx/SYQO9vk7oQ7zp8ukWRVWpVpcEZzug==
+victory-core@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.2.0.tgz#65b00995648fd149f0ef3e2121f441dfd775dc9e"
+  integrity sha512-ha4j1vfWKEJVhN1NT61Aoq1WJbpLWG4RSHuuDaTyRkdp2Zz2mYEo+F0UAYxbcXhcdE3fik4ZZULiv8ve64fIYw==
   dependencies:
     d3-ease "^1.0.0"
     d3-interpolate "^1.1.1"
@@ -8884,209 +8884,209 @@ victory-core@^35.1.1:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-create-container@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.1.1.tgz#ce54f300b84e69297269398ad98da25d6d57a066"
-  integrity sha512-QDnCXKL0JovglmT7Fs7rC+GiPgXcJWlXC8LDWpo0kWXD0OP7jNwkCmO78/QU4tlcAWtVY/CNU+rBMxwDTS6/WQ==
+victory-create-container@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.2.0.tgz#dd2cec040fa7189ec59cff9114df6b97c3332609"
+  integrity sha512-krxZpJKSwMDc6sfAeSRkjF6tdDa7P12LFOCA9unW33Vr2WsQQs8s6+ol+fch8TFB8i5Q6yDISRj69sxzQztwzA==
   dependencies:
     lodash "^4.17.19"
-    victory-brush-container "^35.1.1"
-    victory-core "^35.1.1"
-    victory-cursor-container "^35.1.1"
-    victory-selection-container "^35.1.1"
-    victory-voronoi-container "^35.1.1"
-    victory-zoom-container "^35.1.1"
+    victory-brush-container "^35.2.0"
+    victory-core "^35.2.0"
+    victory-cursor-container "^35.2.0"
+    victory-selection-container "^35.2.0"
+    victory-voronoi-container "^35.2.0"
+    victory-zoom-container "^35.2.0"
 
-victory-cursor-container@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.1.1.tgz#0e26126d029cbd04dc5e6665517580e912a0c489"
-  integrity sha512-wD4N7k+YbHDUJleTgYqvYheN1c/qYlcZ44pXw8BKKqywtZixU8Pm9Tioo6L5e0+nSiGyJDixdvMpt2C5hGHNDw==
-  dependencies:
-    lodash "^4.17.19"
-    prop-types "^15.5.8"
-    victory-core "^35.1.1"
-
-victory-errorbar@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-35.1.1.tgz#5ea0cb7c3afda8f7f17561e3c31d369fc481cc53"
-  integrity sha512-Oz8Fwsg0kDJETnH2B8asbTmOy3uvCgIsF80rY4NKqoGYcfaqY8xhmbxz+ipMyL826+mg3WmTnqVpbdXm3Y3oXw==
+victory-cursor-container@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.2.0.tgz#b5f04357c991253cfe894ffa89e2be200b8a17f2"
+  integrity sha512-VIl1h15Js2Mvkd1YOAgiFKuOxV+Lsn+GcbWS3gPuDDZlTVL82+n/nmcBXf+t6v41tZz9GUfcVphp8MCAT/tiog==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-group@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.1.1.tgz#2ef0ec74d1533734922f437143ffb1160a817503"
-  integrity sha512-OpSAXZ7InMXWT9AEo5UA/QYaD8i9F7pdHqvcSDckoEJPwZ6Sr7deE9LpfVo3KeK6PjzjQBZdrBPggSZwcvl0Zw==
+victory-errorbar@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-35.2.0.tgz#bd5897628d042fdada078d8379e009803dad41ff"
+  integrity sha512-JamxvyjxHwcbJU7eV3HnGbi1SdhvoOKC3zadJr/e/jItMtJrMQWIdErpj/XcL9ScQkLBEq8Plzya3YQo7tSvKA==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.2.0"
+
+victory-group@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.2.0.tgz#f314b50f2a617c7248708ad3cd0bd10a3f7d083a"
+  integrity sha512-crv7to0RkJktrRk8fNoPuXsEYCplQk9Q+BV0AxLTEnPkRyxgUCjHgEgqQ8wqCXfPLYtyjUUteJhGDjinm3e4FQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.1.1"
-    victory-shared-events "^35.1.1"
+    victory-core "^35.2.0"
+    victory-shared-events "^35.2.0"
 
-victory-histogram@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-histogram/-/victory-histogram-35.1.1.tgz#3748f410730ed7e26aeb8f3bfc936354cddffc4f"
-  integrity sha512-S/CGu7nIlN8kSQMNSMRWw9Nr4x/Z9W5giix4nxfj8M1tu0epNsRED4Jav2NUn7S3z+f2N76uJo80zVk894JK+A==
+victory-histogram@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-histogram/-/victory-histogram-35.2.0.tgz#be97f87b3fa7ddeafe6ef1e6602f1703b28fa63e"
+  integrity sha512-Rl7BO8FVtOW7dbgtcDc1iNbZWRKBpACtauIgOAPeFwRfohTPOGzbFTiayo/5eqm7wHR4NfB94MY63eOD2vozqQ==
   dependencies:
     d3-array "^2.4.0"
     d3-scale "^1.0.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-bar "^35.1.1"
-    victory-core "^35.1.1"
+    victory-bar "^35.2.0"
+    victory-core "^35.2.0"
 
-victory-legend@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.1.1.tgz#9f8adf13c84052f93e9dd386c45c44d4eb7bcf80"
-  integrity sha512-RibASpnHin6TAXRhgngEk71Y++Wh+ikRH8nV2hygT+WtTolRj6RsAA43jQwTv4cDqt3v2k+Ddoh4eXpJoH3R2Q==
+victory-legend@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.2.0.tgz#741fed1db9d1e93c29094c23dd6d2b0381f63915"
+  integrity sha512-PiAD3pMg8E7scRRfSHRxgXjWS1xFY0t3BXLYEN4NzxDIyYshHZTWAfn5kOnEDuugd7vovEsog+kyMyXhy/miIg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-line@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.1.1.tgz#41fbda4dc1d3df901b5b1a5c41e1a8cf303be036"
-  integrity sha512-PAY6Q8SN0p4vBiMvBUXVNb3FrZ7BWaN3/8/pWUKKobTVSiKaJmaDXR9u9EDn7yErjwxsFqJQ8+918pfkWvWWNg==
+victory-line@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.2.0.tgz#99edb0d78db4335fb2d7ffb9bd1a6007edad3e22"
+  integrity sha512-Rx51MW46yJfOvGpj71FfYAPOBdSUPQYTpSFdKUEmtFoZwu84dUtHiAbmISk8d8vQTYJDDsGFxgmi2XantR13RA==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-pie@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.1.1.tgz#da7e2bc7c5c536f10762005b47561b9660d7da79"
-  integrity sha512-PFzceL0LPIK30Flz3OrEB7vSCHm5oaQInvvufuUsTUPHxBjq0QDqukV5zHCz0OfdFZ+KzqCTdwD95EFyC1yrYA==
+victory-pie@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.2.0.tgz#728ea5b8b35fc7a87c69681c8863a370b3c495c4"
+  integrity sha512-nt9iRb2GGcKE46bmG8P5LbX+ouYQJi4/e85rfGjUtEVusz2jo2mQ17eeQpZJAJi9R7WlUtM33MxnaqtnZwHYjA==
   dependencies:
     d3-shape "^1.0.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-polar-axis@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-35.1.1.tgz#9a527d2d09770c92c20d2b4439f9f2188beeaeb2"
-  integrity sha512-Y6iFqfkkI3Be4ltg+3AsmXUkk9uDQ+IU6XQWzZ0PZGGEt1ftiRX5GS2tfTQcV//qsannX6t2xKBc0iquPI3+Kw==
+victory-polar-axis@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-35.2.0.tgz#cdd3237bfdcd2ca82d7beff1d2eb75c3c25a302d"
+  integrity sha512-kZJz1ecEN90ycvEWt3scYlsZUAVddpy/nE0MVok/ALI6LU9cJ1cGBvwTxhtXSjs8Yfcl7G3l880MhWIqG5JdyQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-scatter@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.1.1.tgz#ab5bf3afb52c6270705b6c44f0d4365a49a2be5c"
-  integrity sha512-IgJNQHXx7lUoFnUoMNeCatBso+sIdx6/v0Hx94GeP3X6UmGPzBnM9JlyjVQjyJuiEoWQ0MtFhqidy+CSvn4pJg==
+victory-scatter@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.2.0.tgz#bb691587c278e2890b43063290292bb0858c18c2"
+  integrity sha512-C/yjqT5z2ymWu0vPUZFbiEchLSbwCoo/Fwv6VHfia/sI05W1huZ9+5voUstMe9SqLnT/31XF+lUb+xIffcE6qg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-selection-container@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.1.1.tgz#773ac40864276872881a02e739c0293a4eb921c7"
-  integrity sha512-lait103pBL1h9Jv65OiR8xfXhoQ79KpjWsgx0fZQGi+HcvzaKTAv9XGAMqB6GT3PkXFEqrz9K+0cAaRHd8SPvQ==
+victory-selection-container@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.2.0.tgz#2ad22f05bce7e740c333b65e75f3255b3e2fd61e"
+  integrity sha512-mHvTdGxClA2m0HBIleg578GGcsRp7qLL8Rj2n8/iFetzLf9GLE9CtF+a1HKd8yLAeij6XmCNq8MIvO4ERg725g==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-shared-events@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-35.1.1.tgz#8657abe9c38b67f7af22b3192b53d35e7434d47e"
-  integrity sha512-h4qMyZuvTlZAq/UuP3R6ETCLYSmggzU01ZuAbxEqygt+XQ04yG2QJmf8stKxvS1ktYFIXVdrJr/bJjTAIZQ0XQ==
-  dependencies:
-    lodash "^4.17.19"
-    prop-types "^15.5.8"
-    react-fast-compare "^2.0.0"
-    victory-core "^35.1.1"
-
-victory-stack@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.1.1.tgz#3715080be300d2457cf3dd2fbc6873b97c115cb8"
-  integrity sha512-SKXd6YG97CH9KsQB+akhc2jos+6vjGmyJkaHuTXuqGL9TrGtTM1WA784LAOFbNourk/VRTf1TJOz0EtzO2orIw==
+victory-shared-events@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-35.2.0.tgz#345e11acf3cd91a1ea98a406072519161486e97c"
+  integrity sha512-M+dvtCwK/YsnZ6ruKjrir0WfK0n5b63tLer3GwdiEdMyaWgn4hEDhafpH5PYagyG00ujSqadgf3DMRQoimv+dw==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.1.1"
-    victory-shared-events "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-tooltip@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.1.1.tgz#b13b08586aa73e20a022cba1408cf850a098d17c"
-  integrity sha512-2ZMecFgL6lQ2exzNGBmnUia967plHRWAinUYaRMSY4R3+FgOjCLkdVu1XBf/y6EBn+urIw3VK4yS8pn9ESjSOQ==
+victory-stack@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.2.0.tgz#b2005101b85edfb62af1692f6d9173bd80f41b5c"
+  integrity sha512-ofNCYpTj5Qq8ruYLFo46aQ4WyNZ514wqZUytGhs9+muJTClCjmnP4f6jfbsghZbPPucv0fGwABoiXcYIc+fJ5Q==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.2.0"
+    victory-shared-events "^35.2.0"
 
-victory-voronoi-container@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.1.1.tgz#fea1a5862689bc6a1e6cafbfe978de7c384b4701"
-  integrity sha512-AcCOhGMt9WYGDQtGIfbHhabdTmj92Uwr0fyfg+StrZk6AB/KgJproRcKQ91jLQExQkaoqdB9DP83LYGjWnk0zg==
+victory-tooltip@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.2.0.tgz#56189f6d61ba4262405e32a84a2ee75d98826db2"
+  integrity sha512-w6M2g+c0ZFfKM80Cife/9kCOd3xiXSaSCjdokp2GRBA8zD9CkbiCAGYLsF+CQBSoeZpMCyzC6bsiEtzb4SD48g==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.2.0"
+
+victory-voronoi-container@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.2.0.tgz#38155b9c97836eb1785ac2720e9c3204b37d33ac"
+  integrity sha512-mevciZwcVuQ9k4PqTSz/3hSF+XyHR1DbYoZsAZJlocsezncYtdxKYbw7MOraubio/H5wCgsICi/llmxiPFmPHg==
   dependencies:
     delaunay-find "0.0.5"
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.1.1"
-    victory-tooltip "^35.1.1"
+    victory-core "^35.2.0"
+    victory-tooltip "^35.2.0"
 
-victory-voronoi@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-35.1.1.tgz#7dc5b794690b33d2452291b17397f4838966262e"
-  integrity sha512-b8Ec7a/253tgpC+KH2CdvAl+DubSAXWYyd30Bd6T1+oPx+KmRdB76uEmnqUHXzBCEHnkjazfOPb2nLItCoOR9g==
+victory-voronoi@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-35.2.0.tgz#e6d7341566dff915ac597baa660961f8f52b469e"
+  integrity sha512-TJ6t2Bxl5wu451igdJ/vIKddBIHxSJgGbuGybYgj0CTjl4KH9U16Gx8ILILm2bW07/Am1PFWQpjFjK+3Gn5NdA==
   dependencies:
     d3-voronoi "^1.1.2"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory-zoom-container@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.1.1.tgz#0f3df03972f6e8dbde18a22e405e83bd013026bb"
-  integrity sha512-U0sKD56muX1ZK/mBWYjdRUDtrsIRBGHC9MIpNL0Ju6sIoqH//uyBFoO617xf5VMO8iUYywjXEqzXb+60XK41TQ==
+victory-zoom-container@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.2.0.tgz#94e869ce6e6eca22816e1575402c7e304af39a6f"
+  integrity sha512-cmR5IAfL92+ESYk6klwxINlFAQ5kO5DbjncqmThLjc2sVKG+zVffgkD4K2foRXjlOsxN0+nNWDmmRwwSzkENXQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.1.1"
+    victory-core "^35.2.0"
 
-victory@^35.1.1:
-  version "35.1.1"
-  resolved "https://registry.yarnpkg.com/victory/-/victory-35.1.1.tgz#66f2a5b3cedfd7fa8c2d031d426206ef8cada9d9"
-  integrity sha512-PJYPP71dW73qPiemlYBtRjWuw0wmyk8rfbmeUyrzrUG/xwfeO52N96P7MXcV+dBXR4BzLy0G5D0bvGksBFfVWw==
+victory@^35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-35.2.0.tgz#2fdb76fd6cc56a8f1ee9a3bf848c8e24703281ad"
+  integrity sha512-G33seLKbpE73S5WrXatfMT+CpxFXz4MzVSWSL3gah6KeVYunnK7WBkg9Xvwt+zJx5XMaRru8yWamtui5cg6UVg==
   dependencies:
-    victory-area "^35.1.1"
-    victory-axis "^35.1.1"
-    victory-bar "^35.1.1"
-    victory-box-plot "^35.1.1"
-    victory-brush-container "^35.1.1"
-    victory-brush-line "^35.1.1"
-    victory-candlestick "^35.1.1"
-    victory-chart "^35.1.1"
-    victory-core "^35.1.1"
-    victory-create-container "^35.1.1"
-    victory-cursor-container "^35.1.1"
-    victory-errorbar "^35.1.1"
-    victory-group "^35.1.1"
-    victory-histogram "^35.1.1"
-    victory-legend "^35.1.1"
-    victory-line "^35.1.1"
-    victory-pie "^35.1.1"
-    victory-polar-axis "^35.1.1"
-    victory-scatter "^35.1.1"
-    victory-selection-container "^35.1.1"
-    victory-shared-events "^35.1.1"
-    victory-stack "^35.1.1"
-    victory-tooltip "^35.1.1"
-    victory-voronoi "^35.1.1"
-    victory-voronoi-container "^35.1.1"
-    victory-zoom-container "^35.1.1"
+    victory-area "^35.2.0"
+    victory-axis "^35.2.0"
+    victory-bar "^35.2.0"
+    victory-box-plot "^35.2.0"
+    victory-brush-container "^35.2.0"
+    victory-brush-line "^35.2.0"
+    victory-candlestick "^35.2.0"
+    victory-chart "^35.2.0"
+    victory-core "^35.2.0"
+    victory-create-container "^35.2.0"
+    victory-cursor-container "^35.2.0"
+    victory-errorbar "^35.2.0"
+    victory-group "^35.2.0"
+    victory-histogram "^35.2.0"
+    victory-legend "^35.2.0"
+    victory-line "^35.2.0"
+    victory-pie "^35.2.0"
+    victory-polar-axis "^35.2.0"
+    victory-scatter "^35.2.0"
+    victory-selection-container "^35.2.0"
+    victory-shared-events "^35.2.0"
+    victory-stack "^35.2.0"
+    victory-tooltip "^35.2.0"
+    victory-voronoi "^35.2.0"
+    victory-voronoi-container "^35.2.0"
+    victory-zoom-container "^35.2.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
- Adds a documentation sidebar nav for `VictoryAccessibleGroup` under "More". 
- Updates primitive prop specs to include `aria-label` string/function and `tabIndex` number/function
- Add update about VictoryAccessibleGroup to "New Features" and add small example for primitive prop updates

#### `VictoryAccessibleGroup` new section
![Screen Shot 2020-10-08 at 1 28 18 PM](https://user-images.githubusercontent.com/27159818/95505248-48a73380-096b-11eb-9e91-62b752245d8e.png)

#### `VictoryPrimitives` doc update
![Screen Shot 2020-10-08 at 4 04 26 PM](https://user-images.githubusercontent.com/27159818/95518292-ffadaa00-097f-11eb-98f8-bc689e84761c.png)

