### PR TITLE
2059 Implementing missing type definitions

### DIFF
--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -563,7 +563,10 @@ export interface AddEventOptions {
   };
 }
 
-export function addEvents<P>(WrappedComponent: React.ComponentType<P>, options: AddEventOptions): React.ComponentType<P & AddEventProps>;
+export function addEvents<P>(
+  WrappedComponent: React.ComponentType<P>,
+  options: AddEventOptions
+): React.ComponentType<P & AddEventProps>;
 
 export interface AnimatePropTypeInterface {
   duration?: number;

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -546,6 +546,24 @@ export const VictoryTheme: VictoryThemeInterface;
 // #endregion
 
 // #region Victory Util
+export interface AddEventProps {
+  animating: typeof VictoryCommonThemeProps.animating;
+  animate?: typeof VictoryCommonThemeProps.animate;
+  standalone?: typeof VictoryCommonThemeProps.standalone;
+  externalEventMutations?: typeof VictoryCommonThemeProps.externalEventMutations;
+  events: typeof VictoryCommonPrimitiveProps.events;
+  sharedEvents: typeof VictoryCommonThemeProps.sharedEvents;
+  name: typeof VictoryCommonThemeProps.name;
+}
+
+export interface AddEventOptions {
+  components: {
+    name: string;
+    index?: string | number;
+  };
+}
+
+export function addEvents<P>(WrappedComponent: React.ComponentType<P>, options: AddEventOptions): React.ComponentType<P & AddEventProps>;
 
 export interface AnimatePropTypeInterface {
   duration?: number;

--- a/packages/victory/src/index.d.ts
+++ b/packages/victory/src/index.d.ts
@@ -261,7 +261,7 @@ declare module "victory" {
     createContainer,
     VictoryBrushLine,
     VictoryBrushLineProps,
-    // addEvents,
+    addEvents,
     // Collection,
     // Data,
     // DefaultTransitions,


### PR DESCRIPTION
### Draft Notes
This is a draft PR for https://github.com/FormidableLabs/victory/issues/2059 

I wanted to get some quick feedback to validate approach and expectations to resolve the issue by working through a single type.

I've implemented the type definition for victory-core/victory-util/addEvents.

Questions:
Am I wrong that we are maintaining TS definitions manually? 
If we are, that seems very brittle — has any discussion been had around generating types automatically? If we are not, what is the mechanism used to generate the types?

When deciding which interface to utilize for the addEvents type definition I couldn't find an interface that felt right. I was looking for an interface that defined only the properties utilized by the HOC. My motivation is derived from trying to apply the interface segregation principal. From this perspective, the interface `interface VictoryCommonThemeProps` is too broad to be used for the addEvents HOC. Ultimately, I ended up creating `interface AddEventProps` and referenced existing interface attributes for consistency. But this feels like a backwards hack. Ideally, I think the `VictoryCommonThemeProps` interface should have been composed from smaller interfaces  (like an events interface, animating interface, etc) -- that I could have utilized for the addEvents definition. I'm wondering if there been any discussion around this topic before? Or documentation about best practices towards improving the TS type definitions?