### PR TITLE
Chore: add google tag manager script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -33,6 +33,7 @@
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.8.0",
     "react-ga": "^2.4.1",
+    "react-gtm-module": "^2.0.11",
     "react-helmet": "^5.2.0",
     "react-hot-loader": "^4.12.3",
     "react-inlinesvg": "^0.8.1",

--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -12,6 +12,7 @@ import get from "lodash/get";
 import GlobalStyle from "./styles/global";
 import theme from "./styles/theme";
 import Analytics from "./google-analytics";
+import { initGoogleTagManager } from './google-tag-manager';
 import NotFound from "./pages/404";
 
 // eslint-disable-next-line no-magic-numbers
@@ -84,6 +85,11 @@ ScrollToCurrentSection.propTypes = {
 
 // eslint-disable-next-line react/no-multi-comp
 const App = () => {
+
+  useEffect(() => {
+    initGoogleTagManager();
+  }, []);
+
   const basePath = useBasepath() || "";
   return (
     <Root>

--- a/docs/src/google-tag-manager.js
+++ b/docs/src/google-tag-manager.js
@@ -1,0 +1,12 @@
+/**
+ * Google Tag Manager
+ */
+const TagManager = require('react-gtm-module');
+
+export const initGoogleTagManager = () => {
+  if (typeof document === 'undefined') {
+    return {};
+  } else {
+    return TagManager.initialize({ gtmId: 'GTM-MD32945' });
+  }
+};

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6893,6 +6893,11 @@ react-ga@^2.4.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
 
+react-gtm-module@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
+  integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
+
 react-helmet@^5.2.0, react-helmet@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"


### PR DESCRIPTION
### Description: 
Added google tag manager script

### Issue:
https://github.com/FormidableLabs/formidable.com/issues/2051

### To test: 
- go to `victory>docs` and run `yarn install && yarn build && yarn serve` 
- you should see the google tag manager script/noscript added to `<head>` + `<body>`

