### PR TITLE
Patch missing text component type

### DIFF
--- a/docs/src/content/docs/victory-label.md
+++ b/docs/src/content/docs/victory-label.md
@@ -350,6 +350,14 @@ _examples:_ `text={(datum) => "x: " + datum.x}`, `text="Apples\n(green)"`, `text
 />
 ```
 
+## textComponent
+
+`type: element`
+
+The `textComponent` prop takes a component instance which will be used to create text elements when `VictoryLabel` renders labels.
+
+_default:_ `<Text />`
+
 ## textAnchor
 
 `type: "start" || "middle" || "end" || "inherit" || function`

--- a/packages/victory-core/src/index.d.ts
+++ b/packages/victory-core/src/index.d.ts
@@ -248,6 +248,7 @@ export interface VictoryLabelProps {
   style?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
   tabIndex?: NumberOrCallback;
   text?: string[] | StringOrNumberOrCallback;
+  textComponent?: React.ReactElement;
   textAnchor?: TextAnchorType | { (): TextAnchorType };
   title?: string;
   transform?: string | {} | { (): string | {} };


### PR DESCRIPTION
Original PR: #2089 

I'm re-opening this PR from a victory branch to make sure Chromatic and doc deploy steps are working in the build process, and Github actions cannot access secret keys from forks.