### PR TITLE
revert d3-interpolate while updating only d3-color

### DIFF
--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -20,13 +20,16 @@
   "license": "MIT",
   "dependencies": {
     "d3-ease": "^1.0.0",
-    "d3-interpolate": "^3.0.1",
+    "d3-interpolate": "^1.1.1",
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.2.0",
     "d3-timer": "^1.0.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.5.8",
     "react-fast-compare": "^2.0.0"
+  },
+  "resolutions": {
+    "d3-interpolate/d3-color": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^16.6.0 || ^17.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6595,11 +6595,6 @@ d3-color@1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
 
-"d3-color@1 - 3":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.0.1.tgz#03316e595955d1fcd39d9f3610ad41bb90194d0a"
-  integrity sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==
-
 d3-ease@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.6.tgz#ebdb6da22dfac0a22222f2d4da06f66c416a0ec0"
@@ -6608,18 +6603,11 @@ d3-format@1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
 
-d3-interpolate@1:
+d3-interpolate@1, d3-interpolate@^1.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
   dependencies:
     d3-color "1"
-
-d3-interpolate@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
-  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
-  dependencies:
-    d3-color "1 - 3"
 
 d3-path@1:
   version "1.0.9"


### PR DESCRIPTION
Here's a bandaid for the CJS / ESM issue introduced with the recent update to `d3-interpolate`. That update was motivated by a security issue in the `d3-color` dependency. This PR reverts the `d3-interpolate` update, but adds a resolution for `d3-color` to address the security issue. This should get around the ESM issue we were seeing with `d3-interpolate`, because Victory does not directly import `d3-color`. Phew!