### PR TITLE
adding the style type to the group chart in main theme definition

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -388,7 +388,12 @@ export interface VictoryThemeDefinition {
       labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
     };
   } & VictoryCommonThemeProps;
-  group?: VictoryCommonThemeProps;
+  group?: {
+    style?: {
+      data?: VictoryStyleObject;
+      labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
+    };
+  } & VictoryCommonThemeProps;
   independentAxis?: {
     style?: {
       axis?: VictoryStyleObject;


### PR DESCRIPTION
Hello! First time contributing so please let me know if I need to change anything. This PR fixes:

- added option style prop to group chart definition in `VictoryThemeDefinition`


Thanks!