### PR TITLE
Omit first and last bins when specifying d3-array thresholds.

### DIFF
--- a/packages/victory-histogram/src/helper-methods.js
+++ b/packages/victory-histogram/src/helper-methods.js
@@ -43,7 +43,7 @@ const getBinningFunc = ({ data, x, bins, dataOrBinsContainsDates }) => {
 
   if (Array.isArray(bins)) {
     bin.domain([bins[0], bins[bins.length - 1]]);
-    bin.thresholds(bins);
+    bin.thresholds(bins.slice(1, bins.length - 1));
 
     return bin;
   }

--- a/test/client/spec/victory-histogram/victory-histogram.spec.js
+++ b/test/client/spec/victory-histogram/victory-histogram.spec.js
@@ -61,6 +61,17 @@ describe("components/victory-histogram", () => {
       expect(bars.length).to.be.greaterThan(0);
     });
 
+    it("renders 2 bars of equal height", () => {
+      const data = [{ x: 2 }, { x: 3 }];
+      const wrapper = mount(<VictoryHistogram data={data} bins={[2, 2.5, 3]} />);
+      const bars = wrapper.find("Bar");
+      const heights = bars.map(SvgTestHelper.getBarHeight).map((n) => parseInt(n));
+
+      expect(bars.length).to.equal(2);
+      expect(heights[0]).to.equal(heights[1]);
+      expect(heights[0]).to.be.greaterThan(0);
+    });
+
     it("renders bars values with null accessor", () => {
       const data = range(30);
       const wrapper = shallow(<VictoryHistogram data={data} x={null} y={null} />);


### PR DESCRIPTION
This is to fix #1730 

From the [d3-array docs](https://www.npmjs.com/package/d3-array#bin_thresholds):

Thresholds are defined as an array of values [x0, x1, …]. Any value less than
x0 will be placed in the first bin; any value greater than or equal to x0 but
less than x1 will be placed in the second bin; and so on.

When a `VictoryStack` is used, the `bins` are calculated and passed to `VictoryHistogram` which is why the bug was not present in my repro when I was not using `bins` or `VictoryStack`.