### PR TITLE
fix: android touch events

### DIFF
--- a/packages/victory-native/src/components/victory-container.js
+++ b/packages/victory-native/src/components/victory-container.js
@@ -158,10 +158,10 @@ export default class extends VictoryContainer {
           {title ? <title id="title">{title}</title> : null}
           {desc ? <desc id="desc">{desc}</desc> : null}
           {children}
+          <View style={portalDivStyle} pointerEvents="box-none">
+            <Portal {...portalProps} ref={this.savePortalRef} />
+          </View>
         </Svg>
-        <View style={portalDivStyle} pointerEvents="box-none">
-          <Portal {...portalProps} ref={this.savePortalRef} />
-        </View>
       </View>
     );
   }


### PR DESCRIPTION
This adjusts the markup of the native `VictoryContainer` so that it's always rendering its children within an `Svg` element. My hunch is that this seems to fix touch issues on Android because `react-native-svg`'s `Svg` is central to its own implementation of touch events. See [here](https://github.com/react-native-svg/react-native-svg/blob/develop/android/src/main/java/com/horcrux/svg/SvgView.java) to see methods like `hitTest` and `interceptsTouchEvent`. This is why previously proposed solutions like [this](https://github.com/FormidableLabs/victory/issues/2031#issuecomment-1011077399) and [this](https://github.com/FormidableLabs/victory/issues/2031#issuecomment-1020921557) seem to fix the issue.

Currently, the `View` below the main `Svg` is positioned absolutely on top of it, and then renders an empty `Svg` (portal), which I think is why touch events aren't captured on Android.

Tested by running the demo app included in this repo, and by adding various touch events (not included in PR) to various charts and see if they still work.

On iOS this causes no changes (as far as I can tell).

Concerns:
1. On web this would be essentially invalid markup, having an SVG contain html/jsx without declaring it as a `foreignobject` first. However, I don't seem to encounter any errors, warnings, or complaints in doing this here, but just want to flag that.
2. Portals! I'm actually not sure how they work fully on native yet and want to continue investigating there next.