### PR TITLE
Fix for victory-native touch events in VictoryBrushContainer

### DIFF
--- a/packages/victory-native/src/components/victory-brush-container.js
+++ b/packages/victory-native/src/components/victory-brush-container.js
@@ -39,20 +39,20 @@ const nativeBrushMixin = (base) =>
               if (props.disable) {
                 return {};
               }
-              BrushHelpers.onMouseMove.cancel();
+              BrushHelpers.onGlobalMouseMove.cancel();
               return BrushHelpers.onMouseDown(evt, targetProps);
             },
             onTouchMove: (evt, targetProps) => {
               return props.disable
                 ? {}
-                : BrushHelpers.onMouseMove(evt, targetProps);
+                : BrushHelpers.onGlobalMouseMove(evt, targetProps);
             },
             onTouchEnd: (evt, targetProps) => {
               if (props.disable) {
                 return {};
               }
-              BrushHelpers.onMouseMove.cancel();
-              return BrushHelpers.onMouseUp(evt, targetProps);
+              BrushHelpers.onGlobalMouseMove.cancel();
+              return BrushHelpers.onGlobalMouseUp(evt, targetProps);
             }
           }
         }


### PR DESCRIPTION
Fixed bug on react native for touch events for VictoryBrushContainer.
It's related to issue: https://github.com/FormidableLabs/victory/issues/2021