### PR TITLE
use domain min rather than zero for _voronoi point when voronoiDimens…

### DIFF
--- a/demo/js/components/victory-voronoi-container-demo.js
+++ b/demo/js/components/victory-voronoi-container-demo.js
@@ -13,6 +13,26 @@ import { Flyout, VictoryTooltip } from "Packages/victory-tooltip/src/index";
 import { VictoryLegend } from "Packages/victory-legend/src/index";
 import { VictoryLabel, VictoryTheme } from "Packages/victory-core/src/index";
 
+const series1 = [
+  { x: 0, y: 2500 },
+  { x: 2, y: 3300 },
+  { x: 4, y: 4300 },
+  { x: 6, y: 2400 },
+  { x: 8, y: 3300 },
+  { x: 10, y: 5400 },
+  { x: 12, y: 8900 }
+];
+
+const series2 = [
+  { x: 0, y: 200 },
+  { x: 2, y: 3100 },
+  { x: 4, y: 2500 },
+  { x: 6, y: 870 },
+  { x: 8, y: 2300 },
+  { x: 10, y: 550 },
+  { x: 12, y: 5200 }
+];
+
 class App extends React.Component {
   constructor() {
     super();
@@ -82,6 +102,22 @@ class App extends React.Component {
     return (
       <div className="demo">
         <div style={containerStyle}>
+          <VictoryChart
+            style={chartStyle}
+            scale={{ y: "log" }}
+            containerComponent={
+              <VictoryVoronoiContainer
+                voronoiDimension="x"
+                labels={({ datum }) => `y: ${datum.y}`}
+              />
+            }
+          >
+            <VictoryScatter
+              style={{ data: { fill: "red" }, labels: { fill: "red" } }}
+              data={series1}
+            />
+            <VictoryScatter data={series2} />
+          </VictoryChart>
           <VictoryChart
             style={chartStyle}
             domain={{ y: [0, 6] }}

--- a/packages/victory-voronoi-container/src/voronoi-helpers.js
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.js
@@ -1,4 +1,4 @@
-import { Selection, Data, Helpers } from "victory-core";
+import { Collection, Selection, Data, Helpers } from "victory-core";
 import { assign, throttle, isFunction, isEmpty, includes, isString, isRegExp } from "lodash";
 import isEqual from "react-fast-compare";
 import Delaunay from "delaunay-find/lib/index.js";
@@ -24,6 +24,10 @@ const VoronoiHelpers = {
   },
 
   getDatasets(props) {
+    const minDomain = {
+      x: Collection.getMinValue(props.domain.x),
+      y: Collection.getMinValue(props.domain.y)
+    };
     const children = React.Children.toArray(props.children);
     const addMeta = (data, name, child) => {
       const continuous = child && child.type && child.type.continuous;
@@ -32,10 +36,11 @@ const VoronoiHelpers = {
         const { x, y, y0, x0 } = Helpers.getPoint(datum);
         const voronoiX = (+x + +x0) / 2;
         const voronoiY = (+y + +y0) / 2;
+
         return assign(
           {
-            _voronoiX: props.voronoiDimension === "y" ? 0 : voronoiX,
-            _voronoiY: props.voronoiDimension === "x" ? 0 : voronoiY,
+            _voronoiX: props.voronoiDimension === "y" ? minDomain.x : voronoiX,
+            _voronoiY: props.voronoiDimension === "x" ? minDomain.y : voronoiY,
             eventKey: index,
             childName: name,
             continuous,


### PR DESCRIPTION
…ion is given

Fixes https://github.com/FormidableLabs/victory/issues/1857


VictoryVoronoiContainer sets _voronoiX and _voronoiY points for each datum that are used to calculate the set of nearest points, When a voronoiDimension is given, the opposite dimension voronoi point is always set to zero, which works fine for normal scales, but breaks log scales.

This PR uses the domain min rather than zero for the default voronoi point