### PR TITLE
Fix paths in webpack config file for windows machines

### DIFF
--- a/config/webpack/demo/webpack.config.dev-ts.js
+++ b/config/webpack/demo/webpack.config.dev-ts.js
@@ -36,7 +36,7 @@ module.exports = {
     rules: [
       {
         test: /\.(ts|tsx)$/,
-        include: [`${DEMO}/ts`],
+        include: [path.join(DEMO, 'ts')],
         loader: "ts-loader"
       },
       {

--- a/config/webpack/demo/webpack.config.dev.js
+++ b/config/webpack/demo/webpack.config.dev.js
@@ -49,7 +49,7 @@ module.exports = {
         test: /\.js$/,
         // Use include specifically of our sources.
         // Do _not_ use an `exclude` here.
-        include: FILES.concat([`${DEMO}/js`]),
+        include: FILES.concat([path.join(DEMO, 'js')]),
         loader: "babel-loader"
       }
     ]


### PR DESCRIPTION
I was having trouble running up the repository on my machine and after some digging found that it was not recognising the path correctly on my machine. Passing it through `path.normalize()` should make sure that it works fine on either platform.