### PR TITLE
Add recursive check for the first child

### DIFF
--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -172,7 +172,13 @@ export function getDefaultDomainPadding(props, axis, childComponents) {
     return undefined;
   }
 
-  const firstChild = Array.isArray(children) && children[0];
+  function getFirstChild(childrenComponents) {
+    if (Array.isArray(childrenComponents)) {
+      return getFirstChild(childrenComponents[0]);
+    }
+    return childrenComponents[0];
+  }
+  const firstChild = getFirstChild(children);
   if (!firstChild) {
     return undefined;
   }


### PR DESCRIPTION
The https://github.com/FormidableLabs/victory/pull/1908/commits commit fixes the issue https://github.com/FormidableLabs/victory/issues/1911

But there we consider a group of bars. Actually, we can use a group of _stacked_ bars. Previously (at least with 35.4.8) it worked correctly.