### PR TITLE
Always use brushDomain to avoid stale data

### DIFF
--- a/packages/victory-brush-container/src/brush-helpers.js
+++ b/packages/victory-brush-container/src/brush-helpers.js
@@ -257,9 +257,7 @@ const Helpers = {
 
     const brushDomain = defaults({}, targetProps.brushDomain, domain);
 
-    const currentDomain = isEqual(brushDomain, cachedBrushDomain)
-      ? targetProps.currentDomain || brushDomain || domain
-      : brushDomain || domain;
+    const currentDomain = brushDomain || domain;
 
     const domainBox = this.getDomainBox(targetProps, domain, currentDomain);
 

--- a/packages/victory-brush-container/src/victory-brush-container.js
+++ b/packages/victory-brush-container/src/victory-brush-container.js
@@ -182,11 +182,7 @@ export const brushContainerMixin = (base) =>
     }
 
     getRect(props) {
-      const { currentDomain, cachedBrushDomain } = props;
-      const brushDomain = defaults({}, props.brushDomain, props.domain);
-      const domain = isEqual(brushDomain, cachedBrushDomain)
-        ? defaults({}, currentDomain, brushDomain)
-        : brushDomain;
+      const domain = defaults({}, props.brushDomain, props.domain);
       const coordinates = Selection.getDomainCoordinates(props, domain);
       const selectBox = this.getSelectBox(props, coordinates);
       return selectBox ? [selectBox, this.getHandles(props, domain)] : [];


### PR DESCRIPTION
This addresses #2042 

The issue I observed was `brushDomain` and `cachedBrushDomain` are equal (and correct in their values), but `currentDomain` is set to an incorrect value. I don't know enough to know how to fix this further upstream (or how hard it would be to track how all the different state components are being set).