### PR TITLE
add missing allowDraw property

### DIFF
--- a/packages/victory-brush-container/src/index.d.ts
+++ b/packages/victory-brush-container/src/index.d.ts
@@ -3,6 +3,7 @@ import { DomainTuple, VictoryContainerProps } from "victory-core";
 
 export interface VictoryBrushContainerProps extends VictoryContainerProps {
   allowDrag?: boolean;
+  allowDraw?: boolean;
   allowResize?: boolean;
   brushComponent?: React.ReactElement;
   brushDimension?: "x" | "y";


### PR DESCRIPTION
VictoryBrushComponentProps.allowDraw? missing from types.

Documented [here](https://formidable.com/open-source/victory/docs/victory-brush-container/#allowdraw) and [in props](https://github.com/FormidableLabs/victory/blob/753f0df6266dbc305cec443c7746298e93f4a207/packages/victory-brush-container/src/victory-brush-container.js#L14)
