### PR TITLE
add react as a peerDependnecy to all victory packages

### DIFF
--- a/packages/victory-area/package.json
+++ b/packages/victory-area/package.json
@@ -24,6 +24,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-axis/package.json
+++ b/packages/victory-axis/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -24,6 +24,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "temp-version": "webpack --bail --config ../../config/webpack/webpack.config.js --colors"
   },

--- a/packages/victory-box-plot/package.json
+++ b/packages/victory-box-plot/package.json
@@ -24,6 +24,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -24,6 +24,9 @@
     "react-fast-compare": "^2.0.0",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -24,6 +24,9 @@
     "react-fast-compare": "^2.0.0",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-candlestick/package.json
+++ b/packages/victory-candlestick/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-chart/package.json
+++ b/packages/victory-chart/package.json
@@ -27,6 +27,9 @@
     "victory-polar-axis": "^35.9.3",
     "victory-shared-events": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -28,6 +28,9 @@
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-create-container/package.json
+++ b/packages/victory-create-container/package.json
@@ -27,6 +27,9 @@
     "victory-voronoi-container": "^35.9.3",
     "victory-zoom-container": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-cursor-container/package.json
+++ b/packages/victory-cursor-container/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-errorbar/package.json
+++ b/packages/victory-errorbar/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -25,6 +25,9 @@
     "victory-core": "^35.9.3",
     "victory-shared-events": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -27,6 +27,9 @@
     "victory-bar": "^35.9.3",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-legend/package.json
+++ b/packages/victory-legend/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -24,6 +24,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-pie/package.json
+++ b/packages/victory-pie/package.json
@@ -24,6 +24,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-polar-axis/package.json
+++ b/packages/victory-polar-axis/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-scatter/package.json
+++ b/packages/victory-scatter/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-selection-container/package.json
+++ b/packages/victory-selection-container/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-shared-events/package.json
+++ b/packages/victory-shared-events/package.json
@@ -25,6 +25,9 @@
     "react-fast-compare": "^2.0.0",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -25,6 +25,9 @@
     "victory-core": "^35.9.3",
     "victory-shared-events": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-tooltip/package.json
+++ b/packages/victory-tooltip/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -26,6 +26,9 @@
     "victory-core": "^35.9.3",
     "victory-tooltip": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-voronoi/package.json
+++ b/packages/victory-voronoi/package.json
@@ -24,6 +24,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory-zoom-container/package.json
+++ b/packages/victory-zoom-container/package.json
@@ -23,6 +23,9 @@
     "prop-types": "^15.5.8",
     "victory-core": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -46,6 +46,9 @@
     "victory-voronoi-container": "^35.9.3",
     "victory-zoom-container": "^35.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.6.0 || ^17.0.0"
+  },
   "scripts": {
     "version": "nps build-libs && nps build-dists"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12410,7 +12410,17 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.13.1, react-dom@^16.8.3:
+react-dom@^16.13.1:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
+react-dom@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   dependencies:
@@ -12562,7 +12572,16 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^16.13.1, react@^16.8.3:
+react@^16.13.1:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   dependencies:


### PR DESCRIPTION
This PR adds `react` as a peerDependency to all victory packages. 
Closes https://github.com/FormidableLabs/victory/issues/1914