### PR TITLE
add missing scale for container prop types

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -259,6 +259,10 @@ export interface VictoryContainerProps {
   preserveAspectRatio?: string;
   responsive?: boolean;
   role?: string;
+  scale?: {
+    x?: D3Scale;
+    y?: D3Scale;
+  };
   style?: React.CSSProperties;
   tabIndex?: number;
   theme?: VictoryThemeDefinition;


### PR DESCRIPTION
Add missing scale prop type for containers.

fixes https://github.com/FormidableLabs/victory/issues/1831