### PR TITLE
Custom scale documentation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://github.com/FormidableLabs/victory-docs#readme",
   "dependencies": {
+    "@d3fc/d3fc-discontinuous-scale": "^4.0.2",
     "@juggle/resize-observer": "^3.0.2",
     "axios": "^0.19.2",
     "babel-standalone": "^6.26.0",

--- a/docs/src/content/common-props/common-props.md
+++ b/docs/src/content/common-props/common-props.md
@@ -685,6 +685,8 @@ _default:_ `samples={50}`
 
 The `scale` prop determines which scales your chart should use. In this case, scale refers to the d3 scale that is used inside Victory to determine he placement of data, ticks, and labels. A scale type can be either a string ("linear", "time", "log", "sqrt"), or a custom d3 scale function. This prop can be passed as a single scale, or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` instances.
 
+This prop should be set at the top-level of the chart in order to avoid being overwritten by the default value. In other words, unless an individual chart component is being used as a standalone component (without a `VictoryChart` wrapper), this prop should be added to the `VictoryChart` component. 
+
 _note:_ The `x` value supplied to the `scale` prop refers to the _independent_ variable, and the `y` value refers to the _dependent_ variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to the y axis.
 
 _default:_ `scale="linear"`
@@ -705,7 +707,7 @@ _examples:_
   />
 </VictoryChart>
 ```
-In this example, a discontinous scale plugin from d3fc can be used to create a custom scale function to skip weekends along the x-axis. 
+In this example, a [discontinous scale plugin from d3fc](https://github.com/d3fc/d3fc/blob/master/packages/d3fc-discontinuous-scale/README.md) can be used to create a custom scale function to skip weekends along the x-axis. 
 
 _note_: The data set has already been filtered to only include weekdays. 
 

--- a/docs/src/content/common-props/common-props.md
+++ b/docs/src/content/common-props/common-props.md
@@ -6,6 +6,9 @@ type: docs
 scope:
   - range
   - sampleData
+  - d3Scale
+  - scaleDiscontinuous
+  - discontinuitySkipWeekends
 ---
 
 # Common Props
@@ -680,7 +683,7 @@ _default:_ `samples={50}`
 
 `type: scale || { x: scale, y: scale }`
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` instances.
+The `scale` prop determines which scales your chart should use. In this case, scale refers to the d3 scale that is used inside Victory to determine he placement of data, ticks, and labels. A scale type can be either a string ("linear", "time", "log", "sqrt"), or a custom d3 scale function. This prop can be passed as a single scale, or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` instances.
 
 _note:_ The `x` value supplied to the `scale` prop refers to the _independent_ variable, and the `y` value refers to the _dependent_ variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to the y axis.
 
@@ -701,6 +704,40 @@ _examples:_
     y={(d) => Math.pow(1 - d.x, 10)}
   />
 </VictoryChart>
+```
+In this example, a discontinous scale plugin from d3fc can be used to create a custom scale function to skip weekends along the x-axis. 
+
+_note_: The data set has already been filtered to only include weekdays. 
+
+```playground_norender
+function App() {
+  const data = [
+    { x: new Date(2021, 5, 1), y: 8 },
+    { x: new Date(2021, 5, 2), y: 10 },
+    { x: new Date(2021, 5, 3), y: 7 },
+    { x: new Date(2021, 5, 4), y: 4 },
+    { x: new Date(2021, 5, 7), y: 6 },
+    { x: new Date(2021, 5, 8), y: 3 },
+    { x: new Date(2021, 5, 9), y: 7 },
+    { x: new Date(2021, 5, 10), y: 9 },
+    { x: new Date(2021, 5, 11), y: 6 }
+  ];
+
+  const discontinuousScale = scaleDiscontinuous(
+    d3Scale.scaleTime()
+  ).discontinuityProvider(discontinuitySkipWeekends());
+
+  return (
+    <VictoryChart scale={{ x: discontinuousScale }}>
+      <VictoryArea 
+        data={data} 
+        style={{data: { fill: 'lightblue', stroke: 'teal' }}} 
+      />
+    </VictoryChart>
+  );
+}
+
+ReactDOM.render(<App />, mountNode);
 ```
 
 ## sharedEvents

--- a/docs/src/content/gallery/discontinuous-scale.md
+++ b/docs/src/content/gallery/discontinuous-scale.md
@@ -21,6 +21,8 @@ function App() {
     { x: new Date(2021, 5, 11), y: 6 }
   ];
 
+  // scaleDiscontinuous and discontinuitySkipWeekends are both
+  // plugins imported from @d3fc/d3fc-discontinuous-scale
   const discontinuousScale = scaleDiscontinuous(
     d3Scale.scaleTime()
   ).discontinuityProvider(discontinuitySkipWeekends());

--- a/docs/src/content/gallery/discontinuous-scale.md
+++ b/docs/src/content/gallery/discontinuous-scale.md
@@ -1,0 +1,43 @@
+---
+id: 26
+title: Discontinuous Scale
+scope:
+  - d3Scale
+  - scaleDiscontinuous
+  - discontinuitySkipWeekends
+---
+
+```playground_norender
+function App() {
+  const data = [
+    { x: new Date(2021, 5, 1), y: 8 },
+    { x: new Date(2021, 5, 2), y: 10 },
+    { x: new Date(2021, 5, 3), y: 7 },
+    { x: new Date(2021, 5, 4), y: 4 },
+    { x: new Date(2021, 5, 7), y: 6 },
+    { x: new Date(2021, 5, 8), y: 3 },
+    { x: new Date(2021, 5, 9), y: 7 },
+    { x: new Date(2021, 5, 10), y: 9 },
+    { x: new Date(2021, 5, 11), y: 6 }
+  ];
+
+  const discontinuousScale = scaleDiscontinuous(
+    d3Scale.scaleTime()
+  ).discontinuityProvider(discontinuitySkipWeekends());
+
+  return (
+    <VictoryChart 
+      width={400} 
+      height={400} 
+      scale={{ x: discontinuousScale }}
+    >
+      <VictoryArea 
+        data={data} 
+        style={{data: { fill: 'lightblue', stroke: 'teal' }}} 
+      />
+    </VictoryChart>
+  );
+}
+
+ReactDOM.render(<App />, mountNode);
+```

--- a/docs/src/pages/gallery.js
+++ b/docs/src/pages/gallery.js
@@ -5,6 +5,8 @@ import ReactDOM from "react-dom";
 import { withRouteData } from "react-static";
 import { Link } from "react-router-dom";
 import * as Victory from "victory";
+import * as d3Scale from 'd3-scale';
+import { scaleDiscontinuous, discontinuitySkipWeekends } from "@d3fc/d3fc-discontinuous-scale";
 
 import createPath from "../helpers/path-helpers";
 import Page from "../partials/page";
@@ -101,7 +103,10 @@ const Gallery = ({ gallery, sidebarContent }) => {
                 PropTypes,
                 Slider,
                 basketballData,
-                listeningData
+                listeningData,
+                d3Scale,
+                scaleDiscontinuous,
+                discontinuitySkipWeekends
               }}
             />
           )}

--- a/docs/src/partials/markdown/index.js
+++ b/docs/src/partials/markdown/index.js
@@ -10,6 +10,10 @@ import { Link } from "react-router-dom";
 import ComponentPlayground from "component-playground";
 import * as Victory from "victory";
 import styled, { withTheme } from "styled-components";
+import {
+  scaleDiscontinuous,
+  discontinuitySkipWeekends
+} from "@d3fc/d3fc-discontinuous-scale";
 import scopeMap from "./scope-map";
 import PlaygroundContainer from "./playground-container";
 import createPath from "../../helpers/path-helpers";
@@ -37,6 +41,8 @@ const renderPlayground = (props, scope, theme) => {
   const playgroundScope = Object.assign({}, scopeObject, {
     ...Victory,
     styled,
+    scaleDiscontinuous,
+    discontinuitySkipWeekends,
     React,
     ReactDOM
   });

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -829,6 +829,18 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@d3fc/d3fc-discontinuous-scale@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@d3fc/d3fc-discontinuous-scale/-/d3fc-discontinuous-scale-4.0.2.tgz#b06d0be8e5b555a867bfe08347fe9135b3d933f7"
+  integrity sha512-m1H/fL3BQmkytTjUNd0GVGE6KC0CEervrgRNnM5FluouycsbUCQPhiiN1CY1bRh8xcFDQx9vpOUU7DNCjiEbAQ==
+  dependencies:
+    "@d3fc/d3fc-rebind" "^6.0.1"
+
+"@d3fc/d3fc-rebind@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@d3fc/d3fc-rebind/-/d3fc-rebind-6.0.1.tgz#b66e21d938893a92dd939e55e3147f24f46b652e"
+  integrity sha512-+ryBZ53ALMffbADwnFAtTYQJcT7PE5BwpducGYS0X6Jux6ESnp+fP+cDQvBGbDBOVqaziGnfeLeJXjtMnZujmQ==
+
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"


### PR DESCRIPTION
This adds some documentation around the existing custom scale prop that can be used to create a discontinuous scale. I included this example as both an example of `scale` on the custom props page, and a gallery example. 

<img width="1002" alt="Screen Shot 2021-06-22 at 9 57 38 AM" src="https://user-images.githubusercontent.com/13334214/122968557-8359cc00-d340-11eb-8311-97303c20f332.png">

<img width="412" alt="Screen Shot 2021-06-22 at 9 56 56 AM" src="https://user-images.githubusercontent.com/13334214/122968933-eb101700-d340-11eb-8738-43d042b36952.png">


Resolves #1879 
