### PR TITLE
Update CodeMirror version - Fix double scrollbars on the code snippets on the docs

### DIFF
--- a/docs/src/html.js
+++ b/docs/src/html.js
@@ -19,7 +19,7 @@ export default ({ Html, Head, Body, children }) => (
       {/* CodeMirror for Component Playgrounds */}
       <link
         rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.css"
+        href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.59.2/codemirror.min.css"
       />
     </Head>
     <title>Victory</title>


### PR DESCRIPTION
Currently the docs on the website show the editable code snippets with double sidebars.
![image](https://user-images.githubusercontent.com/16062869/108614572-fb000480-73fb-11eb-8bf9-99fdb642b428.png)

Updating the CodeMirror version seems to fix this.