### PR TITLE
correct axis offsets for multi-quadrant charts

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,7 +9,6 @@ on:
     paths:
       - 'stories/**'
       - 'packages/**'
-    types: [ready_for_review]
 
 jobs:
   chromatic:

--- a/packages/victory-axis/src/helper-methods.js
+++ b/packages/victory-axis/src/helper-methods.js
@@ -8,6 +8,8 @@ const orientationSign = {
   bottom: 1
 };
 
+const exists = (val) => val !== null && val !== undefined;
+
 const getCurrentAxis = (props, axis) => {
   const { orientation, horizontal } = props;
   if (orientation) {
@@ -243,8 +245,8 @@ const getOffset = (props, calculatedValues) => {
 
   const x = originPosition.x ? Math.abs(originOffset.x - originPosition.x) : orientationOffset.x;
   const y = originPosition.y ? Math.abs(originOffset.y - originPosition.y) : orientationOffset.y;
-  const offsetX = props.offsetX !== null && props.offsetX !== undefined ? x - props.offsetX : x;
-  const offsetY = props.offsetY !== null && props.offsetY !== undefined ? y - props.offsetY : y;
+  const offsetX = exists(props.offsetX) ? props.offsetX : x;
+  const offsetY = exists(props.offsetY) ? props.offsetY : y;
 
   return {
     x: offsetX,
@@ -278,8 +280,8 @@ const getHorizontalOffset = (props, calculatedValues) => {
 
   const y = originPosition.x ? Math.abs(originOffset.x - originPosition.x) : orientationOffset.x;
   const x = originPosition.y ? Math.abs(originOffset.y - originPosition.y) : orientationOffset.y;
-  const offsetX = props.offsetX !== null && props.offsetX !== undefined ? x - props.offsetX : x;
-  const offsetY = props.offsetY !== null && props.offsetY !== undefined ? y - props.offsetY : y;
+  const offsetX = exists(props.offsetX) ? props.offsetX : x;
+  const offsetY = exists(props.offsetY) ? props.offsetY : y;
 
   return {
     x: offsetX,


### PR DESCRIPTION
fixes https://github.com/FormidableLabs/victory/issues/1861

This PR corrects an regression introduced in https://github.com/FormidableLabs/victory/pull/1835. Rather than being relative to the origin position, the `offsetX` and `offsetY` props should be relative to the edge of the chart svg.