### PR TITLE
Fixed bug in type definition for EventPropTypeInterface where event handler could not be a void function

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -551,6 +551,9 @@ export interface EventPropTypeInterface<TTarget, TEventKey> {
             TTarget,
             TEventKey
           >[];
+        }
+      | {
+          (event: React.SyntheticEvent<any>, props?: any): void;
         };
   };
 }


### PR DESCRIPTION
Fixes the problem raised in issue https://github.com/FormidableLabs/victory/issues/1851.