### PR TITLE
Update EventPropTypeInterface to include prop arg

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -531,10 +531,16 @@ export interface EventPropTypeInterface<TTarget, TEventKey> {
   eventHandlers: {
     [key: string]:
       | {
-          (event: React.SyntheticEvent<any>): EventCallbackInterface<TTarget, TEventKey>;
+          (event: React.SyntheticEvent<any>, props?: any): EventCallbackInterface<
+            TTarget,
+            TEventKey
+          >;
         }
       | {
-          (event: React.SyntheticEvent<any>): EventCallbackInterface<TTarget, TEventKey>[];
+          (event: React.SyntheticEvent<any>, props?: any): EventCallbackInterface<
+            TTarget,
+            TEventKey
+          >[];
         };
   };
 }

--- a/test/client/spec/victory-bar/victory-bar.spec.js
+++ b/test/client/spec/victory-bar/victory-bar.spec.js
@@ -137,8 +137,14 @@ describe("components/victory-bar", () => {
 
     it("attaches an event to data", () => {
       const clickHandler = sinon.spy();
+      const data = [
+        { x: 0, y: 0, label: "0" },
+        { x: 1, y: 1, label: "1" },
+        { x: 2, y: 2, label: "2" }
+      ];
       const wrapper = mount(
         <VictoryBar
+          data={data}
           events={[
             {
               target: "data",
@@ -156,6 +162,10 @@ describe("components/victory-bar", () => {
         expect(omit(clickHandler.args[index][1], ["events", "key"])).to.eql(
           omit(initialProps, ["events", "key"])
         );
+        // It should also include the datum
+        expect(clickHandler.args[index][1].datum).to.include({
+          ...data[index]
+        });
         expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
       });
     });


### PR DESCRIPTION
The `EventPropTypeInterface` is missing additional parameters that are very useful, e.g., extracting the associated data when an item (bar) is clicked.

Since this is my first PR to this repo (and I reread the contributing guide), I am happy to improving tests and typings. The original expectation in the bar tests seem to not complain about the additional argument, but I added an explicit test just in case.