### PR TITLE
add handleWidth to VictoryBrushContainer interface

### DIFF
--- a/demo/js/components/victory-brush-container-demo.js
+++ b/demo/js/components/victory-brush-container-demo.js
@@ -318,6 +318,8 @@ class App extends React.Component {
               <VictoryBrushContainer
                 brushDomain={{ y: [-3, 3] }}
                 brushComponent={<rect style={{ fill: "teal" }} />}
+                handleWidth={1}
+                handleStyle={{stroke: "black", fill: "black"}}
               />
             }
             data={[

--- a/demo/js/components/victory-brush-container-demo.js
+++ b/demo/js/components/victory-brush-container-demo.js
@@ -319,7 +319,7 @@ class App extends React.Component {
                 brushDomain={{ y: [-3, 3] }}
                 brushComponent={<rect style={{ fill: "teal" }} />}
                 handleWidth={1}
-                handleStyle={{stroke: "black", fill: "black"}}
+                handleStyle={{ stroke: "black", fill: "black" }}
               />
             }
             data={[

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -328,6 +328,8 @@ export default class VictoryBrushContainerDemo extends React.Component<
               <VictoryBrushContainer
                 brushDomain={{ y: [-3, 3] }}
                 brushComponent={<rect style={{ fill: "teal" }} />}
+                handleWidth={1}
+                handleStyle={{stroke: "black", fill: "black"}}
               />
             }
             data={[

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -329,7 +329,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
                 brushDomain={{ y: [-3, 3] }}
                 brushComponent={<rect style={{ fill: "teal" }} />}
                 handleWidth={1}
-                handleStyle={{stroke: "black", fill: "black"}}
+                handleStyle={{ stroke: "black", fill: "black" }}
               />
             }
             data={[

--- a/packages/victory-brush-container/src/index.d.ts
+++ b/packages/victory-brush-container/src/index.d.ts
@@ -12,6 +12,7 @@ export interface VictoryBrushContainerProps extends VictoryContainerProps {
   disable?: boolean;
   handleComponent?: React.ReactElement;
   handleStyle?: React.CSSProperties;
+  handleWidth?: number;
   onBrushCleared?: (
     domain: { x: DomainTuple; y: DomainTuple },
     props: VictoryBrushContainerProps


### PR DESCRIPTION
This PR adds the `handleWidth` property to the typescript interface. The handleWidth is documented here https://formidable.com/open-source/victory/docs/victory-brush-container#handlewidth but could not be used in typescript.