### PR TITLE
modify version scripts in individual packages

### DIFF
--- a/packages/victory-area/package.json
+++ b/packages/victory-area/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-axis/package.json
+++ b/packages/victory-axis/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "temp-version": "webpack --bail --config ../../config/webpack/webpack.config.js --colors"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-box-plot/package.json
+++ b/packages/victory-box-plot/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-candlestick/package.json
+++ b/packages/victory-candlestick/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-chart/package.json
+++ b/packages/victory-chart/package.json
@@ -31,7 +31,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -32,7 +32,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-create-container/package.json
+++ b/packages/victory-create-container/package.json
@@ -31,7 +31,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-cursor-container/package.json
+++ b/packages/victory-cursor-container/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-errorbar/package.json
+++ b/packages/victory-errorbar/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -29,7 +29,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -31,7 +31,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-legend/package.json
+++ b/packages/victory-legend/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-pie/package.json
+++ b/packages/victory-pie/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-polar-axis/package.json
+++ b/packages/victory-polar-axis/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-scatter/package.json
+++ b/packages/victory-scatter/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-selection-container/package.json
+++ b/packages/victory-selection-container/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-shared-events/package.json
+++ b/packages/victory-shared-events/package.json
@@ -29,7 +29,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -29,7 +29,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-tooltip/package.json
+++ b/packages/victory-tooltip/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -30,7 +30,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-voronoi/package.json
+++ b/packages/victory-voronoi/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory-zoom-container/package.json
+++ b/packages/victory-zoom-container/package.json
@@ -27,7 +27,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }

--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -50,7 +50,7 @@
     "react": "^16.6.0 || ^17.0.0"
   },
   "scripts": {
-    "version": "nps build-libs && nps build-dists"
+    "version": "yarn run nps build-libs && nps build-dists"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
`nps` devDependency was not being prodived in the same way with lerna update, so this alters the version script that runs on publish. Oddly, this was not caught with the version dry run, which is using `lerna version` rather than `lerna publish` .