### PR TITLE
Fix TS build 2094

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     "jsx": "react",
     "sourceMap": true,
     "moduleResolution": "node",
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "types": ["react", "lodash"],
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
@@ -20,7 +24,7 @@
     "paths": {
       "@packages/*": ["packages/*"]
     },
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "include": [
     "**/src/*",


### PR DESCRIPTION
## Description:

In the main code of the project, all packages have `index.d.ts` files. `skipLibCheck` is set to `true` in the project `tsconfig.json`, which means that unimplemented types can slip through these files without causing a compile error. These errors can then show up after a build release, when users install Victory into their TypeScript projects and set `skipLibCheck` to `true`.

### How the fix is made

- In `tsconfig.json`
```diff
{
  "compilerOptions": {
    "baseUrl": ".",
    "outDir": "demo/dist",
    "rootDir": ".",
    "module": "es6",
    "target": "es5",
    "jsx": "react",
    "sourceMap": true,
    "moduleResolution": "node",
+   "typeRoots": [
+     "./node_modules/@types"
+   ],
+   "types": ["react", "lodash"],
    "allowSyntheticDefaultImports": true,
    "forceConsistentCasingInFileNames": true,
    "noImplicitReturns": true,
    "noImplicitThis": true,
    "noImplicitAny": true,
    "noUnusedLocals": true,
    "strictNullChecks": true,
    "strict": true,
    "suppressImplicitAnyIndexErrors": true,
    "paths": {
      "@packages/*": ["packages/*"]
    },
-   "skipLibCheck": true
+   "skipLibCheck": false
  },
  "include": [
    "**/src/*",
    "demo/ts/*"
  ],
  "exclude": [
      "node_modules",
      "**/*.spec.ts"
  ]
}
```
- Types for react and lodash (which is used in `demo`) are explicitly included

### Testing:

1. In `packages/victory/src/index.ts`, uncomment any unimplemented type <img width="616" alt="Screen Shot 2022-02-14 at 6 32 30 PM" src="https://user-images.githubusercontent.com/7357877/153970065-aaf26baa-b4f0-4454-aff9-0b162c741a5d.png">
2. Run the command `nps compile-ts` <img width="1067" alt="Screen Shot 2022-03-01 at 2 00 51 PM" src="https://user-images.githubusercontent.com/7357877/156248914-a08cac14-6cf1-4f34-bfc5-90565a361b95.png">

