### PR TITLE
downgrade d3-array

### DIFF
--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -19,7 +19,7 @@
   "author": "Formidable",
   "license": "MIT",
   "dependencies": {
-    "d3-array": "^2.4.0",
+    "d3-array": "~2.3.0",
     "d3-scale": "^1.0.0",
     "lodash": "^4.17.19",
     "prop-types": "^15.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5489,9 +5489,10 @@ d3-array@^1.2.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
 
-d3-array@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
+d3-array@~2.3.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.3.3.tgz#e90c39fbaedccedf59fc30473092f99a0e14efa2"
+  integrity sha512-syv3wp0U5aB6toP2zb2OdBkhTy1MWDsCAaYk6OXJZv+G4u7bSWEmYgxLoFyc88RQUhZYGCebW9a9UD1gFi5+MQ==
 
 d3-collection@1:
   version "1.0.7"


### PR DESCRIPTION
Downgrades `d3-array` to the version prior to the offending `cumsum` function was introduced.

This is a temporary solution until the problem is solved upstream

fixes https://github.com/FormidableLabs/victory/issues/1877
fixes https://github.com/FormidableLabs/victory-native/issues/653