### PR TITLE
try using height: auto for portal svg

### DIFF
--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -124,6 +124,7 @@ export default class VictoryContainer extends React.Component {
     } = props;
     const children = this.getChildren(props);
     const dimensions = responsive ? { width: "100%", height: "100%" } : { width, height };
+    const portalDimensions = responsive ? { width: "100%", height: "auto" } : { width, height };
     const divStyle = assign(
       { pointerEvents: "none", touchAction: "none", position: "relative" },
       dimensions
@@ -133,7 +134,7 @@ export default class VictoryContainer extends React.Component {
       dimensions
     );
     const svgStyle = assign({ pointerEvents: "all" }, dimensions);
-    const portalSvgStyle = assign({ overflow: "visible" }, dimensions);
+    const portalSvgStyle = assign({ overflow: "visible" }, portalDimensions);
     const portalProps = {
       width,
       height,


### PR DESCRIPTION
This PR gives the portal svg `height: "auto"` which allows it to be identically sized to the chart svg rather than a few pixels off for charts that use default `preserveAspectRatio`. However this may negatively impact charts that use  different values for `preserveAspectRatio`

related to https://github.com/FormidableLabs/victory/issues/1770