### PR TITLE
Feature/disable inline styles

### DIFF
--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -71,6 +71,9 @@ const getCornerRadius = (cornerRadius, props) => {
 };
 
 const getStyle = (style = {}, props) => {
+  if (props.disableInlineStyle) {
+    return {};
+  }
   const stroke = style.fill || "black";
   const baseStyle = { fill: "black", stroke };
   return Helpers.evaluateStyle(assign(baseStyle, style), props);
@@ -143,6 +146,7 @@ Bar.propTypes = {
     })
   ]),
   datum: PropTypes.object,
+  disableInlineStyles: PropTypes.bool,
   getPath: PropTypes.func,
   horizontal: PropTypes.bool,
   pathComponent: PropTypes.element,

--- a/packages/victory-bar/src/bar.js
+++ b/packages/victory-bar/src/bar.js
@@ -71,7 +71,7 @@ const getCornerRadius = (cornerRadius, props) => {
 };
 
 const getStyle = (style = {}, props) => {
-  if (props.disableInlineStyle) {
+  if (props.disableInlineStyles) {
     return {};
   }
   const stroke = style.fill || "black";

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -25,7 +25,7 @@ const getBarPosition = (props, datum) => {
 const getCalculatedValues = (props) => {
   const { polar } = props;
   const defaultStyles = Helpers.getDefaultStyles(props, "bar");
-  const style = Helpers.getStyles(props.style, defaultStyles);
+  const style = !props.disableInlineStyles ? Helpers.getStyles(props.style, defaultStyles) : {};
   const range = props.range || {
     x: Helpers.getRange(props, "x"),
     y: Helpers.getRange(props, "y")
@@ -58,6 +58,7 @@ const getBaseProps = (props, fallbackProps) => {
     barRatio,
     cornerRadius,
     data,
+    disableInlineStyles,
     domain,
     events,
     height,
@@ -105,6 +106,7 @@ const getBaseProps = (props, fallbackProps) => {
       cornerRadius,
       data,
       datum,
+      disableInlineStyles,
       getPath,
       horizontal,
       index,

--- a/packages/victory-bar/src/index.d.ts
+++ b/packages/victory-bar/src/index.d.ts
@@ -30,6 +30,7 @@ export interface VictoryBarProps
         bottomLeft?: NumberOrCallback;
         bottomRight?: NumberOrCallback;
       };
+  disableInlineStyles?: boolean;
   events?: EventPropTypeInterface<VictoryBarTTargetType, number | string | number[] | string[]>[];
   eventKey?: StringOrNumberOrCallback;
   horizontal?: boolean;
@@ -58,6 +59,7 @@ export interface BarProps extends VictoryCommonPrimitiveProps {
         bottomRight?: NumberOrCallback;
       };
   datum?: any;
+  disableInlineStyles?: boolean;
   getPath?: Function;
   horizontal?: boolean;
   pathComponent?: React.ReactElement;

--- a/packages/victory-bar/src/victory-bar.js
+++ b/packages/victory-bar/src/victory-bar.js
@@ -68,6 +68,7 @@ class VictoryBar extends React.Component {
         bottomRight: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
       })
     ]),
+    disableInlineStyles: PropTypes.bool,
     getPath: PropTypes.func,
     horizontal: PropTypes.bool
   };

--- a/packages/victory-core/src/victory-label/victory-label.js
+++ b/packages/victory-core/src/victory-label/victory-label.js
@@ -59,6 +59,9 @@ const useMultiLineBackgrounds = (props) => {
 };
 
 const getStyles = (style, props) => {
+  if (props.disableInlineStyles) {
+    return {};
+  }
   const getSingleStyle = (s) => {
     s = s ? defaults({}, s, defaultStyles) : defaultStyles;
     const baseStyles = Helpers.evaluateStyle(s, props);

--- a/packages/victory-core/src/victory-util/label-helpers.js
+++ b/packages/victory-core/src/victory-util/label-helpers.js
@@ -166,7 +166,7 @@ function getDegrees(props, datum) {
 }
 
 function getProps(props, index) {
-  const { scale, data, style, horizontal, polar, width, height, theme, labelComponent } = props;
+  const { scale, data, style, horizontal, polar, width, height, theme, labelComponent, disableInlineStyles } = props;
   const datum = data[index];
   const degrees = getDegrees(props, datum);
   const textAnchor = polar ? getPolarTextAnchor(props, degrees) : getTextAnchor(props, datum);
@@ -182,6 +182,7 @@ function getProps(props, index) {
     angle,
     data,
     datum,
+    disableInlineStyles,
     horizontal,
     index,
     polar,

--- a/packages/victory-core/src/victory-util/label-helpers.js
+++ b/packages/victory-core/src/victory-util/label-helpers.js
@@ -166,7 +166,18 @@ function getDegrees(props, datum) {
 }
 
 function getProps(props, index) {
-  const { scale, data, style, horizontal, polar, width, height, theme, labelComponent, disableInlineStyles } = props;
+  const {
+    scale,
+    data,
+    style,
+    horizontal,
+    polar,
+    width,
+    height,
+    theme,
+    labelComponent,
+    disableInlineStyles
+  } = props;
   const datum = data[index];
   const degrees = getDegrees(props, datum);
   const textAnchor = polar ? getPolarTextAnchor(props, degrees) : getTextAnchor(props, datum);

--- a/stories/victory-bar.stories.js
+++ b/stories/victory-bar.stories.js
@@ -1,7 +1,7 @@
 /*eslint-disable no-magic-numbers*/
 /*eslint-disable react/no-multi-comp*/
 import React from "react";
-import { VictoryBar } from "../packages/victory-bar/src";
+import { VictoryBar, Bar } from "../packages/victory-bar/src";
 import { VictoryChart } from "../packages/victory-chart/src";
 import { VictoryGroup } from "../packages/victory-group/src/index";
 import { VictoryStack } from "../packages/victory-stack/src/index";
@@ -932,6 +932,19 @@ export const Domain = () => {
       </VictoryChart>
       <VictoryChart style={parentStyle} maxDomain={{ x: 4 }}>
         <VictoryBar data={getData(7)} />
+      </VictoryChart>
+    </div>
+  );
+};
+
+export const DisableInlineStyles = () => {
+  return (
+    <div style={containerStyle}>
+      <VictoryChart>
+        <VictoryBar disableInlineStyles />
+      </VictoryChart>
+      <VictoryChart>
+        <VictoryBar dataComponent={<Bar disableInlineStyles />} />
       </VictoryChart>
     </div>
   );


### PR DESCRIPTION
This adds a `disableInlineStyles` prop to `Bar` and `VictoryBar`. I'm not sure that the prop on `VictoryBar` does what it should do. Could you point me in the right direction as to where I can pass it down to the `Bar` component?