### PR TITLE
Stop timer when there are no subscriptions

### DIFF
--- a/config/webpack/demo/webpack.config.dev-ts.js
+++ b/config/webpack/demo/webpack.config.dev-ts.js
@@ -36,7 +36,7 @@ module.exports = {
     rules: [
       {
         test: /\.(ts|tsx)$/,
-        include: [path.join(DEMO, 'ts')],
+        include: [path.join(DEMO, "ts")],
         loader: "ts-loader"
       },
       {

--- a/config/webpack/demo/webpack.config.dev.js
+++ b/config/webpack/demo/webpack.config.dev.js
@@ -49,7 +49,7 @@ module.exports = {
         test: /\.js$/,
         // Use include specifically of our sources.
         // Do _not_ use an `exclude` here.
-        include: FILES.concat([path.join(DEMO, 'js')]),
+        include: FILES.concat([path.join(DEMO, "js")]),
         loader: "babel-loader"
       }
     ]


### PR DESCRIPTION
I hope I am not stepping on toes with this, but the other [PR](https://github.com/FormidableLabs/victory/pull/1671) tackling this hasn't been updated since August and having the timers run in the background is making it difficult for me to debug something.

This should avoid starting the the timer upon creation and will remove it again when there are no more subscriptions available. I tested this against the animations demo page by clearing the the interval after some time and checking if there was any activity in the background afterwards.