### PR TITLE
add style interface to SliceProps type

### DIFF
--- a/packages/victory-pie/src/index.d.ts
+++ b/packages/victory-pie/src/index.d.ts
@@ -42,6 +42,7 @@ export interface SliceProps extends VictoryCommonProps {
   };
   sliceEndAngle?: SliceNumberOrCallback<SliceProps, "sliceEndAngle">;
   sliceStartAngle?: SliceNumberOrCallback<SliceProps, "sliceStartAngle">;
+  style?: VictoryStyleInterface;
   tabIndex?: NumberOrCallback;
 }
 


### PR DESCRIPTION
This PR address #2090 and adds `VictoryStyleInterface` as an optional `style` value to the `SliceProps` type declaration. This matches behavior and [the documentation](https://formidable.com/open-source/victory/docs/victory-primitives/#slice) for this component.