### PR TITLE
Reduce CursorContainer's onMouseMove throttle

### DIFF
--- a/packages/victory-cursor-container/src/cursor-helpers.js
+++ b/packages/victory-cursor-container/src/cursor-helpers.js
@@ -1,6 +1,8 @@
 import { Selection } from "victory-core";
 import { throttle, isFunction, mapValues } from "lodash";
 
+const ON_MOUSE_MOVE_THROTTLE_MS = 16;
+
 const CursorHelpers = {
   getDimension(props) {
     const { horizontal, cursorDimension } = props;
@@ -81,11 +83,10 @@ const CursorHelpers = {
 
 export default {
   ...CursorHelpers,
-  onMouseMove: throttle(
-    CursorHelpers.onMouseMove.bind(CursorHelpers),
-    32, // eslint-disable-line no-magic-numbers
-    { leading: true, trailing: false }
-  ),
+  onMouseMove: throttle(CursorHelpers.onMouseMove.bind(CursorHelpers), ON_MOUSE_MOVE_THROTTLE_MS, {
+    leading: true,
+    trailing: false
+  }),
   onMouseLeave: CursorHelpers.onMouseMove.bind(CursorHelpers),
   onTouchEnd: CursorHelpers.onTouchEnd.bind(CursorHelpers)
 };


### PR DESCRIPTION
Issue: Rapid mouse leave from the CursorContainer (especially with multiple CursorContainers on the same page) causes freezing in the container's Cursor. 

Please see issue #1680 for a more detailed breakdown of the problem. 

Attached are gifs from before the change (throttle time at 32ms):

![victory_cursor_container_throttle_bug](https://user-images.githubusercontent.com/29256184/97456416-3c314d80-190f-11eb-8260-14ad8f723fa7.gif)

And after the change (throttle time at 16ms):
![victory_cursor_container_throttle_fixed](https://user-images.githubusercontent.com/29256184/97456656-71d63680-190f-11eb-82d7-8fd9f6bd7837.gif)

