### PR TITLE
Patch missing text component type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 36.2.1 (2022-01-28)
 
-- [#2058](https://github.com/FormidableLabs/victory/pull/2058) - Uncomments type definitions for VictorySelectionContainer
+- [#2058](https://github.com/FormidableLabs/victory/pull/2058) - Uncomments type definitions for `VictorySelectionContainer`
 - [#2057](https://github.com/FormidableLabs/victory/pull/2057) - Adds animationWhitelist prop to animation prop type definition
 - [#2032](https://github.com/FormidableLabs/victory/pull/2032) - Fixes bug with victory native touch events in `VictoryBrushContainer`. Thanks @uginy!
 

--- a/docs/src/content/docs/victory-label.md
+++ b/docs/src/content/docs/victory-label.md
@@ -350,6 +350,14 @@ _examples:_ `text={(datum) => "x: " + datum.x}`, `text="Apples\n(green)"`, `text
 />
 ```
 
+## textComponent
+
+`type: element`
+
+The `textComponent` prop takes a component instance which will be used to create text elements when `VictoryLabel` renders labels.
+
+_default:_ `<Text />`
+
 ## textAnchor
 
 `type: "start" || "middle" || "end" || "inherit" || function`


### PR DESCRIPTION
Hello!

I noticed the docs and typescript were missing the `textComponent` prop on `VictoryLabel` which I needed to overwrite.
Here is PR fixing that.
