### PR TITLE
Add histogram to VictoryThemeDefinition interface

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -429,6 +429,12 @@ export interface VictoryThemeDefinition {
       labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
     };
   } & VictoryCommonThemeProps;
+  histogram?: {
+    style?: {
+      data?: VictoryStyleObject;
+      labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
+    };
+  } & VictoryCommonThemeProps;
   independentAxis?: {
     style?: {
       axis?: VictoryStyleObject;


### PR DESCRIPTION
My TSLint is currently throwing an error when trying to implement a custom theme function that returns a `VictoryThemeDefinition`

```
Object literal may only specify known properties, and 'histogram' does not exist in type 'VictoryThemeDefinition'.ts
```

This assumes that the histogram styles are fundamentally the same as the `VictoryBar` component