### PR TITLE
use y1 for min domain check if it exists

### DIFF
--- a/packages/victory-core/src/victory-util/data.js
+++ b/packages/victory-core/src/victory-util/data.js
@@ -118,7 +118,7 @@ function formatDataFromDomain(dataset, domain, defaultBaseline) {
     if (isUnderMinX(_x) || isOverMaxX(_x)) _x = null;
 
     const baseline = exists(_y0) ? _y0 : defaultBaseline;
-    const value = exists(_y) ? _y : _y1;
+    const value = exists(_y1) ? _y1 : _y;
 
     if (!exists(value)) return datum;
 


### PR DESCRIPTION
Fixes a regression in stacked bar charts that have `minDomain` values set. With this change, the `minDomain` is compared against the stacked `_y1` value for each bar rather than the original (unstacked) `_y` value.