### PR TITLE
Revert "Uncomment type definitions for VictorySelectionContainer"

### DIFF
--- a/packages/victory/src/index.d.ts
+++ b/packages/victory/src/index.d.ts
@@ -109,11 +109,11 @@ declare module "victory" {
     // cursorContainerMixin
   } from "victory-cursor-container";
 
-  import {
-    VictorySelectionContainer,
-    SelectionHelpers,
-    selectionContainerMixin
-  } from "victory-selection-container";
+  // import {
+  //   VictorySelectionContainer,
+  //   SelectionHelpers,
+  //   selectionContainerMixin
+  // } from "victory-selection-container";
 
   import {
     VictoryVoronoiContainer,
@@ -241,9 +241,9 @@ declare module "victory" {
     // ZoomHelpers,
     // zoomContainerMixin,
     // RawZoomHelpers,
-    VictorySelectionContainer,
-    SelectionHelpers,
-    selectionContainerMixin,
+    // VictorySelectionContainer,
+    // SelectionHelpers,
+    // selectionContainerMixin,
     VictoryBrushContainer,
     VictoryBrushContainerProps,
     // BrushHelpers,


### PR DESCRIPTION
Reverts FormidableLabs/victory#2058

Well, apparently this broke the typescript build for TS projects importing Victory. Let's revert this fix for now, and include these types in #2059. I will also add a ticket to make sure the `nps build-ts` command is actually catching these sorts of build failures, because we should try to catch this in CI. 