### PR TITLE
WIP - Allow safe user props to be passed to Area, Axis, Bar, BoxPlot, BrushLine, and ClipContainer

### DIFF
--- a/demo/ts/components/victory-area-demo.tsx
+++ b/demo/ts/components/victory-area-demo.tsx
@@ -137,6 +137,8 @@ export default class VictoryAreaDemo extends React.Component<
       <div className="demo" style={containerStyle}>
         <VictoryChart style={style} scale={{ y: "log" }}>
           <VictoryArea
+            data-test-variable="TESTING 123"
+            aria-label="Victory Area Chart"
             style={{ data: { fill: "cyan", stroke: "cyan" } }}
             labels={({ datum }: any) => Math.round(datum.y)}
             data={[
@@ -438,7 +440,11 @@ export default class VictoryAreaDemo extends React.Component<
         </VictoryStack>
 
         <VictoryChart style={style} theme={VictoryTheme.material}>
-          <VictoryArea style={style} data={[]} />
+          <VictoryArea
+            style={style}
+            data={[]}
+            data-something="TESTING User Props"
+          />
         </VictoryChart>
       </div>
     );

--- a/demo/ts/components/victory-axis-demo.tsx
+++ b/demo/ts/components/victory-axis-demo.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { merge, random, range } from "lodash";
 import { DomainPropType } from "@packages/victory-core";
 import { VictoryAxis, VictoryAxisProps } from "@packages/victory-axis";
+import { VictoryChart } from "@packages/victory-chart";
+import { VictoryScatter } from "@packages/victory-scatter";
 import {
   VictoryLabel,
   VictoryContainer,
@@ -89,10 +91,15 @@ export default class VictoryAxisDemo extends React.Component<
       justifyContent: "center"
     };
 
+    const chartStyle = {
+      parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" }
+    };
+
     return (
       <div className="demo">
         <div style={containerStyle}>
           <VictoryAxis
+            data-user-prop="This prop for testing purposes only"
             style={{
               parent: styleOverrides.parent,
               grid: { stroke: "#CFD8DC" }
@@ -111,7 +118,6 @@ export default class VictoryAxisDemo extends React.Component<
               />
             }
           />
-
           <VictoryAxis
             scale="time"
             style={{
@@ -273,6 +279,22 @@ export default class VictoryAxisDemo extends React.Component<
               "Mariners\nSEA"
             ]}
           />
+
+          <VictoryChart style={chartStyle} horizontal>
+            <VictoryAxis
+              data-user-prop2="This prop for testing purposes only2"
+              tickValues={[
+                new Date(1985, 1, 1),
+                new Date(1990, 1, 1),
+                new Date(1995, 1, 1),
+                new Date(2000, 1, 1),
+                new Date(2005, 1, 1),
+                new Date(2010, 1, 1)
+              ]}
+              tickFormat={(x) => new Date(x).getFullYear()}
+            />
+            <VictoryScatter data={[]} />
+          </VictoryChart>
         </div>
       </div>
     );

--- a/demo/ts/components/victory-bar-demo.tsx
+++ b/demo/ts/components/victory-bar-demo.tsx
@@ -155,6 +155,8 @@ export default class VictoryBarDemo extends React.Component<
       <div className="demo" style={containerStyle}>
         <ChartWrap>
           <VictoryBar
+            aria-label="This is a test"
+            data-testing-user-props="Testing 123"
             cornerRadius={4}
             scale={{ y: "log", x: "linear" }}
             horizontal
@@ -228,6 +230,8 @@ export default class VictoryBarDemo extends React.Component<
 
         <VictoryChart domainPadding={{ y: 20 }}>
           <VictoryBar
+            aria-label="This is a test 2"
+            data-testing-user-props="Testing 123-2"
             data={[
               { x: 1, y: "Alpha" },
               { x: 7, y: "Beta" },
@@ -458,6 +462,8 @@ export default class VictoryBarDemo extends React.Component<
           />
         </VictoryStack>
         <VictoryBar
+          aria-label="This is a test"
+          data-testing-user-props="Testing 123"
           theme={VictoryTheme.grayscale}
           style={{
             parent: parentStyle,

--- a/demo/ts/components/victory-box-plot-demo.tsx
+++ b/demo/ts/components/victory-box-plot-demo.tsx
@@ -68,6 +68,8 @@ export default class VictoryBoxPlotDemo extends React.Component<
           theme={VictoryTheme.material}
         >
           <VictoryBoxPlot
+            aria-label="This is a test"
+            data-testing-user-props="Testing 123"
             minLabels
             maxLabels
             data={[
@@ -225,6 +227,8 @@ export default class VictoryBoxPlotDemo extends React.Component<
           <VictoryBoxPlot boxWidth={10} data={this.state.data} />
         </VictoryChart>
         <VictoryBoxPlot
+          aria-label="This is a test"
+          data-testing-user-props="Testing 123"
           animate
           style={chartStyle}
           boxWidth={10}

--- a/demo/ts/components/victory-brush-line-demo.tsx
+++ b/demo/ts/components/victory-brush-line-demo.tsx
@@ -226,6 +226,8 @@ class App extends React.Component<any, BrushLineDemoState> {
                 externalEventMutations={this.state.externalMutation}
                 axisComponent={
                   <VictoryBrushLine
+                    aria-label="This is a test"
+                    data-testing-user-props="Testing 123"
                     name={attribute}
                     width={20}
                     onBrushDomainChange={this.onDomainChange.bind(this)}

--- a/demo/ts/components/victory-stack-demo.tsx
+++ b/demo/ts/components/victory-stack-demo.tsx
@@ -1,29 +1,39 @@
 import React from "react";
 import { VictoryStack } from "@packages/victory-stack/src/index";
 import { VictoryArea } from "@packages/victory-area/src/index";
-
 class App extends React.Component {
-
   render() {
     return (
       <div>
-        <h3 style={{textAlign: 'center'}}>Standalone Stack</h3>
+        <h3 style={{ textAlign: "center" }}>Standalone Stack</h3>
         <VictoryStack
           aria-label="Victory Stack Demo"
           data-some-user-prop="TESTING 123"
         >
           <VictoryArea
-            data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 5}]}
+            data={[
+              { x: "a", y: 2 },
+              { x: "b", y: 3 },
+              { x: "c", y: 5 }
+            ]}
           />
           <VictoryArea
-            data={[{x: "a", y: 1}, {x: "b", y: 4}, {x: "c", y: 5}]}
+            data={[
+              { x: "a", y: 1 },
+              { x: "b", y: 4 },
+              { x: "c", y: 5 }
+            ]}
           />
           <VictoryArea
-            data={[{x: "a", y: 3}, {x: "b", y: 2}, {x: "c", y: 6}]}
+            data={[
+              { x: "a", y: 3 },
+              { x: "b", y: 2 },
+              { x: "c", y: 6 }
+            ]}
           />
         </VictoryStack>
       </div>
-    )
+    );
   }
 }
 

--- a/packages/victory-area/src/helper-methods.js
+++ b/packages/victory-area/src/helper-methods.js
@@ -1,11 +1,12 @@
 import { assign, isNil } from "lodash";
 import {
-  Helpers,
-  LabelHelpers,
+  Collection,
   Data,
   Domain,
+  Helpers,
+  LabelHelpers,
   Scale,
-  Collection
+  UserProps
 } from "victory-core";
 
 export const getDataWithBaseline = (props, scale) => {
@@ -66,6 +67,8 @@ const getCalculatedValues = (props) => {
 
 export const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "area");
+  const userProps = UserProps.getSafeUserProps(props);
+
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data,
@@ -102,7 +105,8 @@ export const getBaseProps = (props, fallbackProps) => {
       origin,
       padding,
       name,
-      horizontal
+      horizontal,
+      userProps
     },
     all: {
       data: {
@@ -115,7 +119,8 @@ export const getBaseProps = (props, fallbackProps) => {
         groupComponent,
         style: disableInlineStyles ? {} : style.data,
         disableInlineStyles
-      }
+      },
+      userProps
     }
   };
   return data.reduce((childProps, datum, index) => {

--- a/packages/victory-area/src/victory-area.js
+++ b/packages/victory-area/src/victory-area.js
@@ -3,17 +3,17 @@ import React from "react";
 import { getBaseProps } from "./helper-methods";
 import Area from "./area";
 import {
-  PropTypes as CustomPropTypes,
-  Helpers,
-  VictoryLabel,
-  VictoryContainer,
-  CommonProps,
-  DefaultTransitions,
-  VictoryClipContainer,
   addEvents,
-  VictoryTheme,
+  CommonProps,
   Data,
-  Domain
+  DefaultTransitions,
+  Domain,
+  Helpers,
+  PropTypes as CustomPropTypes,
+  VictoryClipContainer,
+  VictoryContainer,
+  VictoryLabel,
+  VictoryTheme
 } from "victory-core";
 
 const fallbackProps = {

--- a/packages/victory-axis/src/helper-methods.js
+++ b/packages/victory-axis/src/helper-methods.js
@@ -1,5 +1,5 @@
 import { assign, defaults } from "lodash";
-import { Helpers, Scale, Axis } from "victory-core";
+import { Axis, Helpers, Scale, UserProps } from "victory-core";
 
 const orientationSign = {
   top: -1,
@@ -541,6 +541,8 @@ const getCalculatedValues = (props) => {
 export const getBaseProps = (props, fallbackProps) => {
   props = Axis.modifyProps(props, fallbackProps);
   const calculatedValues = getCalculatedValues(props);
+  const userProps = UserProps.getSafeUserProps(props);
+
   const {
     axis,
     style,
@@ -585,7 +587,8 @@ export const getBaseProps = (props, fallbackProps) => {
         height,
         padding,
         domain,
-        name
+        name,
+        userProps
       },
       sharedProps
     )

--- a/packages/victory-axis/src/victory-axis.js
+++ b/packages/victory-axis/src/victory-axis.js
@@ -2,15 +2,16 @@ import PropTypes from "prop-types";
 import React from "react";
 import { assign, isEmpty } from "lodash";
 import {
-  PropTypes as CustomPropTypes,
-  VictoryLabel,
-  CommonProps,
-  VictoryContainer,
-  VictoryTheme,
-  LineSegment,
-  TextSize,
   addEvents,
-  Axis
+  Axis,
+  CommonProps,
+  LineSegment,
+  PropTypes as CustomPropTypes,
+  TextSize,
+  UserProps,
+  VictoryContainer,
+  VictoryLabel,
+  VictoryTheme
 } from "victory-core";
 import { getBaseProps, getStyles } from "./helper-methods";
 
@@ -282,9 +283,11 @@ class VictoryAxis extends React.Component {
       this.renderLabel(props),
       ...modifiedGridAndTicks
     ];
+
+    const userProps = UserProps.getSafeUserProps(props);
     return props.standalone
       ? this.renderContainer(props.containerComponent, children)
-      : React.cloneElement(props.groupComponent, {}, children);
+      : React.cloneElement(props.groupComponent, { ...userProps }, children);
   }
 }
 

--- a/packages/victory-bar/src/helper-methods.js
+++ b/packages/victory-bar/src/helper-methods.js
@@ -5,7 +5,8 @@ import {
   Domain,
   Helpers,
   LabelHelpers,
-  Scale
+  Scale,
+  UserProps
 } from "victory-core";
 
 export const getBarPosition = (props, datum) => {
@@ -68,6 +69,8 @@ const getCalculatedValues = (props) => {
 export const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "bar");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const userProps = UserProps.getSafeUserProps(props);
+
   const {
     alignment,
     barRatio,
@@ -106,7 +109,8 @@ export const getBaseProps = (props, fallbackProps) => {
       polar,
       origin,
       padding,
-      style: style.parent
+      style: style.parent,
+      userProps
     }
   };
 

--- a/packages/victory-box-plot/src/helper-methods.js
+++ b/packages/victory-box-plot/src/helper-methods.js
@@ -8,7 +8,14 @@ import {
   isNaN,
   isNil
 } from "lodash";
-import { Helpers, Scale, Domain, Data, Collection } from "victory-core";
+import {
+  Collection,
+  Data,
+  Domain,
+  Helpers,
+  Scale,
+  UserProps
+} from "victory-core";
 import { min as d3Min, max as d3Max, quantile as d3Quantile } from "d3-array";
 
 const TYPES = ["max", "min", "median", "q1", "q3"];
@@ -456,6 +463,8 @@ const isDatumOutOfBounds = (datum, domain) => {
 export const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "boxplot");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const userProps = UserProps.getSafeUserProps(props);
+
   const {
     groupComponent,
     width,
@@ -485,7 +494,8 @@ export const getBaseProps = (props, fallbackProps) => {
       style: style.parent || {},
       padding,
       groupComponent,
-      horizontal
+      horizontal,
+      userProps
     }
   };
   const boxScale = scale.y;

--- a/packages/victory-box-plot/src/victory-box-plot.js
+++ b/packages/victory-box-plot/src/victory-box-plot.js
@@ -2,17 +2,18 @@ import React from "react";
 import PropTypes from "prop-types";
 import { flatten, isNil } from "lodash";
 import {
-  Helpers,
-  VictoryLabel,
   addEvents,
+  Box,
+  CommonProps,
+  DefaultTransitions,
+  Helpers,
   LineSegment,
   PropTypes as CustomPropTypes,
+  UserProps,
   VictoryContainer,
+  VictoryLabel,
   VictoryTheme,
-  Box,
-  Whisker,
-  DefaultTransitions,
-  CommonProps
+  Whisker
 } from "victory-core";
 import { getDomain, getData, getBaseProps } from "./helper-methods";
 
@@ -278,7 +279,9 @@ class VictoryBoxPlot extends React.Component {
       })
     );
     const children = [...dataComponents, ...labelComponents];
-    return this.renderContainer(props.groupComponent, children);
+
+    const userProps = UserProps.getSafeUserProps(props);
+    return React.cloneElement(props.groupComponent, { ...userProps }, children);
   }
 
   // Overridden in native versions

--- a/packages/victory-brush-line/src/victory-brush-line.js
+++ b/packages/victory-brush-line/src/victory-brush-line.js
@@ -1,13 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import {
-  Selection,
-  Helpers,
+  Box,
   Collection,
+  Domain,
+  Helpers,
   LineSegment,
   Scale,
-  Domain,
-  Box
+  Selection,
+  UserProps
 } from "victory-core";
 import { assign, defaults, isFunction, pick } from "lodash";
 import isEqual from "react-fast-compare";
@@ -656,8 +657,10 @@ export default class VictoryBrushLine extends React.Component {
   }
 
   render() {
+    const userProps = UserProps.getSafeUserProps(this.props);
+    const groupProps = { ...this.props.events, ...userProps };
     return (
-      <g {...this.props.events}>
+      <g {...groupProps}>
         {this.renderLine(this.props)}
         {this.renderBrushArea(this.props)}
         {this.renderBrush(this.props)}

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.js
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.js
@@ -91,8 +91,10 @@ export default class VictoryClipContainer extends React.Component {
       children,
       className,
       groupComponent,
-      tabIndex
+      tabIndex,
+      userProps = {}
     } = props;
+
     const clipComponent = this.renderClipComponent(props, clipId);
     const groupProps = assign(
       {
@@ -100,7 +102,8 @@ export default class VictoryClipContainer extends React.Component {
         style,
         transform,
         key: `clipped-group-${clipId}`,
-        clipPath: `url(#${clipId})`
+        clipPath: `url(#${clipId})`,
+        ...userProps
       },
       events
     );
@@ -121,6 +124,7 @@ export default class VictoryClipContainer extends React.Component {
       groupComponent,
       tabIndex
     } = props;
+
     return React.cloneElement(
       groupComponent,
       assign(

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -280,7 +280,11 @@ export default (WrappedComponent, options) => {
         this.globalEvents = Events.getGlobalEvents(parentProps.events);
         parentProps.events = Events.omitGlobalEvents(parentProps.events);
       }
+<<<<<<< HEAD
       
+=======
+
+>>>>>>> 0623b6f3 (Allow users to pass user props to the following components: VictoryArea, VictoryAxis, VictoryBar, VictoryBoxPlot, VictoryBrushLine, and VictoryClipContainer. NOTE: User props will be filtered and only ones that match the user props safelist rules will be passed along to the component.)
       const componentProps = { ...parentProps, ...parentProps.userProps };
       return React.cloneElement(component, componentProps, children);
     }

--- a/packages/victory-group/src/victory-group.js
+++ b/packages/victory-group/src/victory-group.js
@@ -89,7 +89,10 @@ const VictoryGroup = (initialProps) => {
     name
   ]);
 
-  const userProps = React.useMemo(() => UserProps.getSafeUserProps(initialProps), [initialProps]);
+  const userProps = React.useMemo(
+    () => UserProps.getSafeUserProps(initialProps),
+    [initialProps]
+  );
 
   const container = React.useMemo(() => {
     if (standalone) {
@@ -103,7 +106,13 @@ const VictoryGroup = (initialProps) => {
     }
     
     return React.cloneElement(groupComponent, userProps);
-  }, [groupComponent, standalone, containerComponent, containerProps, userProps]);
+  }, [
+    groupComponent,
+    standalone,
+    containerComponent,
+    containerProps,
+    userProps
+  ]);
 
   const events = React.useMemo(() => {
     return Wrapper.getAllEvents(props);

--- a/packages/victory-stack/src/victory-stack.js
+++ b/packages/victory-stack/src/victory-stack.js
@@ -95,7 +95,10 @@ const VictoryStack = (initialProps) => {
     origin,
     name
   ]);
-  const userProps = React.useMemo(() => UserProps.getSafeUserProps(initialProps), [initialProps]);
+  const userProps = React.useMemo(
+    () => UserProps.getSafeUserProps(initialProps),
+    [initialProps]
+  );
 
   const container = React.useMemo(() => {
     if (standalone) {
@@ -108,7 +111,13 @@ const VictoryStack = (initialProps) => {
       return React.cloneElement(containerComponent, defaultContainerProps);
     }
     return React.cloneElement(groupComponent, userProps);
-  }, [groupComponent, standalone, containerComponent, containerProps, userProps]);
+  }, [
+    groupComponent,
+    standalone,
+    containerComponent,
+    containerProps,
+    userProps
+  ]);
 
   const events = React.useMemo(() => {
     return Wrapper.getAllEvents(props);


### PR DESCRIPTION
### Description
Allow users to pass user props to the following components: VictoryArea, VictoryAxis, VictoryBar, VictoryBoxPlot, VictoryBrushLine, and VictoryClipContainer.

NOTE: User props will be filtered and only ones that match the user props safelist rules will be passed along to the component.

### Testing Procedures
Test the following examples for this PR:

- [VictoryArea](http://localhost:3000/#/area)
- [VictoryAxis](http://localhost:3000/#/axis)
- [VictoryBar](http://localhost:3000/#/bar)
- [VictoryBoxPlot](http://localhost:3000/#/boxplot)
- [VictoryBrushLine](http://localhost:3000/#/victory-brush-line)
- [VictoryClipContainer](http://localhost:3000/#/#)

1. Inspect the first item on the example page with Dev Tools. This will be the element WITH a VictoryChart wrapper.  You should see a "data-test-variable" and an "aria-label" attribute attached to the `<g>` tag within the SVG.
2. Inspect the last item on the example page with Dev Tools. This will be the element WITHOUT a VictoryChart wrapper.  You should see a "data-test-variable" and an "aria-label" attribute attached to the `<svg>` tag within the VictoryContainer div.  A VictoryContainer gets added when the chart is considered standalone (not inside a VictoryChart wrapper).


NOTE: There are a few exceptions to where the attributes get added based on the way the components are created.  However, you should find them in the `<svg>` or `<g>` tags for that component when inspecting with DevTools. 

Exceptions to these 2 rules in this PR: 
- 