### PR TITLE
Improve VictoryTooltip rendering performance

### DIFF
--- a/packages/victory-tooltip/src/victory-tooltip.js
+++ b/packages/victory-tooltip/src/victory-tooltip.js
@@ -557,17 +557,13 @@ export default class VictoryTooltip extends React.Component {
 
   // Overridden in victory-core-native
   renderTooltip(props) {
-    const evaluatedProps = this.getEvaluatedProps(props);
-    const {
-      flyoutComponent,
-      labelComponent,
-      groupComponent,
-      active,
-      renderInPortal
-    } = evaluatedProps;
+    const active = Helpers.evaluateProp(props.active, props);
+    const { renderInPortal } = props;
     if (!active) {
       return renderInPortal ? <VictoryPortal>{null}</VictoryPortal> : null;
     }
+    const evaluatedProps = this.getEvaluatedProps(props);
+    const { flyoutComponent, labelComponent, groupComponent } = evaluatedProps;
     const calculatedValues = this.getCalculatedValues(evaluatedProps);
     const children = [
       React.cloneElement(


### PR DESCRIPTION
This is a small update that will improve the performance of any component using `VictoryTooltip` without changing the API. 

Currently, every tooltip is getting re-rendered on every interaction, and the `getEvaluatedProps` function gets called on each render. By moving the `active` check to earlier in the render cycle, we can bypass the `getEvaluatedProps` function if the tooltip is not active, reducing scripting time for inactive tooltips. 

## Performance Comparison

For a `VictoryScatter` chart with 2000 data points and tooltips running in production:

|          | scripting time | rendering time | lighthouse performance score |
|------|---------|-----------|-------------------------------|
|before|892ms|16ms|80|
|after|660ms|19ms|88|

Related issues: #1669, #1621, #1614
