### PR TITLE
Fix getPath types

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -812,7 +812,7 @@ export class LineSegment extends React.Component<LineSegmentProps> {}
 
 export interface PointProps extends VictoryCommonPrimitiveProps {
   datum?: any;
-  getPath?: (props: PointProps) => void;
+  getPath?: (x: number, y: number, size: number) => string;
   pathComponent?: React.ReactElement;
   size?: number | Function;
   symbol?: ScatterSymbolType | Function;


### PR DESCRIPTION
We should change types in getPath. SVG path has string type. In this case it's very important to avoid type errors, when you use library with Typescript.

![image](https://user-images.githubusercontent.com/43094186/105048911-28643600-5a7d-11eb-95b2-96f854da707e.png)
![image](https://user-images.githubusercontent.com/43094186/105049326-94df3500-5a7d-11eb-8cb6-eb33eb6a3020.png)

