### PR TITLE
Fix allowResize false behavior and set defaultBrushArea appropriately

### DIFF
--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -84,7 +84,9 @@ const Helpers = {
   },
 
   getDefaultBrushArea(targetProps, cachedDomain, evt) {
-    const { defaultBrushArea, domain, fullDomain, scale, horizontal } = targetProps;
+    const { domain, fullDomain, scale, horizontal, allowResize } = targetProps;
+    const defaultBrushArea =
+      !allowResize && !targetProps.defaultBrushArea ? "move" : targetProps.defaultBrushArea;
     if (defaultBrushArea === "none") {
       return this.getMinimumDomain();
     } else if (defaultBrushArea === "disable") {
@@ -186,7 +188,8 @@ const Helpers = {
       allowDraw
     } = targetProps;
     const brushDimension = this.getDimension(targetProps);
-
+    const defaultBrushArea =
+      !allowResize && !targetProps.defaultBrushArea ? "move" : targetProps.defaultBrushArea;
     // Don't trigger events for static brushes
     if (!allowResize && !allowDrag) {
       return {};
@@ -254,7 +257,7 @@ const Helpers = {
             {
               target: "parent",
               mutation: () => ({
-                isSelecting: allowResize,
+                isSelecting: allowResize || defaultBrushArea === "move",
                 domainBox,
                 fullDomainBox,
                 parentSVG,
@@ -363,10 +366,10 @@ const Helpers = {
       onBrushCleared,
       currentDomain,
       allowResize,
-      allowDrag,
-      defaultBrushArea
+      allowDrag
     } = targetProps;
-
+    const defaultBrushArea =
+      !allowResize && !targetProps.defaultBrushArea ? "move" : targetProps.defaultBrushArea;
     const defaultBrushHasArea = defaultBrushArea !== undefined && defaultBrushArea !== "none";
     const mutatedProps = { isPanning: false, isSelecting: false };
 


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/victory/issues/1813

This PR fixes a bug that was causing VictoryBrushContainer to behave incorrectly to clicks outside of the bush area when `allowResize` was set to false. It also makes the fallback `defaultBrushArea` behavior "move" when `allowResize` is false.

![move-behavior](https://user-images.githubusercontent.com/3719995/113947410-7278d000-97bf-11eb-84ef-5ac60065298e.gif)
