### PR TITLE
Add Hooks namespace to maintain consistency with helpers

### DIFF
--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -9,8 +9,7 @@ import {
   CommonProps,
   PropTypes as CustomPropTypes,
   Wrapper,
-  usePreviousProps,
-  useAnimationState
+  Hooks
 } from "victory-core";
 import { VictorySharedEvents } from "victory-shared-events";
 import { VictoryAxis } from "victory-axis";
@@ -32,7 +31,7 @@ const fallbackProps = {
 const VictoryChart = (initialProps) => {
   const role = "chart";
   const { getAnimationProps, setAnimationState, getProps } =
-    useAnimationState();
+    Hooks.useAnimationState();
   const props = getProps(initialProps);
 
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, role);
@@ -136,7 +135,7 @@ const VictoryChart = (initialProps) => {
     return Wrapper.getAllEvents(props);
   }, [props]);
 
-  const previousProps = usePreviousProps(initialProps);
+  const previousProps = Hooks.usePreviousProps(initialProps);
 
   React.useEffect(() => {
     // This is called before dismount to keep state in sync

--- a/packages/victory-core/src/index.js
+++ b/packages/victory-core/src/index.js
@@ -44,7 +44,7 @@ export * as Wrapper from "./victory-util/wrapper";
 export * as Axis from "./victory-util/axis";
 export { default as TimerContext } from "./victory-util/timer-context";
 export { default as PortalContext } from "./victory-portal/portal-context";
-export * from "./victory-util/hooks";
+export * as Hooks from "./victory-util/hooks";
 export * as LineHelpers from "./victory-util/line-helpers";
 // TODO: Fix this default export
 export { default as PointPathHelpers } from "./victory-util/point-path-helpers";

--- a/packages/victory-core/src/victory-util/hooks/index.js
+++ b/packages/victory-core/src/victory-util/hooks/index.js
@@ -1,0 +1,2 @@
+export { usePreviousProps } from "./use-previous-props";
+export { useAnimationState } from "./use-animation-state";

--- a/packages/victory-core/src/victory-util/hooks/use-animation-state.js
+++ b/packages/victory-core/src/victory-util/hooks/use-animation-state.js
@@ -1,16 +1,8 @@
 import React from "react";
 import { defaults, some } from "lodash";
 
-import * as Collection from "./collection";
-import * as Transitions from "./transitions";
-
-export const usePreviousProps = (props) => {
-  const ref = React.useRef();
-  React.useEffect(() => {
-    ref.current = props;
-  });
-  return ref.current || {};
-};
+import * as Collection from "../collection";
+import * as Transitions from "../transitions";
 
 const INITIAL_STATE = {
   nodesShouldLoad: false,

--- a/packages/victory-core/src/victory-util/hooks/use-previous-props.js
+++ b/packages/victory-core/src/victory-util/hooks/use-previous-props.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const usePreviousProps = (props) => {
+  const ref = React.useRef();
+  React.useEffect(() => {
+    ref.current = props;
+  });
+  return ref.current || {};
+};

--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -7,8 +7,7 @@ import {
   VictoryTheme,
   CommonProps,
   Wrapper,
-  usePreviousProps,
-  useAnimationState
+  Hooks
 } from "victory-core";
 import { VictorySharedEvents } from "victory-shared-events";
 import { getChildren, useMemoizedProps } from "./helper-methods";
@@ -25,7 +24,7 @@ const VictoryGroup = (initialProps) => {
   // eslint-disable-next-line no-use-before-define
   const { role } = VictoryGroupMemo;
   const { getAnimationProps, setAnimationState, getProps } =
-    useAnimationState();
+    Hooks.useAnimationState();
   const props = getProps(initialProps);
 
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, role);
@@ -105,7 +104,7 @@ const VictoryGroup = (initialProps) => {
     return Wrapper.getAllEvents(props);
   }, [props]);
 
-  const previousProps = usePreviousProps(initialProps);
+  const previousProps = Hooks.usePreviousProps(initialProps);
 
   React.useEffect(() => {
     // This is called before dismount to keep state in sync

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -8,8 +8,7 @@ import {
   CommonProps,
   Wrapper,
   PropTypes as CustomPropTypes,
-  useAnimationState,
-  usePreviousProps
+  Hooks
 } from "victory-core";
 import { VictorySharedEvents } from "victory-shared-events";
 import { getChildren, useMemoizedProps } from "./helper-methods";
@@ -25,7 +24,7 @@ const VictoryStack = (initialProps) => {
   // eslint-disable-next-line no-use-before-define
   const { role } = VictoryStackMemo;
   const { setAnimationState, getAnimationProps, getProps } =
-    useAnimationState();
+    Hooks.useAnimationState();
 
   const props = getProps(initialProps);
 
@@ -112,7 +111,7 @@ const VictoryStack = (initialProps) => {
     return Wrapper.getAllEvents(props);
   }, [props]);
 
-  const previousProps = usePreviousProps(initialProps);
+  const previousProps = Hooks.usePreviousProps(initialProps);
 
   React.useEffect(() => {
     // This is called before dismount to keep state in sync


### PR DESCRIPTION
This moves some files around and adds a Hooks namespace to make it easier to add to the Victory custom hooks without adding more lines of code to `hooks.js`.