### PR TITLE
Update interface with optional rx ry

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -916,6 +916,8 @@ export class Whisker extends React.Component<WhiskerProps> {}
 export interface VictoryPrimitiveShapeProps
   extends VictoryCommonPrimitiveProps {
   desc?: string;
+  rx?: number;
+  ry?: number;
 }
 
 export class Circle extends React.Component<VictoryPrimitiveShapeProps> {}


### PR DESCRIPTION
Added an optional rx and ry prop to `VictoryPrimitiveShapeProps` as mentioned on https://github.com/FormidableLabs/victory/issues/1893.