### PR TITLE
experimental domainPadding change

### DIFF
--- a/docs/src/data/basketball-data.js
+++ b/docs/src/data/basketball-data.js
@@ -1,5 +1,5 @@
 export default {
-  "1990": [
+  1990: [
     {
       player: "Michael Jordan",
       "3pa": 1.1
@@ -621,7 +621,7 @@ export default {
       "3pa": 0
     }
   ],
-  "1991": [
+  1991: [
     {
       player: "Michael Jordan",
       "3pa": 1.3
@@ -1215,7 +1215,7 @@ export default {
       "3pa": 0
     }
   ],
-  "1992": [
+  1992: [
     {
       player: "Michael Jordan",
       "3pa": 2.9
@@ -1801,7 +1801,7 @@ export default {
       "3pa": 0.1
     }
   ],
-  "1993": [
+  1993: [
     {
       player: "David Robinson",
       "3pa": 0.4
@@ -2383,7 +2383,7 @@ export default {
       "3pa": 0
     }
   ],
-  "1994": [
+  1994: [
     {
       player: "Shaquille O'Neal",
       "3pa": 0.1
@@ -2937,7 +2937,7 @@ export default {
       "3pa": 0
     }
   ],
-  "1995": [
+  1995: [
     {
       player: "Michael Jordan",
       "3pa": 3.2
@@ -3551,7 +3551,7 @@ export default {
       "3pa": 0
     }
   ],
-  "1996": [
+  1996: [
     {
       player: "Michael Jordan",
       "3pa": 3.6
@@ -4097,7 +4097,7 @@ export default {
       "3pa": 0
     }
   ],
-  "1997": [
+  1997: [
     {
       player: "Michael Jordan",
       "3pa": 1.5
@@ -4679,7 +4679,7 @@ export default {
       "3pa": 0.8
     }
   ],
-  "1998": [
+  1998: [
     {
       player: "Allen Iverson",
       "3pa": 4.1
@@ -5305,7 +5305,7 @@ export default {
       "3pa": 0
     }
   ],
-  "1999": [
+  1999: [
     {
       player: "Shaquille O'Neal",
       "3pa": 0
@@ -5899,7 +5899,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2000": [
+  2000: [
     {
       player: "Allen Iverson",
       "3pa": 4.3
@@ -6497,7 +6497,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2001": [
+  2001: [
     {
       player: "Allen Iverson",
       "3pa": 4.5
@@ -7091,7 +7091,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2002": [
+  2002: [
     {
       player: "Tracy McGrady",
       "3pa": 6
@@ -7693,7 +7693,7 @@ export default {
       "3pa": 0.5
     }
   ],
-  "2003": [
+  2003: [
     {
       player: "Tracy McGrady",
       "3pa": 7.7
@@ -8279,7 +8279,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2004": [
+  2004: [
     {
       player: "Allen Iverson",
       "3pa": 4.5
@@ -8829,7 +8829,7 @@ export default {
       "3pa": 0.6
     }
   ],
-  "2005": [
+  2005: [
     {
       player: "Kobe Bryant",
       "3pa": 6.5
@@ -9423,7 +9423,7 @@ export default {
       "3pa": 0.2
     }
   ],
-  "2006": [
+  2006: [
     {
       player: "Kobe Bryant",
       "3pa": 5.2
@@ -10037,7 +10037,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2007": [
+  2007: [
     {
       player: "LeBron James",
       "3pa": 4.8
@@ -10679,7 +10679,7 @@ export default {
       "3pa": 0.1
     }
   ],
-  "2008": [
+  2008: [
     {
       player: "Dwyane Wade",
       "3pa": 3.5
@@ -11265,7 +11265,7 @@ export default {
       "3pa": 0.1
     }
   ],
-  "2009": [
+  2009: [
     {
       player: "Kevin Durant",
       "3pa": 4.3
@@ -11895,7 +11895,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2010": [
+  2010: [
     {
       player: "Kevin Durant",
       "3pa": 5.3
@@ -12525,7 +12525,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2011": [
+  2011: [
     {
       player: "Kevin Durant",
       "3pa": 5.2
@@ -13135,7 +13135,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2012": [
+  2012: [
     {
       player: "Carmelo Anthony",
       "3pa": 6.2
@@ -13733,7 +13733,7 @@ export default {
       "3pa": 0
     }
   ],
-  "2013": [
+  2013: [
     {
       player: "Kevin Durant",
       "3pa": 6.1
@@ -14483,7 +14483,7 @@ export default {
       "3pa": 2.9
     }
   ],
-  "2014": [
+  2014: [
     {
       player: "Russell Westbrook",
       "3pa": 4.3
@@ -15265,7 +15265,7 @@ export default {
       "3pa": 2.5
     }
   ],
-  "2015": [
+  2015: [
     {
       player: "Stephen Curry",
       "3pa": 11.2
@@ -16059,7 +16059,7 @@ export default {
       "3pa": 0.8
     }
   ],
-  "2016": [
+  2016: [
     {
       player: "Russell Westbrook",
       "3pa": 7.2
@@ -16833,7 +16833,7 @@ export default {
       "3pa": 2.4
     }
   ],
-  "2017": [
+  2017: [
     {
       player: "James Harden",
       "3pa": 10
@@ -17587,7 +17587,7 @@ export default {
       "3pa": 2.4
     }
   ],
-  "2018": [
+  2018: [
     {
       player: "James Harden",
       "3pa": 13.2
@@ -18357,7 +18357,7 @@ export default {
       "3pa": 2.6
     }
   ],
-  "2019": [
+  2019: [
     {
       player: "James Harden",
       "3pa": 12.6

--- a/packages/victory-core/src/victory-util/domain.js
+++ b/packages/victory-core/src/victory-util/domain.js
@@ -81,11 +81,12 @@ function padDomain(domain, props, axis) {
   const rangeExtent = Math.abs(range[0] - range[1]);
 
   const paddedRangeExtent = Math.max(rangeExtent - padding.left - padding.right, 1);
-  const paddedDomainExtent = (Math.abs(max.valueOf() - min.valueOf()) / paddedRangeExtent) * rangeExtent;
+  const paddedDomainExtent =
+    (Math.abs(max.valueOf() - min.valueOf()) / paddedRangeExtent) * rangeExtent;
 
   const simplePadding = {
-    left: paddedDomainExtent * padding.left / rangeExtent,
-    right: paddedDomainExtent * padding.right / rangeExtent
+    left: (paddedDomainExtent * padding.left) / rangeExtent,
+    right: (paddedDomainExtent * padding.right) / rangeExtent
   };
 
   let paddedDomain = {
@@ -105,7 +106,7 @@ function padDomain(domain, props, axis) {
     return coerce ? 0 : val;
   };
 
-  if (addsQuadrants && singleQuadrantDomainPadding) {
+  if (addsQuadrants && singleQuadrantDomainPadding !== false) {
     // Naive initial padding calculation
     const initialPadding = {
       left: (Math.abs(max - min) * padding.left) / rangeExtent,
@@ -113,16 +114,16 @@ function padDomain(domain, props, axis) {
     };
 
     // Adjust the domain by the initial padding
-  const adjustedDomain = {
-    min: adjust(min.valueOf() - initialPadding.left, "min"),
-    max: adjust(max.valueOf() + initialPadding.right, "max")
-  };
+    const adjustedDomain = {
+      min: adjust(min.valueOf() - initialPadding.left, "min"),
+      max: adjust(max.valueOf() + initialPadding.right, "max")
+    };
 
-  // re-calculate padding, taking the adjusted domain into account
-  const finalPadding = {
-    left: (Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.left) / rangeExtent,
-    right: (Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.right) / rangeExtent
-  };
+    // re-calculate padding, taking the adjusted domain into account
+    const finalPadding = {
+      left: (Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.left) / rangeExtent,
+      right: (Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.right) / rangeExtent
+    };
 
     // Adjust the domain by the final padding
     paddedDomain = {
@@ -130,7 +131,6 @@ function padDomain(domain, props, axis) {
       max: adjust(max.valueOf() + finalPadding.right, "max")
     };
   }
-
 
   // default to minDomain / maxDomain if they exist
   const finalDomain = {

--- a/packages/victory-core/src/victory-util/domain.js
+++ b/packages/victory-core/src/victory-util/domain.js
@@ -80,26 +80,39 @@ function padDomain(domain, props, axis) {
   const range = Helpers.getRange(props, currentAxis);
   const rangeExtent = Math.abs(range[0] - range[1]);
 
-  // Naive initial padding calculation
-  const initialPadding = {
-    left: (Math.abs(max - min) * padding.left) / rangeExtent,
-    right: (Math.abs(max - min) * padding.right) / rangeExtent
+  const paddedRangeExtent = Math.max(rangeExtent - padding.left - padding.right, 1);
+  const paddedDomainExtent = (Math.abs(max.valueOf() - min.valueOf()) / paddedRangeExtent) * rangeExtent;
+
+  const simplePadding = {
+    left: paddedDomainExtent * padding.left / rangeExtent,
+    right: paddedDomainExtent * padding.right / rangeExtent
+  };
+
+  let paddedDomain = {
+    min: min.valueOf() - simplePadding.left,
+    max: max.valueOf() + simplePadding.right
   };
 
   const singleQuadrantDomainPadding = isPlainObject(props.singleQuadrantDomainPadding)
     ? props.singleQuadrantDomainPadding[axis]
     : props.singleQuadrantDomainPadding;
 
+  const addsQuadrants = (min >= 0 && paddedDomain.min <= 0) || (max <= 0 && paddedDomain.max >= 0);
+
   const adjust = (val, type) => {
-    if (singleQuadrantDomainPadding === false) {
-      return val;
-    }
     const coerce =
       (type === "min" && min >= 0 && val <= 0) || (type === "max" && max <= 0 && val >= 0);
     return coerce ? 0 : val;
   };
 
-  // Adjust the domain by the initial padding
+  if (addsQuadrants && singleQuadrantDomainPadding) {
+    // Naive initial padding calculation
+    const initialPadding = {
+      left: (Math.abs(max - min) * padding.left) / rangeExtent,
+      right: (Math.abs(max - min) * padding.right) / rangeExtent
+    };
+
+    // Adjust the domain by the initial padding
   const adjustedDomain = {
     min: adjust(min.valueOf() - initialPadding.left, "min"),
     max: adjust(max.valueOf() + initialPadding.right, "max")
@@ -111,11 +124,13 @@ function padDomain(domain, props, axis) {
     right: (Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.right) / rangeExtent
   };
 
-  // Adjust the domain by the final padding
-  const paddedDomain = {
-    min: adjust(min.valueOf() - finalPadding.left, "min"),
-    max: adjust(max.valueOf() + finalPadding.right, "max")
-  };
+    // Adjust the domain by the final padding
+    paddedDomain = {
+      min: adjust(min.valueOf() - finalPadding.left, "min"),
+      max: adjust(max.valueOf() + finalPadding.right, "max")
+    };
+  }
+
 
   // default to minDomain / maxDomain if they exist
   const finalDomain = {

--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -123,8 +123,12 @@ export default {
             isContinuous(child) || (child.props.children && isContinuous(child.props.children))
           );
         });
-      const { nodesWillExit, nodesWillEnter, childrenTransitions, nodesShouldEnter } =
-        Transitions.getInitialTransitionState(oldChildren, nextChildren);
+      const {
+        nodesWillExit,
+        nodesWillEnter,
+        childrenTransitions,
+        nodesShouldEnter
+      } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
 
       this.setState({
         nodesWillExit,

--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -341,11 +341,11 @@ export default {
       childRole === "stack" ? undefined : this.getColor(calculatedProps, child, index);
     const defaultColor =
       childRole === "line" ? { fill: "none", stroke: defaultFill } : { fill: defaultFill };
-    const dataWidth = role === "stack" ? {} : this.getWidth(calculatedProps);
+    const dataWidth = role === "stack" ? {} : { width: this.getWidth(calculatedProps) };
     const dataStyle = defaults(
       {},
       childStyle.data,
-      assign({}, { width: dataWidth }, style.data, defaultColor)
+      assign({}, dataWidth, style.data, defaultColor)
     );
     const labelsStyle = defaults({}, childStyle.labels, style.labels);
     return {

--- a/stories/victory-bar.stories.js
+++ b/stories/victory-bar.stories.js
@@ -614,35 +614,35 @@ export const StackedBars = () => {
 export const GroupedBars = () => {
   return (
     <div style={containerStyle}>
-      <VictoryChart {...defaultChartProps} domainPadding={30}>
+      <VictoryChart {...defaultChartProps}>
         <VictoryGroup offset={20} labels={({ datum }) => datum.x}>
           <VictoryBar data={getData(3)} />
           <VictoryBar data={getData(3, "seed-1")} />
           <VictoryBar data={getData(3, "seed-2")} />
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart {...defaultChartProps} domainPadding={30}>
+      <VictoryChart {...defaultChartProps}>
         <VictoryGroup offset={10} labels={({ datum }) => datum.x}>
           <VictoryBar data={getData(5)} />
           <VictoryBar data={getData(3, "seed-1")} />
           <VictoryBar data={getData(2, "seed-2")} />
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart {...defaultChartProps} domainPadding={30}>
+      <VictoryChart {...defaultChartProps}>
         <VictoryGroup offset={20} labels={({ datum }) => datum.x}>
           <VictoryBar data={getMixedData(3)} />
           <VictoryBar data={getMixedData(3, "seed")} />
           <VictoryBar data={getMixedData(3, "seed-1")} />
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart horizontal {...defaultChartProps} domainPadding={30}>
+      <VictoryChart horizontal {...defaultChartProps}>
         <VictoryGroup offset={20} labels={({ datum }) => datum.x}>
           <VictoryBar data={getMixedData(3)} />
           <VictoryBar data={getMixedData(3, "seed")} />
           <VictoryBar data={getMixedData(3, "seed-1")} />
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart {...defaultChartProps} domainPadding={30}>
+      <VictoryChart {...defaultChartProps}>
         <VictoryGroup
           offset={20}
           labels={({ datum }) => datum.x}
@@ -653,7 +653,7 @@ export const GroupedBars = () => {
           <VictoryBar data={getMixedData(3, "seed-1")} />
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart horizontal {...defaultChartProps} domainPadding={30}>
+      <VictoryChart horizontal {...defaultChartProps}>
         <VictoryGroup
           offset={20}
           labels={({ datum }) => datum.x}
@@ -664,7 +664,7 @@ export const GroupedBars = () => {
           <VictoryBar data={getMixedData(3, "seed-1")} />
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart {...defaultChartProps} domainPadding={30}>
+      <VictoryChart {...defaultChartProps}>
         <VictoryGroup offset={20} labels={({ datum }) => datum.x} style={{ data: { width: 15 } }}>
           <VictoryStack colorScale="red">
             <VictoryBar data={getData(3)} />
@@ -683,7 +683,7 @@ export const GroupedBars = () => {
           </VictoryStack>
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart horizontal {...defaultChartProps} domainPadding={30}>
+      <VictoryChart horizontal {...defaultChartProps}>
         <VictoryGroup offset={20} labels={({ datum }) => datum.x} style={{ data: { width: 15 } }}>
           <VictoryStack colorScale="red">
             <VictoryBar data={getData(3)} />
@@ -702,49 +702,49 @@ export const GroupedBars = () => {
           </VictoryStack>
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart {...defaultChartProps} domainPadding={30}>
+      <VictoryChart {...defaultChartProps}>
         <VictoryGroup
           offset={20}
           labels={({ datum }) => datum.x}
           labelComponent={<VictoryTooltip active />}
         >
           <VictoryStack colorScale="red">
-            <VictoryBar data={getMixedData(3)} />
-            <VictoryBar data={getMixedData(3, "seed-1")} />
-            <VictoryBar data={getMixedData(3, "seed-2")} />
+            <VictoryBar data={getMixedData(3)} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-1")} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-2")} barWidth={6} />
           </VictoryStack>
           <VictoryStack colorScale="green">
-            <VictoryBar data={getMixedData(3)} />
-            <VictoryBar data={getMixedData(3, "seed-3")} />
-            <VictoryBar data={getMixedData(3, "seed-4")} />
+            <VictoryBar data={getMixedData(3)} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-3")} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-4")} barWidth={6} />
           </VictoryStack>
           <VictoryStack colorScale="blue">
-            <VictoryBar data={getMixedData(3)} />
-            <VictoryBar data={getMixedData(3, "seed-5")} />
-            <VictoryBar data={getMixedData(3, "seed-6")} />
+            <VictoryBar data={getMixedData(3)} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-5")} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-6")} barWidth={6} />
           </VictoryStack>
         </VictoryGroup>
       </VictoryChart>
-      <VictoryChart horizontal {...defaultChartProps} domainPadding={30}>
+      <VictoryChart horizontal {...defaultChartProps}>
         <VictoryGroup
           offset={20}
           labels={({ datum }) => datum.x}
           labelComponent={<VictoryTooltip active />}
         >
           <VictoryStack colorScale="red">
-            <VictoryBar data={getMixedData(3)} />
-            <VictoryBar data={getMixedData(3, "seed-1")} />
-            <VictoryBar data={getMixedData(3, "seed-2")} />
+            <VictoryBar data={getMixedData(3)} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-1")} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-2")} barWidth={6} />
           </VictoryStack>
           <VictoryStack colorScale="green">
-            <VictoryBar data={getMixedData(3)} />
-            <VictoryBar data={getMixedData(3, "seed-3")} />
-            <VictoryBar data={getMixedData(3, "seed-4")} />
+            <VictoryBar data={getMixedData(3)} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-3")} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-4")} barWidth={6} />
           </VictoryStack>
           <VictoryStack colorScale="blue">
-            <VictoryBar data={getMixedData(3)} />
-            <VictoryBar data={getMixedData(3, "seed-5")} />
-            <VictoryBar data={getMixedData(3, "seed-6")} />
+            <VictoryBar data={getMixedData(3)} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-5")} barWidth={6} />
+            <VictoryBar data={getMixedData(3, "seed-6")} barWidth={6} />
           </VictoryStack>
         </VictoryGroup>
       </VictoryChart>


### PR DESCRIPTION
This PR:

- updates how `domainPadding` is applied to charts when 1) the additional padding _would not_ result new quadradants being added, or 2) the user has set `singleQuadrantDomainPadding={false}`. In these cases, `domainPadding` is applied by calculating a new, smaller range that takes the desired, pixel-based padding into account, and then adding domain padding such that the previous domain fits entirely within the new, smaller range. In most cases, this change will make it much easier to do things like create bar charts where the first bar starts cleanly at the edge of the chart, by setting `domainPadding={{ x: myBarWidth / 2 }}`
**This may cause visual changes for charts that use very large values for `domainPadding`. The `domainPadding` prop may need to be adjusted**

- calculates a more exact `defaultDomainPadding` for grouped bar charts based on the `offset`, number of bars, and the width of each bar (either from the `barWidth` prop or from a default `barWidth` based on the number of bars and the range). Previously, `defaultDomainPadding` was approximated based only on `offset` and number of bars. 