### PR TITLE
Add RegExp array to voronoiBlacklist type

### DIFF
--- a/packages/victory-voronoi-container/src/index.d.ts
+++ b/packages/victory-voronoi-container/src/index.d.ts
@@ -11,7 +11,7 @@ export interface VictoryVoronoiContainerProps extends VictoryContainerProps {
   onActivated?: (points: any[], props: VictoryVoronoiContainerProps) => void;
   onDeactivated?: (points: any[], props: VictoryVoronoiContainerProps) => void;
   radius?: number;
-  voronoiBlacklist?: string[];
+  voronoiBlacklist?: (string | RegExp)[];
   voronoiDimension?: "x" | "y";
   voronoiPadding?: PaddingProps;
 }


### PR DESCRIPTION
typings for ```voronoiBlacklist``` do not currently include regular expressions, which are supported as of [this](https://github.com/FormidableLabs/victory/pull/1278) PR. This changes the type so ```voronoiBlacklist``` correctly allows both strings and regular expressions.