### PR TITLE
add a check for children before attempting barWidth calculation

### DIFF
--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -48,6 +48,9 @@ export default {
     }
 
     const firstChild = Array.isArray(children) && children[0];
+    if (!firstChild) {
+      return undefined;
+    }
     let barWidth = firstChild.props.barWidth;
     let dataLength =
       (firstChild.props.data && firstChild.props.data.length) || 1;


### PR DESCRIPTION
encountered a minor error related to recent changes in automatic `barWidth` calculation for grouped bars. This PR adds a quick check for the existence of children