### PR TITLE
added function to the victory area interpolation prop type

### DIFF
--- a/packages/victory-area/src/index.d.ts
+++ b/packages/victory-area/src/index.d.ts
@@ -18,7 +18,7 @@ export interface VictoryAreaProps
     VictoryMultiLabelableProps {
   eventKey?: string[] | number[] | StringOrNumberOrCallback;
   events?: EventPropTypeInterface<VictoryAreaTTargetType, string | number>[];
-  interpolation?: InterpolationPropType;
+  interpolation?: InterpolationPropType | Function;
   samples?: number;
   style?: VictoryStyleInterface;
 }


### PR DESCRIPTION
This PR fixes https://github.com/FormidableLabs/victory/issues/1864 issue. The function interpolation indeed already works, only type needed updating. 

Let me know if PR needs some updating.