### PR TITLE
Allow bin prop to be an array of negative numbers as well

### DIFF
--- a/packages/victory-histogram/src/victory-histogram.js
+++ b/packages/victory-histogram/src/victory-histogram.js
@@ -51,9 +51,7 @@ export class VictoryHistogram extends React.Component {
     ...CommonProps.dataProps,
     binSpacing: CustomPropTypes.nonNegative,
     bins: PropTypes.oneOfType([
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([CustomPropTypes.nonNegative, PropTypes.instanceOf(Date)])
-      ),
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)])),
       CustomPropTypes.nonNegative
     ]),
     cornerRadius: PropTypes.oneOfType([


### PR DESCRIPTION
This PR updates the `bins` prop of `VictoryHistogram` to allow negative numbers as well. For example, `bins={[-20, 0, 20]}` should be allowed.