### PR TITLE
Gallery Page: small tweaks to `Link` placement

### DIFF
--- a/docs/src/pages/gallery.js
+++ b/docs/src/pages/gallery.js
@@ -90,7 +90,7 @@ const Gallery = ({ gallery, sidebarContent }) => {
     const title = item.data.title;
 
     return (
-      <Link to={createPath(`gallery/${slug}`)}>
+      <>
         <StyledLazyRender
           LazyRenderedComponent={() => (
             <Preview
@@ -114,8 +114,10 @@ const Gallery = ({ gallery, sidebarContent }) => {
             />
           )}
         />
-        <Title>{title}</Title>
-      </Link>
+        <Link to={createPath(`gallery/${slug}`)}>
+          <Title>{title}</Title>
+        </Link>
+      </>
     );
   };
 


### PR DESCRIPTION
## Description

Right now, on the gallery page of the docs, each gallery item is wrapped in a `Link`, so that the interactive chart is wrapped by the `Link`. This entails that when you interact with one of the gallery items, and `mouseup`, the `Link` is activated. This is shown here:

https://user-images.githubusercontent.com/12721310/135670103-9d7e5966-d194-4d81-ae2e-0c69c2ea49f2.mp4

## Proposed Solution

This PR proposes moving the chart preview _outside_ of the `Link`, and only have the title contained by the `Link` -- which is probably a more semantic usage of `Link`, and avoids this behavior. This updated behavior is shown here:


https://user-images.githubusercontent.com/12721310/135670193-a4eea1b3-5e6e-46eb-957f-42244cea1684.mp4
