### PR TITLE
Avoid rerenders on ignored events

### DIFF
--- a/packages/victory-core/src/victory-util/events.js
+++ b/packages/victory-core/src/victory-util/events.js
@@ -201,7 +201,7 @@ export default {
     // eslint-disable-next-line max-params
     const onEvent = (evt, childProps, eventKey, eventName) => {
       const eventReturn = events[eventName](evt, childProps, eventKey, this);
-      if (eventReturn) {
+      if (!isEmpty(eventReturn)) {
         const callbacks = compileCallbacks(eventReturn);
         this.setState(parseEventReturn(eventReturn, eventKey), callbacks);
       }


### PR DESCRIPTION
Issue: Victory codebase uses `return {}` as a way of saying "ignore this event", but it still leads to rerendering of `VictorySharedEvents` and therefore its children