### PR TITLE
use lodash keys consistently

### DIFF
--- a/config/webpack/demo/webpack.config.dev-ts.js
+++ b/config/webpack/demo/webpack.config.dev-ts.js
@@ -36,7 +36,7 @@ module.exports = {
     rules: [
       {
         test: /\.(ts|tsx)$/,
-        include: [path.join(DEMO, 'ts')],
+        include: [path.join(DEMO, "ts")],
         loader: "ts-loader"
       },
       {

--- a/config/webpack/demo/webpack.config.dev.js
+++ b/config/webpack/demo/webpack.config.dev.js
@@ -49,7 +49,7 @@ module.exports = {
         test: /\.js$/,
         // Use include specifically of our sources.
         // Do _not_ use an `exclude` here.
-        include: FILES.concat([path.join(DEMO, 'js')]),
+        include: FILES.concat([path.join(DEMO, "js")]),
         loader: "babel-loader"
       }
     ]

--- a/packages/victory-core/src/victory-portal/portal.js
+++ b/packages/victory-core/src/victory-portal/portal.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "../victory-util/prop-types";
+import { keys } from "lodash";
 
 export default class Portal extends React.Component {
   static displayName = "Portal";
@@ -37,7 +38,7 @@ export default class Portal extends React.Component {
   }
 
   getChildren() {
-    return Object.keys(this.map).map((key) => {
+    return keys(this.map).map((key) => {
       const el = this.map[key];
       return el ? React.cloneElement(el, { key }) : el;
     });

--- a/packages/victory-core/src/victory-util/events.js
+++ b/packages/victory-core/src/victory-util/events.js
@@ -166,8 +166,7 @@ export default {
       };
 
       // returns an entire mutated state for all children
-      const allChildNames =
-        childNames === "all" ? without(keys(baseProps), "parent") : childNames;
+      const allChildNames = childNames === "all" ? without(keys(baseProps), "parent") : childNames;
       return Array.isArray(allChildNames)
         ? allChildNames.reduce((memo, childName) => {
             return assign(memo, getReturnByChild(childName));

--- a/packages/victory-core/src/victory-util/events.js
+++ b/packages/victory-core/src/victory-util/events.js
@@ -1,4 +1,4 @@
-import { assign, isEmpty, isFunction, without, pickBy, uniq, includes } from "lodash";
+import { assign, isEmpty, isFunction, without, pickBy, uniq, includes, keys } from "lodash";
 
 export default {
   /* Returns all own and shared events that should be attached to a single target element,
@@ -108,10 +108,10 @@ export default {
         }
         if (eventReturn.eventKey === "all") {
           return baseProps[childName]
-            ? without(Object.keys(baseProps[childName]), "parent")
-            : without(Object.keys(baseProps), "parent");
+            ? without(keys(baseProps[childName]), "parent")
+            : without(keys(baseProps), "parent");
         } else if (eventReturn.eventKey === undefined && eventKey === "parent") {
-          return baseProps[childName] ? Object.keys(baseProps[childName]) : Object.keys(baseProps);
+          return baseProps[childName] ? keys(baseProps[childName]) : keys(baseProps);
         }
         return eventReturn.eventKey !== undefined ? eventReturn.eventKey : eventKey;
       };
@@ -134,7 +134,7 @@ export default {
           if (state[key] && state[key][target]) {
             delete state[key][target];
           }
-          if (state[key] && !Object.keys(state[key]).length) {
+          if (state[key] && !keys(state[key]).length) {
             delete state[key];
           }
           return state;
@@ -167,7 +167,7 @@ export default {
 
       // returns an entire mutated state for all children
       const allChildNames =
-        childNames === "all" ? without(Object.keys(baseProps), "parent") : childNames;
+        childNames === "all" ? without(keys(baseProps), "parent") : childNames;
       return Array.isArray(allChildNames)
         ? allChildNames.reduce((memo, childName) => {
             return assign(memo, getReturnByChild(childName));
@@ -208,7 +208,7 @@ export default {
     };
 
     // returns a new events object with enhanced event handlers
-    return Object.keys(events).reduce((memo, event) => {
+    return keys(events).reduce((memo, event) => {
       memo[event] = onEvent;
       return memo;
     }, {});
@@ -219,7 +219,7 @@ export default {
    */
   getPartialEvents(events, eventKey, childProps) {
     return events
-      ? Object.keys(events).reduce((memo, eventName) => {
+      ? keys(events).reduce((memo, eventName) => {
           const appliedEvent = (evt) => events[eventName](evt, childProps, eventKey, eventName);
           memo[eventName] = appliedEvent;
           return memo;
@@ -283,7 +283,7 @@ export default {
     baseProps = baseProps || {};
     baseState = baseState || {};
 
-    const eventKeys = Object.keys(baseProps);
+    const eventKeys = keys(baseProps);
     return eventKeys.reduce((memo, eventKey) => {
       const keyState = baseState[eventKey] || {};
       const keyProps = baseProps[eventKey] || {};
@@ -294,7 +294,7 @@ export default {
       } else {
         // use keys from both state and props so that elements not intially included in baseProps
         // will be used. (i.e. labels)
-        const targets = uniq(Object.keys(keyProps).concat(Object.keys(keyState)));
+        const targets = uniq(keys(keyProps).concat(keys(keyState)));
         memo[eventKey] = targets.reduce((m, target) => {
           const identifier = { eventKey, target, childName };
           const mutation = this.getExternalMutation(

--- a/packages/victory-core/src/victory-util/helpers.js
+++ b/packages/victory-core/src/victory-util/helpers.js
@@ -1,7 +1,7 @@
 /* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import React from "react";
-import { defaults, isFunction, property, pick, assign } from "lodash";
+import { defaults, isFunction, property, pick, assign, keys } from "lodash";
 
 // Private Functions
 
@@ -30,14 +30,14 @@ function getPolarRange(props, axis) {
  * creates an object with some keys excluded
  * replacement for lodash.omit for performance. does not mimick the entire lodash.omit api
  * @param {Object} originalObject: created object will be based on this object
- * @param {Array<String>} keys: an array of keys to omit from the new object
+ * @param {Array<String>} ks: an array of keys to omit from the new object
  * @returns {Object} new object with same properties as originalObject
  */
-function omit(originalObject, keys = []) {
+function omit(originalObject, ks = []) {
   // code based on babel's _objectWithoutProperties
   const newObject = {};
   for (const key in originalObject) {
-    if (keys.indexOf(key) >= 0) {
+    if (ks.indexOf(key) >= 0) {
       continue;
     }
     if (!Object.prototype.hasOwnProperty.call(originalObject, key)) {
@@ -128,10 +128,10 @@ function evaluateProp(prop, props) {
 }
 
 function evaluateStyle(style, props) {
-  if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
+  if (!style || !keys(style).some((value) => isFunction(style[value]))) {
     return style;
   }
-  return Object.keys(style).reduce((prev, curr) => {
+  return keys(style).reduce((prev, curr) => {
     prev[curr] = evaluateProp(style[curr], props);
     return prev;
   }, {});

--- a/packages/victory-core/src/victory-util/transitions.js
+++ b/packages/victory-core/src/victory-util/transitions.js
@@ -1,5 +1,5 @@
 /* eslint-disable func-style */
-import { assign, defaults, identity } from "lodash";
+import { assign, defaults, identity, keys } from "lodash";
 import React from "react";
 
 function getDatumKey(datum, idx) {
@@ -16,7 +16,7 @@ function getKeyedData(data) {
 
 function getKeyedDataDifference(a, b) {
   let hasDifference = false;
-  const difference = Object.keys(a).reduce((_difference, key) => {
+  const difference = keys(a).reduce((_difference, key) => {
     if (!(key in b)) {
       hasDifference = true;
       _difference[key] = true;

--- a/packages/victory-create-container/src/create-container.js
+++ b/packages/victory-create-container/src/create-container.js
@@ -1,4 +1,4 @@
-import { toPairs, groupBy, forOwn, includes, flow, isEmpty, isFunction } from "lodash";
+import { toPairs, groupBy, forOwn, includes, flow, isEmpty, isFunction, keys } from "lodash";
 import { VictoryContainer, Log } from "victory-core";
 import { voronoiContainerMixin } from "victory-voronoi-container";
 import { zoomContainerMixin } from "victory-zoom-container";
@@ -112,7 +112,7 @@ const checkBehaviorName = (behavior, behaviors) => {
 
 const makeCreateContainerFunction = (mixinMap, Container) => (behaviorA, behaviorB, ...invalid) => {
   // eslint-disable-line
-  const behaviors = Object.keys(mixinMap);
+  const behaviors = keys(mixinMap);
 
   checkBehaviorName(behaviorA, behaviors);
   checkBehaviorName(behaviorB, behaviors);

--- a/packages/victory-shared-events/src/victory-shared-events.js
+++ b/packages/victory-shared-events/src/victory-shared-events.js
@@ -1,4 +1,4 @@
-import { assign, isFunction, defaults, isEmpty, fromPairs } from "lodash";
+import { assign, isFunction, defaults, isEmpty, fromPairs, keys } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import { PropTypes as CustomPropTypes, Events, Helpers, TimerContext } from "victory-core";
@@ -104,7 +104,7 @@ export default class VictorySharedEvents extends React.Component {
           props.externalEventMutations,
           baseProps,
           this.state,
-          Object.keys(baseProps)
+          keys(baseProps)
         )
       : undefined;
   }
@@ -196,7 +196,7 @@ export default class VictorySharedEvents extends React.Component {
         }
       }, []);
     };
-    const childNames = Object.keys(baseProps);
+    const childNames = keys(baseProps);
     const childComponents = React.Children.toArray(props.children);
     return alterChildren(childComponents, childNames);
   }


### PR DESCRIPTION
replaces `Object.keys` with lodash `keys` across all packages.

fixes https://github.com/FormidableLabs/victory/issues/1736
