### PR TITLE
Add explicit types for VictoryGroup#children

### DIFF
--- a/packages/victory-group/src/index.d.ts
+++ b/packages/victory-group/src/index.d.ts
@@ -19,6 +19,7 @@ export interface VictoryGroupProps
     VictoryDatableProps,
     VictoryMultiLabelableProps {
   categories?: CategoryPropType;
+  children?: React.ReactNode;
   color?: string;
   colorScale?: ColorScalePropType;
   domain?: DomainPropType;


### PR DESCRIPTION
We plan to remove implicit types for `children` in `@types/react@18.x`. 

I ran `yarn nps compile-ts` and only `VictoryGroup` was reporting failures when `children` weren't added by `@types/react`.