### PR TITLE
remove spectrum links and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
 
 * See the **docs and examples** on the website: http://formidable.com/open-source/victory.
 * **Experiment** with all Victory components in this [code sandbox](https://codesandbox.io/s/m3xo745x2x)
-* For support, join the **Spectrum chat room** at https://spectrum.chat/victory.
 
 ## Getting started
 

--- a/docs/src/content/faq/faq.md
+++ b/docs/src/content/faq/faq.md
@@ -8,7 +8,7 @@ slug: faq
 ---
 # Frequently Asked Questions (FAQ)
 
-Thanks for trying Victory! The FAQs below are based on issues and questions from our [support channel](https://spectrum.chat/victory). You can find more examples in [our gallery](/gallery). Can't find what you're looking for? Help us improve these docs by [opening an issue](https://github.com/FormidableLabs/victory/issues/new) with the "docs" tag, or by making a pull request.
+Thanks for trying Victory! The FAQs below are based on issues and questions from our users. You can find more examples in [our gallery](/gallery). Can't find what you're looking for? Help us improve these docs by [opening an issue](https://github.com/FormidableLabs/victory/issues/new) with the "docs" tag, or by making a pull request.
 
 ## Styles
 

--- a/docs/src/partials/home/_content.js
+++ b/docs/src/partials/home/_content.js
@@ -26,11 +26,6 @@ const content = {
         location: "gallery"
       },
       {
-        text: "SUPPORT",
-        location: "https://spectrum.chat/victory",
-        external: true
-      },
-      {
         text: "GITHUB",
         location: "https://github.com/FormidableLabs/victory",
         external: true

--- a/docs/src/partials/sidebar/components/introduction.js
+++ b/docs/src/partials/sidebar/components/introduction.js
@@ -52,7 +52,6 @@ const Introduction = ({ content }) => {
   const mobileLinks = [
     { slug: "/about", title: "About" },
     { slug: "/gallery", title: "Gallery" },
-    { slug: "https://spectrum.chat/victory", title: "Support" },
     { slug: "https://github.com/FormidableLabs/victory", title: "Github" },
     { slug: "/docs/faq", title: "FAQs" }
   ];

--- a/docs/static-config-helpers/site-data.js
+++ b/docs/static-config-helpers/site-data.js
@@ -9,10 +9,6 @@ export default {
   googleAnalyticsID: "UA-43290258-1", // GA tracking ID.
   projectLinks: [
     {
-      label: "Support",
-      url: "https://spectrum.chat/victory"
-    },
-    {
       label: "GitHub",
       url: "https://github.com/FormidableLabs/victory"
     }


### PR DESCRIPTION
Since spectrum is becoming read only, we should remove references to spectrum from Victory's docs site