### PR TITLE
Refactor VictoryStack

### DIFF
--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -23,7 +23,7 @@ const fallbackProps = {
 
 const VictoryGroup = (initialProps) => {
   // eslint-disable-next-line no-use-before-define
-  const { role } = VictoryGroup;
+  const { role } = VictoryGroupMemo;
   const { getAnimationProps, state, setState, setAnimationState } =
     useAnimationState();
   const props =

--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -21,7 +21,7 @@ const fallbackProps = {
   offset: 0
 };
 
-const BaseVictoryGroup = (initialProps) => {
+const VictoryGroup = (initialProps) => {
   // eslint-disable-next-line no-use-before-define
   const { role } = VictoryGroup;
   const { getAnimationProps, state, setState, setAnimationState } =
@@ -143,12 +143,6 @@ const BaseVictoryGroup = (initialProps) => {
   return React.cloneElement(container, container.props, newChildren);
 };
 
-// We need to attatch the static properties to the memoized version, or else
-// VictoryChart will not be able to get this component's role type
-const VictoryGroup = React.memo(BaseVictoryGroup, isEqual);
-
-VictoryGroup.displayName = "VictoryGroup";
-VictoryGroup.role = "group";
 VictoryGroup.propTypes = {
   ...CommonProps.baseProps,
   ...CommonProps.dataProps,
@@ -183,12 +177,19 @@ VictoryGroup.defaultProps = {
   theme: VictoryTheme.grayscale
 };
 
-VictoryGroup.expectedComponents = [
+// We need to attatch the static properties to the memoized version, or else
+// VictoryChart will not be able to get this component's role type
+const VictoryGroupMemo = React.memo(VictoryGroup, isEqual);
+
+VictoryGroupMemo.displayName = "VictoryGroup";
+VictoryGroupMemo.role = "group";
+
+VictoryGroupMemo.expectedComponents = [
   "groupComponent",
   "containerComponent",
   "labelComponent"
 ];
 
-VictoryGroup.getChildren = getChildren;
+VictoryGroupMemo.getChildren = getChildren;
 
-export default VictoryGroup;
+export default VictoryGroupMemo;

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -23,7 +23,7 @@ const fallbackProps = {
 
 const VictoryStack = (initialProps) => {
   // eslint-disable-next-line no-use-before-define
-  const { role } = VictoryStack;
+  const { role } = VictoryStackMemo;
   const { setState, setAnimationState, getAnimationProps, state } =
     useAnimationState();
 

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -7,7 +7,9 @@ import {
   VictoryTheme,
   CommonProps,
   Wrapper,
-  PropTypes as CustomPropTypes
+  PropTypes as CustomPropTypes,
+  useAnimationState,
+  usePreviousProps
 } from "victory-core";
 import { VictorySharedEvents } from "victory-shared-events";
 import { getChildren, getCalculatedProps } from "./helper-methods";
@@ -19,100 +21,39 @@ const fallbackProps = {
   padding: 50
 };
 
-export default class VictoryStack extends React.Component {
-  static displayName = "VictoryStack";
+const VictoryStackBase = (initialProps) => {
+  // eslint-disable-next-line no-use-before-define
+  const { role } = VictoryStack;
+  const { setState, setAnimationState, getAnimationProps, state } =
+    useAnimationState();
 
-  static role = "stack";
+  const props =
+    state && state.nodesWillExit
+      ? state.oldProps || initialProps
+      : initialProps;
 
-  static propTypes = {
-    ...CommonProps.baseProps,
-    bins: PropTypes.oneOfType([
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([
-          CustomPropTypes.nonNegative,
-          PropTypes.instanceOf(Date)
-        ])
-      ),
-      CustomPropTypes.nonNegative
-    ]),
-    categories: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.string),
-      PropTypes.shape({
-        x: PropTypes.arrayOf(PropTypes.string),
-        y: PropTypes.arrayOf(PropTypes.string)
-      })
-    ]),
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node
-    ]),
-    colorScale: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.string),
-      PropTypes.oneOf([
-        "grayscale",
-        "qualitative",
-        "heatmap",
-        "warm",
-        "cool",
-        "red",
-        "green",
-        "blue"
-      ])
-    ]),
-    fillInMissingData: PropTypes.bool,
-    horizontal: PropTypes.bool,
-    labelComponent: PropTypes.element,
-    labels: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
-    style: PropTypes.shape({
-      parent: PropTypes.object,
-      data: PropTypes.object,
-      labels: PropTypes.object
-    }),
-    xOffset: PropTypes.number
-  };
+  const modifiedProps = Helpers.modifyProps(props, fallbackProps, role);
+  const {
+    eventKey,
+    containerComponent,
+    standalone,
+    groupComponent,
+    externalEventMutations,
+    width,
+    height,
+    theme,
+    polar,
+    horizontal,
+    name
+  } = modifiedProps;
 
-  static defaultProps = {
-    containerComponent: <VictoryContainer />,
-    groupComponent: <g />,
-    standalone: true,
-    theme: VictoryTheme.grayscale,
-    fillInMissingData: true
-  };
+  const childComponents = React.Children.toArray(modifiedProps.children);
+  const calculatedProps = getCalculatedProps(modifiedProps, childComponents);
+  const { domain, scale, style, origin } = calculatedProps;
 
-  static expectedComponents = [
-    "groupComponent",
-    "containerComponent",
-    "labelComponent"
-  ];
-
-  static getChildren = getChildren;
-
-  constructor(props) {
-    super(props);
-    if (props.animate) {
-      this.state = {
-        nodesShouldLoad: false,
-        nodesDoneLoad: false,
-        animating: true
-      };
-      this.setAnimationState = Wrapper.setAnimationState.bind(this);
-    }
-  }
-
-  shouldComponentUpdate(nextProps) {
-    if (this.props.animate) {
-      if (!isEqual(this.props, nextProps)) {
-        this.setAnimationState(this.props, nextProps);
-        return false;
-      }
-    }
-    return true;
-  }
-
-  getNewChildren(props, childComponents, calculatedProps) {
+  const newChildren = React.useMemo(() => {
     const children = getChildren(props, childComponents, calculatedProps);
-    const getAnimationProps = Wrapper.getAnimationProps.bind(this);
-    const newChildren = children.map((child, index) => {
+    const orderedChildren = children.map((child, index) => {
       const childProps = assign(
         { animate: getAnimationProps(props, child, index) },
         child.props
@@ -124,73 +65,159 @@ export default class VictoryStack extends React.Component {
       are rendered behind lower children. This looks nicer for stacked bars with cornerRadius, and
       areas with strokes
     */
-    return newChildren.reverse();
-  }
+    return orderedChildren.reverse();
+  }, [props, childComponents, calculatedProps, getAnimationProps]);
 
-  renderContainer(containerComponent, props) {
-    const containerProps = defaults({}, containerComponent.props, props);
-    return React.cloneElement(containerComponent, containerProps);
-  }
-
-  getContainerProps(props, calculatedProps) {
-    const { width, height, standalone, theme, polar, horizontal, name } = props;
-    const { domain, scale, style, origin } = calculatedProps;
-    return {
-      domain,
-      scale,
-      width,
-      height,
-      standalone,
-      theme,
-      style: style.parent,
-      horizontal,
-      polar,
-      origin,
-      name
-    };
-  }
-
-  render() {
-    const { role } = this.constructor;
-    const props =
-      this.state && this.state.nodesWillExit
-        ? this.state.oldProps || this.props
-        : this.props;
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps, role);
-    const {
-      eventKey,
-      containerComponent,
-      standalone,
-      groupComponent,
-      externalEventMutations
-    } = modifiedProps;
-    const childComponents = React.Children.toArray(modifiedProps.children);
-    const calculatedProps = getCalculatedProps(modifiedProps, childComponents);
-    const newChildren = this.getNewChildren(
-      modifiedProps,
-      childComponents,
-      calculatedProps
-    );
-    const containerProps = standalone
-      ? this.getContainerProps(modifiedProps, calculatedProps)
-      : {};
-    const container = standalone
-      ? this.renderContainer(containerComponent, containerProps)
-      : groupComponent;
-    const events = Wrapper.getAllEvents(props);
-    if (!isEmpty(events)) {
-      return (
-        <VictorySharedEvents
-          container={container}
-          eventKey={eventKey}
-          events={events}
-          externalEventMutations={externalEventMutations}
-        >
-          {newChildren}
-        </VictorySharedEvents>
-      );
+  const containerProps = React.useMemo(() => {
+    if (standalone) {
+      return {
+        domain,
+        scale,
+        width,
+        height,
+        standalone,
+        theme,
+        style: style.parent,
+        horizontal,
+        polar,
+        origin,
+        name
+      };
     }
+    return {};
+  }, [
+    standalone,
+    domain,
+    scale,
+    width,
+    height,
+    theme,
+    style,
+    horizontal,
+    polar,
+    origin,
+    name
+  ]);
 
-    return React.cloneElement(container, container.props, newChildren);
+  const container = React.useMemo(() => {
+    if (standalone) {
+      const defaultContainerProps = defaults(
+        {},
+        containerComponent.props,
+        containerProps
+      );
+      return React.cloneElement(containerComponent, defaultContainerProps);
+    }
+    return groupComponent;
+  }, [groupComponent, standalone, containerComponent, containerProps]);
+
+  const events = React.useMemo(() => {
+    return Wrapper.getAllEvents(props);
+  }, [props]);
+
+  const previousProps = usePreviousProps();
+
+  React.useEffect(() => {
+    if (initialProps.animate) {
+      setState({
+        nodesShouldLoad: false,
+        nodesDoneLoad: false,
+        animating: true
+      });
+    }
+    // This hook will run once when the component is initialized
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    if (initialProps.animate) {
+      setAnimationState(previousProps, initialProps);
+    }
+  }, [setAnimationState, previousProps, initialProps]);
+
+  if (!isEmpty(events)) {
+    return (
+      <VictorySharedEvents
+        container={container}
+        eventKey={eventKey}
+        events={events}
+        externalEventMutations={externalEventMutations}
+      >
+        {newChildren}
+      </VictorySharedEvents>
+    );
   }
-}
+
+  return React.cloneElement(container, container.props, newChildren);
+};
+
+const VictoryStack = React.memo(VictoryStackBase, isEqual);
+
+VictoryStack.displayName = "VictoryStack";
+
+VictoryStack.role = "stack";
+
+VictoryStack.propTypes = {
+  ...CommonProps.baseProps,
+  bins: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        CustomPropTypes.nonNegative,
+        PropTypes.instanceOf(Date)
+      ])
+    ),
+    CustomPropTypes.nonNegative
+  ]),
+  categories: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.shape({
+      x: PropTypes.arrayOf(PropTypes.string),
+      y: PropTypes.arrayOf(PropTypes.string)
+    })
+  ]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
+  colorScale: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.oneOf([
+      "grayscale",
+      "qualitative",
+      "heatmap",
+      "warm",
+      "cool",
+      "red",
+      "green",
+      "blue"
+    ])
+  ]),
+  fillInMissingData: PropTypes.bool,
+  horizontal: PropTypes.bool,
+  labelComponent: PropTypes.element,
+  labels: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
+  style: PropTypes.shape({
+    parent: PropTypes.object,
+    data: PropTypes.object,
+    labels: PropTypes.object
+  }),
+  xOffset: PropTypes.number
+};
+
+VictoryStack.defaultProps = {
+  containerComponent: <VictoryContainer />,
+  groupComponent: <g />,
+  standalone: true,
+  theme: VictoryTheme.grayscale,
+  fillInMissingData: true
+};
+
+VictoryStack.expectedComponents = [
+  "groupComponent",
+  "containerComponent",
+  "labelComponent"
+];
+
+VictoryStack.getChildren = getChildren;
+
+export default VictoryStack;

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -21,7 +21,7 @@ const fallbackProps = {
   padding: 50
 };
 
-const VictoryStackBase = (initialProps) => {
+const VictoryStack = (initialProps) => {
   // eslint-disable-next-line no-use-before-define
   const { role } = VictoryStack;
   const { setState, setAnimationState, getAnimationProps, state } =
@@ -151,12 +151,6 @@ const VictoryStackBase = (initialProps) => {
   return React.cloneElement(container, container.props, newChildren);
 };
 
-const VictoryStack = React.memo(VictoryStackBase, isEqual);
-
-VictoryStack.displayName = "VictoryStack";
-
-VictoryStack.role = "stack";
-
 VictoryStack.propTypes = {
   ...CommonProps.baseProps,
   bins: PropTypes.oneOfType([
@@ -212,12 +206,17 @@ VictoryStack.defaultProps = {
   fillInMissingData: true
 };
 
-VictoryStack.expectedComponents = [
+const VictoryStackMemo = React.memo(VictoryStack, isEqual);
+
+VictoryStackMemo.displayName = "VictoryStack";
+VictoryStackMemo.role = "stack";
+
+VictoryStackMemo.expectedComponents = [
   "groupComponent",
   "containerComponent",
   "labelComponent"
 ];
 
-VictoryStack.getChildren = getChildren;
+VictoryStackMemo.getChildren = getChildren;
 
-export default VictoryStack;
+export default VictoryStackMemo;


### PR DESCRIPTION
This applies the same refactor from VictoryGroup in #1931 to VictoryStack. This one has about the same before and after performance, because we weren't seeing as much re-rendering with VictoryStack originally.

Before: 

<img width="1233" alt="Screen Shot 2021-08-16 at 3 01 00 PM" src="https://user-images.githubusercontent.com/13334214/129634825-94f326b7-26a9-4daa-a7e5-558a1cd8fe38.png">

After:

<img width="1227" alt="Screen Shot 2021-08-16 at 2 57 35 PM" src="https://user-images.githubusercontent.com/13334214/129634939-d1894b8a-d628-4059-ac11-8ed262753c4f.png">

