### PR TITLE
Fix MultiLabelableProps and Tooltip orientation TS definitions

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -676,7 +676,7 @@ export interface VictoryLabelableProps {
 }
 
 export interface VictoryMultiLabelableProps extends VictoryLabelableProps {
-  labels?: string[] | number[] | { (data: any): string[] | number[] | null };
+  labels?: string[] | number[] | { (data: any): string | string[] | number | number[] | null };
 }
 
 export interface VictorySingleLabelableProps extends VictoryLabelableProps {

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -676,7 +676,7 @@ export interface VictoryLabelableProps {
 }
 
 export interface VictoryMultiLabelableProps extends VictoryLabelableProps {
-  labels?: string[] | number[] | { (data: any): string | number | null };
+  labels?: string[] | number[] | { (data: any): string[] | number[] | null };
 }
 
 export interface VictorySingleLabelableProps extends VictoryLabelableProps {

--- a/packages/victory-tooltip/src/index.d.ts
+++ b/packages/victory-tooltip/src/index.d.ts
@@ -5,7 +5,6 @@ import {
   StringOrNumberOrCallback,
   VictoryCommonProps,
   VictoryLabelableProps,
-  VictoryNumberCallback,
   VictoryThemeDefinition,
   VictoryStyleObject,
   PaddingOrCallback
@@ -37,7 +36,7 @@ export interface VictoryTooltipProps extends VictoryLabelableProps {
   flyoutComponent?: React.ReactElement;
   flyoutPadding?: PaddingOrCallback;
   index?: number | string;
-  orientation?: OrientationTypes | VictoryNumberCallback;
+  orientation?: OrientationTypes | ((...args: any[]) => OrientationTypes);
   pointerLength?: NumberOrCallback;
   pointerOrientation?: OrientationTypes | ((...args: any[]) => OrientationTypes);
   pointerWidth?: NumberOrCallback;


### PR DESCRIPTION
* Adjusted `labels` prop to accept function that returns array of strings or numbers (which obviously works in JS, but TypeScript complains and `any` assertion is needed)
* Fixed `orientation` prop to accept function that returns `OrientationTypes`, similarly to `pointerOrientation` prop. I removed `VictoryNumberCallback` because I think it doesn't make any sense there, but I'm not 100% sure.