### PR TITLE
Add id attribute to VictoryLabelProps interface

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -212,6 +212,7 @@ export interface VictoryLabelProps {
   direction?: string;
   events?: React.DOMAttributes<any>;
   groupComponent?: React.ReactElement;
+  id?: string | number | Function;
   inline?: boolean;
   labelPlacement?: LabelOrientationType;
   lineHeight?: StringOrNumberOrCallback | (string | number)[];

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -212,7 +212,7 @@ export interface VictoryLabelProps {
   direction?: string;
   events?: React.DOMAttributes<any>;
   groupComponent?: React.ReactElement;
-  id?: string | number | Function;
+  id?: StringOrNumberOrCallback;
   inline?: boolean;
   labelPlacement?: LabelOrientationType;
   lineHeight?: StringOrNumberOrCallback | (string | number)[];


### PR DESCRIPTION
As per https://github.com/FormidableLabs/victory/pull/1575 and https://github.com/FormidableLabs/victory-docs/pull/678, `VictoryLabel` can receive an`id` prop.