### PR TITLE
Update ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,8 +2,6 @@
 
 ### Checklist
 
-- [ ] This is not a `victory-native` specific issue. (Issues that only appear in `victory-native` should be opened [here](https://github.com/FormidableLabs/victory-native/issues/new))
-
 - [ ] I have read through the [FAQ](https://formidable.com/open-source/victory/docs/faq) and [Guides](https://formidable.com/open-source/victory/guides/) before asking a question
 
 - [ ] I am using the latest version of Victory


### PR DESCRIPTION
One last tweak I could find! The docs site doesn't seem to point to the actual `victory-native` git repo, from what I could find - so I think we should be good on that front.