### PR TITLE
VictoryStack Custom Baseline Support

### DIFF
--- a/packages/victory-stack/src/helper-methods.js
+++ b/packages/victory-stack/src/helper-methods.js
@@ -56,7 +56,7 @@ function getY0(datum, index, datasets) {
   }
   const y = datum._y;
   const group = datum._group;
-  let customY0Points = datasets[0].map(datum => datum.y0);
+  const firstDatasetBaseline = datasets[0].map(d => d.y0);
 
   const previousDatasets = datasets.slice(0, index);
   const previousPoints = previousDatasets.reduce((prev, dataset) => {
@@ -76,7 +76,7 @@ function getY0(datum, index, datasets) {
     previousPoints.reduce((memo, value) => {
       const sameSign = (y < 0 && value < 0) || (y >= 0 && value >= 0);
       return sameSign ? +value + memo : memo;
-    }, customY0Points[group] || 0);
+    }, firstDatasetBaseline[group] || 0);
   return previousPoints.some((point) => point instanceof Date) ? new Date(y0) : y0;
 }
 

--- a/packages/victory-stack/src/helper-methods.js
+++ b/packages/victory-stack/src/helper-methods.js
@@ -56,7 +56,7 @@ function getY0(datum, index, datasets) {
   }
   const y = datum._y;
   const group = datum._group;
-  const firstDatasetBaseline = datasets[0].map(d => d.y0);
+  const firstDatasetBaseline = datasets[0].map((d) => d.y0);
 
   const previousDatasets = datasets.slice(0, index);
   const previousPoints = previousDatasets.reduce((prev, dataset) => {

--- a/packages/victory-stack/src/helper-methods.js
+++ b/packages/victory-stack/src/helper-methods.js
@@ -55,6 +55,9 @@ function getY0(datum, index, datasets) {
     return datum.y0;
   }
   const y = datum._y;
+  const group = datum._group;
+  let customY0Points = datasets[0].map(datum => datum.y0);
+
   const previousDatasets = datasets.slice(0, index);
   const previousPoints = previousDatasets.reduce((prev, dataset) => {
     return prev.concat(
@@ -67,12 +70,13 @@ function getY0(datum, index, datasets) {
         .map((previousDatum) => previousDatum._y || 0)
     );
   }, []);
+
   const y0 =
     previousPoints.length &&
     previousPoints.reduce((memo, value) => {
       const sameSign = (y < 0 && value < 0) || (y >= 0 && value >= 0);
       return sameSign ? +value + memo : memo;
-    }, 0);
+    }, customY0Points[group] || 0);
   return previousPoints.some((point) => point instanceof Date) ? new Date(y0) : y0;
 }
 

--- a/stories/data.js
+++ b/stories/data.js
@@ -33,6 +33,13 @@ const getData = (num, seed, max = 10) => {
   return range(num).map((v) => ({ x: v + 1, y: rand() }));
 };
 
+const getDataWithBaseline = (num, seed, max = 10) => {
+  seed = seed || "getData";
+  const baseSeed = seedrandom(seed);
+  const rand = () => baseSeed.quick() * max;
+  return range(num).map((v) => ({ x: v + 1, y: rand(), y0: rand() }));
+};
+
 const getDescendingSmallData = () => {
   return [
     { x: 1, y: 2 },
@@ -97,6 +104,7 @@ const getStackedData = (num, samples, useStrings) => {
 
 export {
   getData,
+  getDataWithBaseline,
   getStringData,
   getMixedData,
   getTimeData,

--- a/stories/victory-area.stories.js
+++ b/stories/victory-area.stories.js
@@ -6,7 +6,7 @@ import { VictoryArea } from "../packages/victory-area/src";
 import { VictoryTooltip } from "../packages/victory-tooltip/src";
 import { VictoryTheme, VictoryLabel } from "../packages/victory-core/src";
 import { VictoryChart } from "../packages/victory-chart/src";
-import { getData, getMixedData, getTimeData, getLogData } from "./data";
+import { getData, getMixedData, getTimeData, getLogData, getDataWithBaseline } from "./data";
 import { fromJS } from "immutable";
 
 const containerStyle = {
@@ -350,6 +350,13 @@ export const Stacked = () => {
           <VictoryArea data={getData(9)} />
           <VictoryArea data={getData(5, "seed-1")} />
           <VictoryArea data={getData(3, "seed-2")} />
+        </VictoryStack>
+      </VictoryChart>
+      <VictoryChart {...defaultChartProps}>
+        <VictoryStack>
+          <VictoryArea data={getDataWithBaseline(5)} />
+          <VictoryArea data={getData(5, "seed-1")} />
+          <VictoryArea data={getData(5, "seed-2")} />
         </VictoryStack>
       </VictoryChart>
     </div>

--- a/stories/victory-bar.stories.js
+++ b/stories/victory-bar.stories.js
@@ -8,7 +8,14 @@ import { VictoryStack } from "../packages/victory-stack/src/index";
 import { VictoryTooltip } from "../packages/victory-tooltip/src/index";
 import { VictoryTheme, VictoryLabel } from "../packages/victory-core/src/index";
 import { VictoryPolarAxis } from "../packages/victory-polar-axis/src/index";
-import { getData, getStackedData, getMixedData, getTimeData, getLogData } from "./data";
+import {
+  getData,
+  getStackedData,
+  getMixedData,
+  getTimeData,
+  getLogData,
+  getDataWithBaseline
+} from "./data";
 import { fromJS } from "immutable";
 
 const containerStyle = {
@@ -591,6 +598,13 @@ export const StackedBars = () => {
           <VictoryBar data={getData(100, "seed-5")} />
           <VictoryBar data={getData(200, "seed-6")} />
           <VictoryBar data={getData(190, "seed-7")} />
+        </VictoryStack>
+      </VictoryChart>
+      <VictoryChart {...defaultChartProps}>
+        <VictoryStack>
+          <VictoryBar data={getDataWithBaseline(7)} />
+          <VictoryBar data={getData(7, "seed-1")} />
+          <VictoryBar data={getData(7, "seed-2")} />
         </VictoryStack>
       </VictoryChart>
     </div>


### PR DESCRIPTION
Adds support for supplying custom baselines (y0) to the first child in a set of VictoryStack wrapped components, so that they stack correctly based on that first dataset.

Example:
```
<VictoryChart>
  <VictoryStack>
    <VictoryArea
      style={{ data: { fill: "red" } }}
      data={[
        { x: 1, y: 2, y0: 1 },
        { x: 2, y: 1, y0: -2 },
        { x: 3, y: 4, y0: 1 },
        { x: 4, y: 2, y0: -3 }
      ]}
    />
    <VictoryArea
      data={[
        { x: 1, y: 2 },
        { x: 2, y: 1 },
        { x: 3, y: 4 },
        { x: 4, y: 2 }
      ]}
    />
    <VictoryArea
      data={[
        { x: 1, y: 2 },
        { x: 2, y: 1 },
        { x: 3, y: 4 },
        { x: 4, y: 2 }
      ]}
    />
    <VictoryArea
      data={[
        { x: 1, y: 1 },
        { x: 2, y: 4 },
        { x: 3, y: 3 },
        { x: 4, y: 8 }
      ]}
    />
  </VictoryStack>
</VictoryChart>
```

Previous:
<img width="984" alt="Screen Shot 2021-05-05 at 10 38 01 AM" src="https://user-images.githubusercontent.com/1028686/117159103-02de0c80-ad8e-11eb-854e-301b736d2d36.png">
After:
<img width="813" alt="Screen Shot 2021-05-04 at 4 50 00 PM" src="https://user-images.githubusercontent.com/1028686/117159147-0c677480-ad8e-11eb-8e98-7002a8016647.png">
