### PR TITLE
Fix Horizontal charts panning at the incorrect rate

### DIFF
--- a/packages/victory-zoom-container/src/zoom-helpers.js
+++ b/packages/victory-zoom-container/src/zoom-helpers.js
@@ -138,7 +138,7 @@ const RawZoomHelpers = {
       ? newDomain.map((val) => new Date(val))
       : newDomain;
   },
-  // eslint-disable-next-line max-params
+
   getDomainScale(domain, scale, axis) {
     const axisDomain = Array.isArray(domain) ? domain : domain[axis];
     const [from, to] = axisDomain;

--- a/packages/victory-zoom-container/src/zoom-helpers.js
+++ b/packages/victory-zoom-container/src/zoom-helpers.js
@@ -259,10 +259,8 @@ const RawZoomHelpers = {
       const lastDomain = this.getLastDomain(targetProps, originalDomain);
       const deltaX = horizontal ? y - startY : startX - x;
       const deltaY = horizontal ? startX - x : y - startY;
-      const dx =
-        deltaX / this.getDomainScale(lastDomain, scale, "x");
-      const dy =
-        deltaY / this.getDomainScale(lastDomain, scale, "y");
+      const dx = deltaX / this.getDomainScale(lastDomain, scale, "x");
+      const dy = deltaY / this.getDomainScale(lastDomain, scale, "y");
       const currentDomain = {
         x:
           zoomDimension === "y"

--- a/packages/victory-zoom-container/src/zoom-helpers.js
+++ b/packages/victory-zoom-container/src/zoom-helpers.js
@@ -139,11 +139,10 @@ const RawZoomHelpers = {
       : newDomain;
   },
   // eslint-disable-next-line max-params
-  getDomainScale(domain, scale, axis, horizontal) {
+  getDomainScale(domain, scale, axis) {
     const axisDomain = Array.isArray(domain) ? domain : domain[axis];
     const [from, to] = axisDomain;
-    const otherAxis = axis === "x" ? "y" : "x";
-    const range = horizontal ? scale[otherAxis].range() : scale[axis].range();
+    const range = scale[axis].range();
     const plottableWidth = Math.abs(range[0] - range[1]);
     return plottableWidth / (to - from);
   },
@@ -261,9 +260,9 @@ const RawZoomHelpers = {
       const deltaX = horizontal ? y - startY : startX - x;
       const deltaY = horizontal ? startX - x : y - startY;
       const dx =
-        deltaX / this.getDomainScale(lastDomain, scale, "x", horizontal);
+        deltaX / this.getDomainScale(lastDomain, scale, "x");
       const dy =
-        deltaY / this.getDomainScale(lastDomain, scale, "y", horizontal);
+        deltaY / this.getDomainScale(lastDomain, scale, "y");
       const currentDomain = {
         x:
           zoomDimension === "y"


### PR DESCRIPTION
This is in regards to this bug reported for horizontal graphs: https://github.com/FormidableLabs/victory/issues/2083

### The Problem
When a chart is set to horizontal mode and is zoomed and panned, the panning rate is not 1:1 with mouse movement.

It looks like getDomainScale is setting the range incorrectly.
```
  getDomainScale(domain, scale, axis, horizontal) {
    const axisDomain = Array.isArray(domain) ? domain : domain[axis];
    const [from, to] = axisDomain;
    const otherAxis = axis === "x" ? "y" : "x";
    const range = horizontal ? scale[otherAxis].range() : scale[axis].range();
    const plottableWidth = Math.abs(range[0] - range[1]);
    return plottableWidth / (to - from);
  },
```

const range does not need to switch the axis - scale already handles that:
```
  const scale = {
    x: Scale.getBaseScale(props, "x")
      .domain(domain.x)
      .range(props.horizontal ? range.y : range.x),
    y: Scale.getBaseScale(props, "y")
      .domain(domain.y)
      .range(props.horizontal ? range.x : range.y)
  };
```

 So range would just need to be:
```
 const range =  scale[axis].range();
```

This appears to fix horizontal panning! Everything else appears to still be working properly as well. 
