### PR TITLE
Added the ability to add victory charts title and desc props for better accessibility

### DIFF
--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -213,11 +213,20 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
-          <VictoryChart style={chartStyle} polar>
+          <VictoryChart 
+            polar
+            style={chartStyle} 
+            title="Victory Polar Scatter Chart"
+            desc="Circular graph with a twirl pattern of data points."
+          >
             <VictoryScatter />
           </VictoryChart>
 
-          <VictoryChart style={assign({}, chartStyle, bgStyle)}>
+          <VictoryChart
+            style={assign({}, chartStyle, bgStyle)}  
+            title="Victory Scatter Chart"
+            desc="Graph with scattered data points"
+          >
             <VictoryScatter
               data={[
                 { x: -3, y: -3 },
@@ -227,11 +236,21 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart style={chartStyle} theme={dependentAxisTheme}>
+          <VictoryChart 
+            style={chartStyle} 
+            theme={dependentAxisTheme}
+            title="Victory Diagonal Scatter Chart"
+            desc="Graph with a diagonal pattern of data points."
+          >
             <VictoryScatter />
           </VictoryChart>
 
-          <VictoryChart style={chartStyle} domainPadding={{ x: [0, 20] }}>
+          <VictoryChart 
+            style={chartStyle} 
+            domainPadding={{ x: [0, 20] }}
+            title="Victory Bar Chart"
+            desc="Bar graph"
+          >
             <VictoryAxis dependentAxis style={axisStyle} />
             <VictoryAxis style={axisStyle} tickCount={6} />
             <VictoryBar
@@ -249,7 +268,11 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart style={chartStyle}>
+          <VictoryChart 
+            style={chartStyle}
+            title="Victory Bar Chart with label data bars"
+            desc="Bar graph with labeled data bars with different widths."
+          >
             <VictoryAxis tickFormat={(t, i, ts) => `${t}s ${i} ${ts[0]}`} />
             <VictoryBar
               groupComponent={<VictoryClipContainer />}
@@ -262,7 +285,11 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart style={chartStyle}>
+          <VictoryChart
+            style={chartStyle}
+            title="Victory Horizontal Bar Graph"
+            desc="Horizontal bar graph data with x and y axis points."
+          >
             <VictoryGroup
               labels={["a", "b", "c"]}
               horizontal

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -217,7 +217,7 @@ class App extends React.Component {
             polar
             style={chartStyle} 
             title="Victory Polar Scatter Chart"
-            desc="Circular graph with a twirl pattern of data points."
+            desc="Circular graph with a twirl pattern of data points"
           >
             <VictoryScatter />
           </VictoryChart>
@@ -240,7 +240,7 @@ class App extends React.Component {
             style={chartStyle} 
             theme={dependentAxisTheme}
             title="Victory Diagonal Scatter Chart"
-            desc="Graph with a diagonal pattern of data points."
+            desc="Graph with a diagonal pattern of data points"
           >
             <VictoryScatter />
           </VictoryChart>
@@ -271,7 +271,7 @@ class App extends React.Component {
           <VictoryChart 
             style={chartStyle}
             title="Victory Bar Chart with label data bars"
-            desc="Bar graph with labeled data bars with different widths."
+            desc="Bar graph with labeled data bars with different widths"
           >
             <VictoryAxis tickFormat={(t, i, ts) => `${t}s ${i} ${ts[0]}`} />
             <VictoryBar
@@ -288,7 +288,7 @@ class App extends React.Component {
           <VictoryChart
             style={chartStyle}
             title="Victory Horizontal Bar Graph"
-            desc="Horizontal bar graph data with x and y axis points."
+            desc="Horizontal bar graph data with x and y axis points"
           >
             <VictoryGroup
               labels={["a", "b", "c"]}

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -213,9 +213,9 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
-          <VictoryChart 
+          <VictoryChart
             polar
-            style={chartStyle} 
+            style={chartStyle}
             title="Victory Polar Scatter Chart"
             desc="Circular graph with a twirl pattern of data points"
           >
@@ -223,7 +223,7 @@ class App extends React.Component {
           </VictoryChart>
 
           <VictoryChart
-            style={assign({}, chartStyle, bgStyle)}  
+            style={assign({}, chartStyle, bgStyle)}
             title="Victory Scatter Chart"
             desc="Graph with scattered data points"
           >
@@ -236,8 +236,8 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart 
-            style={chartStyle} 
+          <VictoryChart
+            style={chartStyle}
             theme={dependentAxisTheme}
             title="Victory Diagonal Scatter Chart"
             desc="Graph with a diagonal pattern of data points"
@@ -245,8 +245,8 @@ class App extends React.Component {
             <VictoryScatter />
           </VictoryChart>
 
-          <VictoryChart 
-            style={chartStyle} 
+          <VictoryChart
+            style={chartStyle}
             domainPadding={{ x: [0, 20] }}
             title="Victory Bar Chart"
             desc="Bar graph"
@@ -268,7 +268,7 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart 
+          <VictoryChart
             style={chartStyle}
             title="Victory Bar Chart with label data bars"
             desc="Bar graph with labeled data bars with different widths"

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -37,6 +37,7 @@ const VictoryChart = (initialProps) => {
 
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, role);
   const {
+    desc,
     eventKey,
     containerComponent,
     standalone,
@@ -46,7 +47,8 @@ const VictoryChart = (initialProps) => {
     height,
     theme,
     polar,
-    name
+    name,
+    title,
   } = modifiedProps;
 
   const axes = props.polar
@@ -90,34 +92,38 @@ const VictoryChart = (initialProps) => {
   const containerProps = React.useMemo(() => {
     if (standalone) {
       return {
+        desc,
         domain,
-        scale,
         width,
         height,
-        standalone,
-        theme,
-        style: style.parent,
         horizontal,
         name,
+        origin: polar ? origin : undefined,
         polar,
         radius,
-        origin: polar ? origin : undefined
+        theme,
+        title,
+        scale,
+        standalone,
+        style: style.parent
       };
     }
     return {};
   }, [
+    desc,
     domain,
-    scale,
-    width,
     height,
-    standalone,
-    theme,
-    style,
     horizontal,
     name,
+    origin,
     polar,
     radius,
-    origin
+    scale,
+    standalone,
+    style,
+    title,
+    theme,
+    width
   ]);
 
   const container = React.useMemo(() => {

--- a/packages/victory-chart/src/victory-chart.js
+++ b/packages/victory-chart/src/victory-chart.js
@@ -48,7 +48,7 @@ const VictoryChart = (initialProps) => {
     theme,
     polar,
     name,
-    title,
+    title
   } = modifiedProps;
 
   const axes = props.polar


### PR DESCRIPTION
## The Problem:
- When running the Chrome/Edge Accessibility Insights tool, the `VictoryCharts` component throws the error below due to missing alternate text:
![image](https://user-images.githubusercontent.com/42012215/164109963-ad72bfb2-66f4-4124-9711-95d9097c358e.png)

## The solution:
- Added the ability to add a title and description to the `VictoryChart` svg component: 
![image](https://user-images.githubusercontent.com/42012215/164110142-a13a9283-44de-4790-9574-6ad8ef24e355.png)

![image](https://user-images.githubusercontent.com/42012215/164110101-396cd643-4bf4-4aa6-8b31-dd9d5595c3f8.png)

## Tested
- Tested manually by adding the new title and description props to some of the `VictoryCharts` components within the `victory-chart-demo.js` file and running the accessibility tool:
![image](https://user-images.githubusercontent.com/42012215/164110382-20560a35-630d-4763-a613-3e7b9df7885c.png)

All `VictoryChart` components with the new title and desc props present pass with no errors, while the rest still fail.

This PR is created to resolve this issue: https://github.com/FormidableLabs/victory/issues/2078 
Accessibility tool: https://chrome.google.com/webstore/detail/accessibility-insights-fo/pbjjkligggfmakdaogkfomddhfmpjeni?msclkid=e63b5c6bc02e11ec9e1dd5de91f4d99d