### PR TITLE
Add victory core tests

### DIFF
--- a/packages/victory-core/src/victory-label/victory-label.js
+++ b/packages/victory-core/src/victory-label/victory-label.js
@@ -12,6 +12,7 @@ import * as Log from "../victory-util/log";
 import * as CustomPropTypes from "../victory-util/prop-types";
 import * as Style from "../victory-util/style";
 import * as TextSize from "../victory-util/textsize";
+import * as UserProps from "../victory-util/user-props";
 
 const defaultStyles = {
   fill: "#252525",
@@ -487,6 +488,7 @@ const renderLabel = (calculatedProps, tspanValues) => {
     tspanComponent,
     textComponent
   } = calculatedProps;
+  const userProps = UserProps.getSafeUserProps(calculatedProps);
 
   const textProps = {
     "aria-label": ariaLabel,
@@ -501,7 +503,8 @@ const renderLabel = (calculatedProps, tspanValues) => {
     title,
     desc: Helpers.evaluateProp(desc, calculatedProps),
     tabIndex: Helpers.evaluateProp(tabIndex, calculatedProps),
-    id
+    id,
+    ...userProps
   };
 
   const tspans = text.map((line, i) => {
@@ -528,6 +531,7 @@ const VictoryLabel = (props) => {
     return null;
   }
   const calculatedProps = getCalculatedProps(props);
+
   const { text, style, capHeight, backgroundPadding, lineHeight } =
     calculatedProps;
 

--- a/test/jest/rendering-utils.js
+++ b/test/jest/rendering-utils.js
@@ -1,0 +1,6 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+
+export const renderInSvg = (component) => {
+  return render(<svg>{component}</svg>);
+};

--- a/test/jest/victory-core/victory-accessible-group/victory-accessible-group.test.js
+++ b/test/jest/victory-core/victory-accessible-group/victory-accessible-group.test.js
@@ -1,0 +1,75 @@
+import React from "react";
+import { renderInSvg } from "../../rendering-utils";
+import { VictoryAccessibleGroup } from "victory-core";
+// This prevents the warnings about the `g` attribute being unrecognized outside of an SVG container.
+
+describe("components/victory-accessible-group", () => {
+  it("renders an g with an aria-label", () => {
+    const { container } = renderInSvg(
+      <VictoryAccessibleGroup aria-label="test-aria-label" />
+    );
+    expect(container.querySelector("g")).toMatchInlineSnapshot(`
+      <g
+        aria-label="test-aria-label"
+        class="VictoryAccessibleGroup"
+      />
+    `);
+  });
+
+  it("renders an g with a tabIndex and className", () => {
+    const { container } = renderInSvg(
+      <VictoryAccessibleGroup tabIndex={5} className="accessibility" />
+    );
+    expect(container.querySelector("g")).toMatchInlineSnapshot(`
+      <g
+        class="accessibility"
+        tabindex="5"
+      />
+    `);
+  });
+
+  it("renders an g with a desc node if given", () => {
+    const { container } = renderInSvg(
+      <VictoryAccessibleGroup
+        aria-label="desc node tests"
+        desc="test description"
+        aria-describedby="describes group"
+      />
+    );
+    expect(container.querySelector("g")).toMatchInlineSnapshot(`
+      <g
+        aria-describedby="describes group"
+        aria-label="desc node tests"
+        class="VictoryAccessibleGroup"
+      >
+        <desc
+          id="describes group"
+        >
+          test description
+        </desc>
+      </g>
+    `);
+  });
+
+  it("uses the desc getAttribute value for descId and aria-describedby if no aria-describedby getAttribute value", () => {
+    const { container } = renderInSvg(
+      <VictoryAccessibleGroup
+        aria-label="desc node tests"
+        desc="applies to both aria-describeby and descId"
+      />
+    );
+    expect(container.querySelector("g")).toMatchInlineSnapshot(`
+      <g
+        aria-describedby="applies-to-both-aria-describeby-and-descId"
+        aria-label="desc node tests"
+        class="VictoryAccessibleGroup"
+      >
+        <desc
+          id="applies-to-both-aria-describeby-and-descId"
+        >
+          applies to both aria-describeby and descId
+        </desc>
+      </g>
+    `);
+  });
+});

--- a/test/jest/victory-core/victory-accessible-group/victory-accessible-group.test.js
+++ b/test/jest/victory-core/victory-accessible-group/victory-accessible-group.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { renderInSvg } from "../../rendering-utils";
 import { VictoryAccessibleGroup } from "victory-core";
-// This prevents the warnings about the `g` attribute being unrecognized outside of an SVG container.
 
 describe("components/victory-accessible-group", () => {
   it("renders an g with an aria-label", () => {

--- a/test/jest/victory-core/victory-animation/util.test.js
+++ b/test/jest/victory-core/victory-animation/util.test.js
@@ -1,0 +1,76 @@
+/* eslint-disable no-unused-expressions */
+import { victoryInterpolator } from "victory-core/lib/victory-animation/util";
+
+describe("victoryInterpolator", () => {
+  it("does not attempt to interpolate identical values", () => {
+    // This case fails with the default interpolator, returning *almost* 3.
+    expect(victoryInterpolator(3, 3)(0.25920000000000004)).toEqual(3);
+  });
+
+  it("does not attempt to interpolate Boolean values", () => {
+    // The default interpolator would return 0.5.
+    expect(victoryInterpolator(false, true)(0.5)).toEqual(true);
+  });
+
+  it("always returns the end value if starting from null", () => {
+    const interpolator = victoryInterpolator(null, 5);
+    expect(interpolator(0)).toEqual(5);
+    expect(interpolator(0.49)).toEqual(5);
+    expect(interpolator(0.5)).toEqual(5);
+    expect(interpolator(1)).toEqual(5);
+  });
+
+  it("always returns the end value if ending on null", () => {
+    const interpolator = victoryInterpolator(5, null);
+    expect(interpolator(0)).toBeNull();
+    expect(interpolator(0.49)).toBeNull();
+    expect(interpolator(0.5)).toBeNull();
+    expect(interpolator(1)).toBeNull();
+  });
+
+  it("always returns the end value if starting from undefined", () => {
+    const interpolator = victoryInterpolator(undefined, 5);
+    expect(interpolator(0)).toEqual(5);
+    expect(interpolator(0.49)).toEqual(5);
+    expect(interpolator(0.5)).toEqual(5);
+    expect(interpolator(1)).toEqual(5);
+  });
+
+  it("always returns the end value if ending on undefined", () => {
+    const interpolator = victoryInterpolator(5, undefined);
+    expect(interpolator(0)).toBeUndefined();
+    expect(interpolator(0.49)).toBeUndefined();
+    expect(interpolator(0.5)).toBeUndefined();
+    expect(interpolator(1)).toBeUndefined();
+  });
+
+  it("interpolates functions", () => {
+    const fromFn = () => 5;
+    const toFn = () => 10;
+    const interpolator = victoryInterpolator(fromFn, toFn);
+    const halfwayFn = interpolator(0.5);
+    expect(halfwayFn).toBeInstanceOf(Function);
+    expect(halfwayFn()).toEqual(7.5);
+  });
+
+  it("interpolates string values", () => {
+    // From https://github.com/d3/d3-interpolate/blob/main/test/value-test.js#L5-L7
+    const interpolator = victoryInterpolator("foo", "bar");
+    expect(interpolator(0.5)).toEqual("bar");
+  });
+
+  it("interpolates color values", () => {
+    // From https://github.com/d3/d3-interpolate/blob/main/test/value-test.js#L15
+    const interpolator = victoryInterpolator("red", "blue");
+    expect(interpolator(0.5)).toEqual("rgb(128, 0, 128)");
+  });
+
+  it("interpolates object values", () => {
+    // From https://github.com/d3/d3-interpolate/blob/main/test/value-test.js#L44
+    const interpolator = victoryInterpolator(
+      { color: "red" },
+      { color: "blue" }
+    );
+    expect(interpolator(0.5)).toEqual({ color: "rgb(128, 0, 128)" });
+  });
+});

--- a/test/jest/victory-core/victory-container/victory-container.test.js
+++ b/test/jest/victory-core/victory-container/victory-container.test.js
@@ -1,0 +1,81 @@
+import React from "react";
+import { VictoryContainer } from "victory-core";
+import { fireEvent, render } from "@testing-library/react";
+
+describe("components/victory-container", () => {
+  it("renders an svg with a role of img", () => {
+    const { container } = render(<VictoryContainer />);
+    const output = container.querySelector("svg");
+    expect(output.getAttribute("role")).toContain("img");
+  });
+
+  it("renders an svg with a custom role", () => {
+    const { container } = render(<VictoryContainer role="presentation" />);
+    expect(container.querySelector("svg").getAttribute("role")).toEqual(
+      "presentation"
+    );
+  });
+
+  it("renders an svg with a title node", () => {
+    const { container } = render(<VictoryContainer title="Victory Chart" />);
+    expect(container.querySelector("title")).toMatchInlineSnapshot(`
+      <title
+        id="victory-container-3-title"
+      >
+        Victory Chart
+      </title>
+    `);
+  });
+
+  it("renders an svg with a desc node", () => {
+    const { container } = render(<VictoryContainer desc="description" />);
+    expect(container.querySelector("desc")).toMatchInlineSnapshot(`
+      <desc
+        id="victory-container-4-desc"
+      >
+        description
+      </desc>
+    `);
+  });
+
+  it("renders an svg with an aria-describedby attribute", () => {
+    const { container } = render(
+      <VictoryContainer aria-describedby="testid" desc="description" />
+    );
+    const describedElement = container.querySelector(
+      `svg[aria-describedby~="testid"]`
+    );
+    expect(describedElement).toBeDefined();
+  });
+
+  it("renders an svg with an aria-labelledby attribute", () => {
+    const { container } = render(
+      <VictoryContainer aria-labelledby="testid" title="title" />
+    );
+    const describedElement = container.querySelector(
+      `svg[aria-labelledby~="testid"]`
+    );
+    expect(describedElement).toBeDefined();
+  });
+
+  it("renders an svg with the correct viewbox", () => {
+    const width = 300;
+    const height = 300;
+    const { container } = render(
+      <VictoryContainer width={width} height={height} />
+    );
+    const svg = container.querySelector("svg");
+    const viewBoxValue = `0 0 ${width} ${height}`;
+    expect(svg.getAttribute("viewBox")).toEqual(viewBoxValue);
+  });
+
+  it("attaches an event to the container", () => {
+    const clickHandler = jest.fn();
+    const { container } = render(
+      <VictoryContainer events={{ onClick: clickHandler }} />
+    );
+    const svg = container.querySelector("svg");
+    fireEvent.click(svg);
+    expect(clickHandler).toBeCalled();
+  });
+});

--- a/test/jest/victory-core/victory-label/victory-label.test.js
+++ b/test/jest/victory-core/victory-label/victory-label.test.js
@@ -1,0 +1,246 @@
+import React from "react";
+import { VictoryLabel, Log } from "victory-core";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderInSvg } from "../../rendering-utils";
+
+describe("components/victory-label", () => {
+  it("accepts user props", () => {
+    renderInSvg(
+      <VictoryLabel
+        data-testid="victory-label"
+        aria-label="test-aria-label"
+        text="label"
+      />
+    );
+
+    expect(screen.getByTestId("victory-label")).toBeDefined();
+    expect(screen.getByLabelText("test-aria-label")).toBeDefined();
+  });
+
+  it("has expected content with render", () => {
+    const { container } = renderInSvg(<VictoryLabel text="such text, wow" />);
+    expect(container.querySelector("tspan").innerHTML).toMatchInlineSnapshot(
+      `"such text, wow"`
+    );
+  });
+
+  it("sets dx and dy for text element", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel dx={30} dy={30} text="such text, wow" />
+    );
+    const output = container.querySelector("text");
+    expect(output.getAttribute("dx")).toEqual("30");
+    // dy = props.dy + (capHeight(0.71) / 2 + (0.5 - length(1) / 2) * lineHeight(1)) * fontSize(14);
+    expect(output.getAttribute("dy")).toBeNull();
+  });
+
+  it("sets x and y for text element", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel x="100%" y={30} text="such text, wow" />
+    );
+    const output = container.querySelector("text");
+    expect(output.getAttribute("x")).toEqual("100%");
+    expect(parseFloat(output.getAttribute("y"))).toEqual(34.97);
+  });
+
+  it("has a transform property that rotates the text to match the labelAngle getAttribute", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel angle={46} text="such text, wow" />
+    );
+    const output = container.querySelector("text");
+    expect(output.getAttribute("transform")).toContain("rotate(46");
+  });
+
+  it("accepts the angle getAttribute as a function", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel angle={() => 46} text="such text, wow" />
+    );
+    const output = container.querySelector("text");
+    expect(output.getAttribute("transform")).toContain("rotate(46");
+  });
+
+  it("strips px from fontSize", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel
+        style={{ fontSize: "10px" }}
+        text="such text, wow"
+        data-font-size={(props) => props.style.fontSize}
+      />
+    );
+    const output = container.querySelector("text");
+    expect(output.getAttribute("data-font-size")).toEqual("10");
+  });
+
+  it("uses a default fontSize when an invalid fontSize is given", () => {
+    // This suppresses the console warning for invalid fontSize prop
+    jest.spyOn(Log, "warn").mockImplementation(() => {});
+
+    const { container } = renderInSvg(
+      <VictoryLabel style={{ fontSize: "foo" }} text="such text, wow" />
+    );
+    const output = container.querySelector("tspan");
+    expect(output.getAttribute("style")).toContain("font-size: 14px");
+  });
+
+  it("renders an array of text as seperate tspans", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel text={["one", "two", "three"]} />
+    );
+    const output = container.querySelectorAll("tspan");
+    expect(output.length).toEqual(3);
+  });
+
+  it("renders splits newlines into tspans", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel text={"one\ntwo\nthree"} />
+    );
+    const output = container.querySelectorAll("tspan");
+    expect(output.length).toEqual(3);
+  });
+
+  it("renders title and desc if provided ", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel text="title and desc" title="title" desc="desc" />
+    );
+
+    const { container: container2 } = renderInSvg(
+      <VictoryLabel text="title and desc" />
+    );
+
+    const title = container.querySelectorAll("title");
+    expect(title.length).toEqual(1);
+
+    const desc = container.querySelectorAll("desc");
+    expect(desc.length).toEqual(1);
+
+    const noTitle = container2.querySelectorAll("title");
+    expect(noTitle.length).toEqual(0);
+
+    const noDesc = container2.querySelectorAll("desc");
+    expect(noDesc.length).toEqual(0);
+  });
+
+  it("renders tspan styles independently when `style` is an array", () => {
+    const fill = ["red", "green", "blue"];
+    const { container } = renderInSvg(
+      <VictoryLabel
+        text={"one\ntwo\nthree"}
+        style={[{ fill: fill[0] }, { fill: fill[1] }, { fill: fill[2] }]}
+      />
+    );
+    const output = container.querySelectorAll("tspan");
+    output.forEach((tspan, index) => {
+      expect(tspan.getAttribute("style")).toContain(`fill: ${fill[index]}`);
+    });
+  });
+
+  describe("event handling", () => {
+    it("attaches an to the parent object", () => {
+      const clickHandler = jest.fn();
+      const { container } = renderInSvg(
+        <VictoryLabel text="hi" events={{ onClick: clickHandler }} />
+      );
+      fireEvent.click(container.querySelector("text"));
+      expect(clickHandler).toHaveBeenCalled();
+    });
+  });
+
+  it("renders 'tspan' elements inline when `inline` getAttribute is passed", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel text={["Inline", "label", "testing"]} inline dx={5} />
+    );
+
+    const output = container.querySelectorAll("tspan");
+    output.forEach((tspan) => {
+      // passing `inline` sets x and dy to undefined
+      expect(tspan.getAttribute("x")).toBeNull();
+      expect(
+        tspan.getAttribute("dy") === null || tspan.getAttribute("dy") === "0"
+      ).toBeTruthy();
+      expect(tspan.getAttribute("dx")).toEqual("5");
+    });
+  });
+
+  it("passes lineHeight as an array if provided", () => {
+    const lineHeight = [1, 2, 3];
+    const expectedDy = [0, 21, 35];
+    const { container } = renderInSvg(
+      <VictoryLabel
+        text={["lineHeight", "array", "testing"]}
+        lineHeight={lineHeight}
+      />
+    );
+
+    const output = container.querySelectorAll("tspan");
+    output.forEach((tspan, index) => {
+      /*
+      to calculate dy:
+      ((this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0])) / 2)
+      */
+      expect(parseInt(tspan.getAttribute("dy"))).toEqual(expectedDy[index]);
+    });
+  });
+
+  it("defaults lineHeight to 1 if an empty array is provided for lineHeight", () => {
+    const expectedDy = [0, 14, 14, 14];
+    const { container } = renderInSvg(
+      <VictoryLabel
+        text={["lineHeight", "empty", "array", "testing"]}
+        lineHeight={[]}
+      />
+    );
+
+    const output = container.querySelectorAll("tspan");
+    output.forEach((tspan, index) => {
+      expect(parseInt(tspan.getAttribute("dy"))).toEqual(expectedDy[index]);
+    });
+  });
+
+  it("defaults style to `defaultStyles` if an empty array is provided for `style`", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel text={["style", "empty", "array", "testing"]} style={[]} />
+    );
+
+    expect(
+      container.querySelector("tspan").getAttribute("style")
+    ).toMatchInlineSnapshot(
+      `"fill: #252525; font-size: 14px; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"`
+    );
+  });
+
+  it("passes id if provided as a string", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel text="Some VictoryLabel" id="my-custom-id" />
+    );
+
+    const output = container.querySelectorAll("text");
+    output.forEach((text) => {
+      expect(text.getAttribute("id")).toEqual("my-custom-id");
+    });
+  });
+
+  it("passes id if provided as a number", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel text="Some VictoryLabel" id={12345} />
+    );
+
+    const output = container.querySelectorAll("text");
+    output.forEach((text) => {
+      expect(text.getAttribute("id")).toEqual("12345");
+    });
+  });
+
+  it("runs function if id provided as a function", () => {
+    const { container } = renderInSvg(
+      <VictoryLabel
+        text="Some VictoryLabel"
+        id={() => `created-in-function-${Math.random()}`}
+      />
+    );
+
+    const output = container.querySelectorAll("text");
+    output.forEach((text) => {
+      expect(text.getAttribute("id")).toMatch(/^created-in-function-[\d\.]+$/);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-primitives/clip-path.test.js
+++ b/test/jest/victory-core/victory-primitives/clip-path.test.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { ClipPath } from "victory-core";
+import { renderInSvg } from "../../rendering-utils";
+
+describe("victory-primitives/clip-path", () => {
+  const baseProps = {
+    clipId: 4,
+    clipPadding: {
+      top: 2,
+      bottom: 2,
+      left: 2,
+      right: 2
+    },
+    clipHeight: 30,
+    clipWidth: 20,
+    translateX: 3,
+    translateY: 8
+  };
+
+  it("should render a children", () => {
+    const { container } = renderInSvg(
+      <ClipPath {...baseProps}>
+        <rect data-testid="rect" />
+      </ClipPath>
+    );
+
+    expect(container.querySelector("clipPath")).toMatchInlineSnapshot(`
+      <clippath
+        id="4"
+      >
+        <rect
+          data-testid="rect"
+        />
+      </clippath>
+    `);
+  });
+
+  it("should render a clipPath with the passed id", () => {
+    const { container } = renderInSvg(<ClipPath {...baseProps} />);
+
+    expect(container.querySelector("clipPath")).toMatchInlineSnapshot(`
+      <clippath
+        id="4"
+      />
+    `);
+  });
+});

--- a/test/jest/victory-core/victory-primitives/curve.test.js
+++ b/test/jest/victory-core/victory-primitives/curve.test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { Curve } from "victory-line";
+import { renderInSvg } from "../../rendering-utils";
+import * as d3Scale from "victory-vendor/lib/d3-scale";
+
+describe("victory-primitives/curve", () => {
+  const baseProps = {
+    data: [
+      { _x1: 1, x1: 1, _y1: 4, y1: 4, eventKey: 0 },
+      { _x1: 2, x1: 2, _y1: 5, y1: 5, eventKey: 1 },
+      { _x1: 3, x1: 3, _y1: 7, y1: 7, eventKey: 2 },
+      { _x1: 4, x1: 4, _y1: 10, y1: 10, eventKey: 3 },
+      { _x1: 5, x1: 5, _y1: 15, y1: 15, eventKey: 4 }
+    ],
+    scale: {
+      x: d3Scale.scaleLinear(),
+      y: d3Scale.scaleLinear()
+    },
+    interpolation: "basis"
+  };
+
+  it("should render a single curve for consecutive data", () => {
+    const { container } = renderInSvg(<Curve {...baseProps} />);
+    expect(container.querySelector("path")).toMatchInlineSnapshot(`
+      <path
+        d="M1,4L1.1666666666666667,4.166666666666667C1.3333333333333333,4.333333333333333,1.6666666666666667,4.666666666666667,2,5.166666666666667C2.3333333333333335,5.666666666666667,2.6666666666666665,6.333333333333333,3,7.166666666666667C3.3333333333333335,8,3.6666666666666665,9,4,10.333333333333334C4.333333333333333,11.666666666666666,4.666666666666667,13.333333333333334,4.833333333333333,14.166666666666666L5,15"
+        role="presentation"
+        shape-rendering="auto"
+        style="fill: none; stroke: black;"
+      />
+    `);
+  });
+});

--- a/test/jest/victory-core/victory-primitives/curve.test.js
+++ b/test/jest/victory-core/victory-primitives/curve.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Curve } from "victory-line";
 import { renderInSvg } from "../../rendering-utils";
-import * as d3Scale from "victory-vendor/lib/d3-scale";
+import * as d3Scale from "victory-vendor/d3-scale";
 
 describe("victory-primitives/curve", () => {
   const baseProps = {

--- a/test/jest/victory-core/victory-primitives/line.test.js
+++ b/test/jest/victory-core/victory-primitives/line.test.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { Line } from "victory-core";
+import { renderInSvg } from "../../rendering-utils";
+
+describe("victory-primitives/line", () => {
+  const baseProps = {
+    x1: 0,
+    y1: 1,
+    x2: 2,
+    y2: 4
+  };
+
+  it("should render a line element with the correct coordinates", () => {
+    const { container } = renderInSvg(<Line {...baseProps} />);
+    expect(container.querySelector("line")).toMatchInlineSnapshot(`
+      <line
+        vector-effect="non-scaling-stroke"
+        x1="0"
+        x2="2"
+        y1="1"
+        y2="4"
+      />
+    `);
+  });
+});

--- a/test/jest/victory-core/victory-primitives/point.test.js
+++ b/test/jest/victory-core/victory-primitives/point.test.js
@@ -1,0 +1,38 @@
+import { assign } from "lodash";
+import React from "react";
+import { Point, PointPathHelpers as pathHelpers } from "victory-core";
+import { renderInSvg } from "../../rendering-utils";
+
+describe("victory-primitives/point", () => {
+  const baseProps = {
+    x: 5,
+    y: 10,
+    size: 1
+  };
+
+  it("should render the appropriate symbol", () => {
+    [
+      "circle",
+      "square",
+      "diamond",
+      "triangleDown",
+      "triangleUp",
+      "plus",
+      "minus",
+      "star",
+      "cross"
+    ].forEach((symbol) => {
+      const stub = jest
+        .spyOn(pathHelpers, symbol)
+        // eslint-disable-next-line max-nested-callbacks
+        .mockImplementation(() => `${symbol} symbol`);
+      const props = assign({}, baseProps, { symbol });
+      const { container } = renderInSvg(<Point {...props} />);
+      const directions = container.querySelector("path").getAttribute("d");
+
+      expect(stub).toHaveBeenCalledTimes(1);
+      expect(stub).toHaveBeenCalledWith(5, 10, 1);
+      expect(directions).toEqual(`${symbol} symbol`);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-primitives/slice.test.js
+++ b/test/jest/victory-core/victory-primitives/slice.test.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Slice } from "victory-pie";
+import { renderInSvg } from "../../rendering-utils";
+
+describe("victory-primitives/slice", () => {
+  describe("rendering", () => {
+    it("renders a path with attribute `d` equal to the result of `props.pathFunction` called with `props.slice`", () => {
+      const EXPECTED_D_ATTR = "M1,1";
+      const slice = { x: 1, y: 1 };
+      const pathFunction = (sli) => {
+        // The path function is called with `props.slice`
+        expect(sli).toEqual(slice);
+
+        return EXPECTED_D_ATTR;
+      };
+
+      const { container } = renderInSvg(
+        <Slice pathFunction={pathFunction} slice={slice} />
+      );
+
+      expect(container.querySelector("path")).toMatchInlineSnapshot(`
+        <path
+          d="M1,1"
+          role="presentation"
+          shape-rendering="auto"
+        />
+      `);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/axis.test.js
+++ b/test/jest/victory-core/victory-util/axis.test.js
@@ -1,7 +1,7 @@
-import { Scale, Axis } from "victory-core";
 import React from "react";
 import { VictoryAxis } from "victory-axis";
 import { VictoryBar } from "victory-bar";
+import { Axis, Scale } from "victory-core";
 
 describe("helpers/axis", () => {
   const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);

--- a/test/jest/victory-core/victory-util/axis.test.js
+++ b/test/jest/victory-core/victory-util/axis.test.js
@@ -1,0 +1,175 @@
+import { Scale, Axis } from "victory-core";
+import React from "react";
+import { VictoryAxis } from "victory-axis";
+import { VictoryBar } from "victory-bar";
+
+describe("helpers/axis", () => {
+  const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);
+  const getVictoryBar = (props) => React.createElement(VictoryBar, props);
+
+  describe("isVertical", () => {
+    it("returns true when the orientation is vertical", () => {
+      const props = { orientation: "left" };
+      const verticalResult = Axis.isVertical(props);
+      expect(verticalResult).toEqual(true);
+    });
+
+    it("returns false when the orientation is horizontal", () => {
+      const props = { orientation: "bottom" };
+      const verticalResult = Axis.isVertical(props);
+      expect(verticalResult).toEqual(false);
+    });
+  });
+
+  describe("getDomain", () => {
+    it("determines a domain from tickValues", () => {
+      const props = { tickValues: [1, 2, 3] };
+      const domainResult = Axis.getDomain(props);
+      expect(domainResult).toEqual([1, 3]);
+    });
+
+    it("determines a domain from string tick values", () => {
+      const props = { tickValues: ["a", "b", "c", "d"] };
+      const domainResult = Axis.getDomain(props);
+      expect(domainResult).toEqual([1, 4]);
+    });
+
+    it("reverses a domain from tickValues when the axis is vertical", () => {
+      const props = { tickValues: [1, 2, 3], dependentAxis: true };
+      const domainResult = Axis.getDomain(props);
+      expect(domainResult).toEqual([3, 1]);
+    });
+
+    it("determines a domain from props", () => {
+      const props = { domain: [1, 2] };
+      const domainResult = Axis.getDomain(props);
+      expect(domainResult).toEqual([1, 2]);
+    });
+
+    it("calculates a domain from a single tickValue", () => {
+      const props = { tickValues: [1] };
+      const domainResult = Axis.getDomain(props);
+      const verySmallNumber = Math.pow(10, -10);
+      expect(domainResult).toEqual([1 - verySmallNumber, 1 + verySmallNumber]);
+    });
+
+    it("returns undefined if the given axis doesn't match this axis", () => {
+      const props = { domain: [1, 3] };
+      const domainResultX = Axis.getDomain(props, "x");
+      expect(domainResultX).toEqual([1, 3]);
+      const domainResultY = Axis.getDomain(props, "y");
+      expect(domainResultY).toBeUndefined();
+    });
+  });
+
+  describe("getAxis", () => {
+    it("determines the axis based on type (dependent / independent)", () => {
+      expect(Axis.getAxis({ dependentAxis: true })).toEqual("y");
+      expect(Axis.getAxis({})).toEqual("x");
+    });
+  });
+
+  describe("getAxisComponent", () => {
+    const dependentAxis = getVictoryAxis({ dependentAxis: true });
+    const independentAxis = getVictoryAxis({ dependentAxis: false });
+    const bar = getVictoryBar({});
+
+    beforeEach(() => {
+      jest.spyOn(dependentAxis.type, "getAxis");
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("returns the independent axis when called with 'x'", () => {
+      const childComponents = [dependentAxis, independentAxis, bar];
+      const componentResult = Axis.getAxisComponent(childComponents, "x");
+      expect(dependentAxis.type.getAxis).toBeCalledWith(dependentAxis.props);
+      expect(independentAxis.type.getAxis).toBeCalledWith(
+        independentAxis.props
+      );
+      expect(componentResult).toEqual(independentAxis);
+    });
+  });
+
+  describe("getTickFormat", () => {
+    const scale = Scale.getBaseScale({ scale: { x: "linear" } }, "x");
+    const ticks = [1, 2, 3, 4, 5];
+    beforeEach(() => {
+      jest.spyOn(scale, "tickFormat");
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("returns tickFormat function from props", () => {
+      const props = { tickFormat: (x) => x * 5 };
+      const tickProps = { scale, ticks };
+      const formatResult = Axis.getTickFormat(props, tickProps);
+      expect(scale.tickFormat).not.toHaveBeenCalled();
+      expect(formatResult).toEqual(props.tickFormat);
+    });
+
+    it("converts tickFormat array from props to a function", () => {
+      const props = { tickFormat: [1, 2, 3, 4, 5] };
+      const tickProps = { scale, ticks };
+      const formatResult = Axis.getTickFormat(props, tickProps);
+      expect(scale.tickFormat).not.toHaveBeenCalled();
+      expect(formatResult).toBeInstanceOf(Function);
+    });
+
+    it("converts tickFormat string array from props to a function", () => {
+      const props = { tickValues: ["cats", "dogs", "birds"] };
+      const tickProps = { scale, ticks };
+      const formatResult = Axis.getTickFormat(props, tickProps);
+      expect(scale.tickFormat).not.toHaveBeenCalled();
+      expect(formatResult).toBeInstanceOf(Function);
+    });
+
+    it("calculates a tick format from scale", () => {
+      const props = {};
+      const tickProps = { scale, ticks };
+      const formatResult = Axis.getTickFormat(props, tickProps);
+      expect(formatResult).toBeInstanceOf(Function);
+    });
+  });
+
+  describe("getTicks", () => {
+    const scale = Scale.getBaseScale({ scale: { x: "linear" } }, "x");
+    beforeEach(() => {
+      jest.spyOn(scale, "ticks");
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("returns tickValues from props", () => {
+      const props = { tickValues: [1, 2, 3] };
+      const tickResult = Axis.getTicks(props);
+      expect(tickResult).toEqual(props.tickValues);
+    });
+
+    it("returns converts string tickValues to numbers", () => {
+      const props = { tickValues: ["a", "b", "c", "d"] };
+      const tickResult = Axis.getTicks(props);
+      expect(tickResult).toEqual([1, 2, 3, 4]);
+    });
+
+    it("calculates tickValues from scale.ticks()", () => {
+      const props = { tickCount: 5 };
+      Axis.getTicks(props, scale);
+      expect(scale.ticks).toBeCalledWith(5);
+    });
+
+    // TODO: This is failing, but I'm not sure whether it's an issue with the test or the code
+    it.skip("calculates tickValues from scale.ticks(), and removes zero if axes cross", () => {
+      const props = { tickCount: 5, crossAxis: true };
+      const tickResult = Axis.getTicks(props, scale);
+      expect(scale.ticks).toBeCalledWith(5);
+      expect(tickResult).not.toContain(0);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/collection.test.js
+++ b/test/jest/victory-core/victory-util/collection.test.js
@@ -1,0 +1,151 @@
+import { Collection } from "victory-core";
+
+describe("victory-util/collection", () => {
+  describe("containsStrings", () => {
+    it("handles empty argument", () => {
+      expect(Collection.containsStrings()).toEqual(false);
+    });
+
+    it("handles empty array", () => {
+      expect(Collection.containsStrings([])).toEqual(false);
+    });
+
+    it("returns false for collections of non-strings", () => {
+      expect(Collection.containsStrings([0, 1])).toEqual(false);
+      expect(Collection.containsStrings([undefined, null, NaN])).toEqual(false);
+      expect(Collection.containsStrings([{}, { a: "foo" }])).toEqual(false);
+    });
+
+    it("returns false for collections with strings", () => {
+      expect(Collection.containsStrings(["hello"])).toEqual(true);
+      expect(Collection.containsStrings(["hello", "there"])).toEqual(true);
+      expect(Collection.containsStrings([0, "hello", {}, null])).toEqual(true);
+    });
+  });
+
+  describe("containsOnlyStrings", () => {
+    it("handles empty argument", () => {
+      expect(Collection.containsOnlyStrings()).toEqual(false);
+    });
+
+    it("handles empty array", () => {
+      expect(Collection.containsOnlyStrings([])).toEqual(false);
+    });
+
+    it("returns false for collections of non-strings", () => {
+      expect(Collection.containsOnlyStrings([0, 1])).toEqual(false);
+      expect(Collection.containsOnlyStrings([undefined, null, NaN])).toEqual(
+        false
+      );
+      expect(Collection.containsOnlyStrings([{}, { a: "foo" }])).toEqual(false);
+    });
+
+    it("returns false for collections with some strings", () => {
+      expect(Collection.containsOnlyStrings(["hello", 0])).toEqual(false);
+      expect(Collection.containsOnlyStrings(["hello", ["not me"]])).toEqual(
+        false
+      );
+      expect(Collection.containsOnlyStrings([0, "hello", {}, null])).toEqual(
+        false
+      );
+    });
+
+    it("returns true for collections with only strings", () => {
+      expect(Collection.containsOnlyStrings(["hello"])).toEqual(true);
+      expect(Collection.containsOnlyStrings(["hello", "there"])).toEqual(true);
+    });
+  });
+
+  describe("isArrayOfArrays", () => {
+    it("handles empty argument", () => {
+      expect(Collection.isArrayOfArrays()).toEqual(false);
+    });
+
+    it("handles empty array", () => {
+      expect(Collection.isArrayOfArrays([])).toEqual(false);
+    });
+
+    it("returns false for collections of non-arrays", () => {
+      expect(Collection.isArrayOfArrays([1])).toEqual(false);
+      expect(Collection.isArrayOfArrays([{}])).toEqual(false);
+      expect(Collection.isArrayOfArrays(["a"])).toEqual(false);
+    });
+
+    it("returns false for mixed collections", () => {
+      expect(Collection.isArrayOfArrays([[], 1, {}])).toEqual(false);
+      expect(Collection.isArrayOfArrays([1, [], {}])).toEqual(false);
+      expect(Collection.isArrayOfArrays([1, {}, []])).toEqual(false);
+    });
+
+    it("returns true for collections of arrays", () => {
+      expect(Collection.isArrayOfArrays([[]])).toEqual(true);
+      expect(Collection.isArrayOfArrays([[{}]])).toEqual(true);
+      expect(Collection.isArrayOfArrays([[[]]])).toEqual(true);
+      expect(Collection.isArrayOfArrays([[], []])).toEqual(true);
+    });
+  });
+
+  describe("removeUndefined", () => {
+    it("handles empty array", () => {
+      expect(Collection.removeUndefined([])).toEqual([]);
+    });
+
+    it("does not filter non-undefineds", () => {
+      const testArray = [0, 1, "a", {}, false, null, NaN];
+      expect(Collection.removeUndefined(testArray)).toEqual(testArray);
+    });
+
+    it("filters out undefineds", () => {
+      const testArray = [
+        undefined,
+        0,
+        undefined,
+        {},
+        false,
+        null,
+        NaN,
+        undefined
+      ];
+      const expectedArray = [0, {}, false, null, NaN];
+      expect(Collection.removeUndefined(testArray)).toEqual(expectedArray);
+    });
+  });
+
+  describe("getMaxValue", () => {
+    it("returns a date if array contains dates", () => {
+      const array = [new Date(2016, 3, 6), new Date(2017, 5, 3), 10];
+      expect(Collection.getMaxValue(array)).toEqual(new Date(2017, 5, 3));
+    });
+
+    it("returns a number if array does not contain dates", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMaxValue(array)).toEqual(10);
+    });
+
+    it("allows values to be concated and returns the appropriate number", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMaxValue(array, 1, 20)).toEqual(20);
+    });
+  });
+
+  describe("getMinValue", () => {
+    it("returns a date if array contains dates", () => {
+      const array = [
+        new Date(2016, 3, 6),
+        new Date(2017, 5, 3),
+        new Date(2015, 11, 4)
+      ];
+      expect(Collection.getMinValue(array)).toEqual(new Date(2015, 11, 4));
+    });
+
+    it("returns a number if array does not contain dates", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMinValue(array)).toEqual(3);
+    });
+
+    it("allows values to be concated and returns the appropriate number", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMinValue(array, 1, 20)).toEqual(1);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/data.test.js
+++ b/test/jest/victory-core/victory-util/data.test.js
@@ -1,0 +1,382 @@
+/* eslint no-unused-expressions: 0, max-nested-callbacks: 0 */
+import React from "react";
+import { Data, VictoryPortal } from "victory-core";
+import { fromJS } from "immutable";
+
+const immutableDataTest = {
+  createData: (data) => fromJS(data),
+  testLabel: "data in immutable"
+};
+
+const dataTest = {
+  createData: (data) => data,
+  testLabel: "data in js"
+};
+
+describe("victory-util/data", () => {
+  describe("createStringMap", () => {
+    const tickValues = ["one", "two", "three"];
+    const categories = ["red", "green", "blue"];
+
+    it("returns a string map from strings in tickValues", () => {
+      const props = { tickValues };
+      const stringMap = Data.createStringMap(props, "x");
+      expect(stringMap).toEqual({ one: 1, two: 2, three: 3 });
+    });
+
+    it("returns a string map from strings in categories", () => {
+      const props = { categories };
+      const stringMap = Data.createStringMap(props, "x");
+      expect(stringMap).toEqual({ red: 1, green: 2, blue: 3 });
+    });
+
+    [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
+      describe(`returning string maps with ${testLabel}`, () => {
+        const data = createData([
+          { x: "one", y: 1 },
+          { x: "red", y: 2 },
+          { x: "cat", y: 3 }
+        ]);
+
+        it("returns a string map from strings in data", () => {
+          const props = { data };
+          const stringMap = Data.createStringMap(props, "x");
+          expect(stringMap).toEqual({ one: 1, red: 2, cat: 3 });
+        });
+
+        it("a unique set of values is returned from multiple sources", () => {
+          const props = { tickValues, data };
+          const stringMap = Data.createStringMap(props, "x");
+          expect(stringMap).toEqual({
+            one: 1,
+            two: 2,
+            three: 3,
+            red: 4,
+            cat: 5
+          });
+        });
+      });
+    });
+  });
+
+  [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
+    describe(`getStringsFromData with ${testLabel}`, () => {
+      it("returns an array of strings from a data prop", () => {
+        const props = {
+          data: createData([
+            { x: "one", y: 1 },
+            { x: "red", y: 2 },
+            { x: "cat", y: 3 }
+          ])
+        };
+        const dataStrings = Data.getStringsFromData(props, "x");
+        expect(dataStrings).toEqual(["one", "red", "cat"]);
+      });
+
+      it("returns an array of strings from array-type data", () => {
+        const props = {
+          data: createData([
+            ["one", 1],
+            ["red", 2],
+            ["cat", 3]
+          ]),
+          x: 0,
+          y: 1
+        };
+        const dataStrings = Data.getStringsFromData(props, "x");
+        expect(dataStrings).toEqual(["one", "red", "cat"]);
+      });
+
+      it("only returns strings, if data is mixed", () => {
+        const props = {
+          data: createData([
+            { x: 1, y: 1 },
+            { x: "three", y: 3 }
+          ])
+        };
+        expect(Data.getStringsFromData(props, "x")).toEqual(["three"]);
+      });
+
+      it("returns an empty array when no strings are present", () => {
+        const props = {
+          data: createData([
+            { x: 1, y: 1 },
+            { x: 3, y: 3 }
+          ])
+        };
+        expect(Data.getStringsFromData(props, "x")).toEqual([]);
+      });
+
+      it("returns an empty array when the data prop is undefined", () => {
+        expect(Data.getStringsFromData({}, "x")).toEqual([]);
+      });
+    });
+  });
+
+  describe("getStringsFromAxes", () => {
+    it("returns an array of strings when tickValues is an array", () => {
+      const props = { tickValues: [1, "three", 5] };
+      expect(Data.getStringsFromAxes(props, "x")).toEqual(["three"]);
+    });
+
+    it("returns an array of strings when tickValues is an object", () => {
+      const props = { tickValues: { x: [1, "three", 5] } };
+      expect(Data.getStringsFromAxes(props, "x")).toEqual(["three"]);
+    });
+
+    it("returns an empty array when a given axis is not defined", () => {
+      const props = { tickValues: { y: [1, "three", 5] } };
+      expect(Data.getStringsFromAxes(props, "x")).toEqual([]);
+    });
+
+    it("returns an empty array when no strings are present", () => {
+      const props = { tickValues: [1, 3, 5] };
+      expect(Data.getStringsFromAxes(props, "x")).toEqual([]);
+    });
+
+    it("returns an empty array when the tickValues prop is undefined", () => {
+      expect(Data.getStringsFromAxes({}, "x")).toEqual([]);
+    });
+  });
+
+  describe("getStringsFromCategories", () => {
+    it("returns an empty array when no strings are present", () => {
+      const props = { categories: [1, 3, 5] };
+      expect(Data.getStringsFromCategories(props, "x")).toEqual([]);
+    });
+
+    it("returns an empty array when the category prop is undefined", () => {
+      expect(Data.getStringsFromCategories({}, "x")).toEqual([]);
+    });
+  });
+
+  [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
+    describe(`formatData with ${testLabel}`, () => {
+      it("formats a single dataset", () => {
+        const dataset = [
+          { _x: 1, _y: 3, x: 1, y: 3 },
+          { _x: 2, _y: 5, x: 2, y: 5 }
+        ];
+        const props = { data: createData(dataset) };
+        const formatted = Data.formatData(dataset, props);
+        expect(Array.isArray(formatted)).toBeTruthy();
+        expect(Object.keys(formatted[0])).toEqual(
+          expect.arrayContaining(["_x", "_y", "x", "y"])
+        );
+      });
+    });
+  });
+
+  describe("getData", () => {
+    [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
+      describe(`with ${testLabel}`, () => {
+        it("formats and returns the data prop", () => {
+          const data = createData([
+            { x: "kittens", y: 3 },
+            { x: "cats", y: 5 }
+          ]);
+          const props = { data, x: "x", y: "y" };
+          const expectedReturnWithEventKeys = [
+            { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3 },
+            { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5 }
+          ];
+          const returnData = Data.getData(props);
+          expect(returnData).toEqual(expectedReturnWithEventKeys);
+        });
+
+        it("uses the event key when it is passed in", () => {
+          const data = createData([
+            { x: 2, y: 2, eventKey: 13 },
+            { x: 1, y: 3, eventKey: 21 },
+            { x: 3, y: 1, eventKey: 11 }
+          ]);
+
+          const returnData = Data.getData({ data });
+
+          expect(returnData).toEqual([
+            { _x: 2, x: 2, _y: 2, y: 2, eventKey: 13 },
+            { _x: 1, x: 1, _y: 3, y: 3, eventKey: 21 },
+            { _x: 3, x: 3, _y: 1, y: 1, eventKey: 11 }
+          ]);
+        });
+
+        it("uses a custom event key when it is passed in", () => {
+          const data = createData([
+            { x: 2, y: 2, myEventKey: 3 },
+            { x: 1, y: 3, myEventKey: 2 },
+            { x: 3, y: 1, myEventKey: 1 }
+          ]);
+
+          const returnData = Data.getData({ data, eventKey: "myEventKey" });
+
+          expect(returnData).toEqual([
+            { _x: 2, x: 2, _y: 2, y: 2, eventKey: 3, myEventKey: 3 },
+            { _x: 1, x: 1, _y: 3, y: 3, eventKey: 2, myEventKey: 2 },
+            { _x: 3, x: 3, _y: 1, y: 1, eventKey: 1, myEventKey: 1 }
+          ]);
+        });
+
+        it("uses a eventKey functions", () => {
+          const data = createData([
+            { x: 2, y: 2 },
+            { x: 1, y: 3 },
+            { x: 3, y: 1 }
+          ]);
+
+          const returnData = Data.getData({ data, eventKey: (d) => d.x });
+
+          expect(returnData).toEqual([
+            { _x: 2, x: 2, _y: 2, y: 2, eventKey: 2 },
+            { _x: 1, x: 1, _y: 3, y: 3, eventKey: 1 },
+            { _x: 3, x: 3, _y: 1, y: 1, eventKey: 3 }
+          ]);
+        });
+
+        it("uses a eventKey functions with index", () => {
+          const data = createData([
+            { x: 2, y: 2 },
+            { x: 1, y: 3 },
+            { x: 3, y: 1 }
+          ]);
+
+          const returnData = Data.getData({ data, eventKey: (d, i) => i });
+
+          expect(returnData).toEqual([
+            { _x: 2, x: 2, _y: 2, y: 2, eventKey: 0 },
+            { _x: 1, x: 1, _y: 3, y: 3, eventKey: 1 },
+            { _x: 3, x: 3, _y: 1, y: 1, eventKey: 2 }
+          ]);
+        });
+
+        it("does not sort data when sort key not passed", () => {
+          const data = createData([
+            { x: 2, y: 2 },
+            { x: 1, y: 3 },
+            { x: 3, y: 1 }
+          ]);
+
+          const returnData = Data.getData({ data });
+
+          expect(returnData).toEqual([
+            { _x: 2, x: 2, _y: 2, y: 2 },
+            { _x: 1, x: 1, _y: 3, y: 3 },
+            { _x: 3, x: 3, _y: 1, y: 1 }
+          ]);
+        });
+
+        it("sorts data according to sort key", () => {
+          const data = createData([
+            { x: 1, y: 1, order: 2 },
+            { x: 3, y: 3, order: 1 },
+            { x: 2, y: 2, order: 3 }
+          ]);
+
+          const returnData = Data.getData({ data, sortKey: "order" });
+
+          expect(returnData).toEqual([
+            { _x: 3, x: 3, _y: 3, y: 3, order: 1 },
+            { _x: 1, x: 1, _y: 1, y: 1, order: 2 },
+            { _x: 2, x: 2, _y: 2, y: 2, order: 3 }
+          ]);
+        });
+
+        it("sorts data according to sort key and sort order", () => {
+          const data = createData([
+            { x: 1, y: 1, order: 2 },
+            { x: 3, y: 3, order: 1 },
+            { x: 2, y: 2, order: 3 }
+          ]);
+
+          const returnData = Data.getData({
+            data,
+            sortKey: "order",
+            sortOrder: "descending"
+          });
+
+          expect(returnData).toEqual([
+            { _x: 2, x: 2, _y: 2, y: 2, order: 3 },
+            { _x: 1, x: 1, _y: 1, y: 1, order: 2 },
+            { _x: 3, x: 3, _y: 3, y: 3, order: 1 }
+          ]);
+        });
+
+        // Ensures previous VictoryLine api for sortKey prop stays consistent
+        it("sorts data according to evaluated sort key when sort key is x or y", () => {
+          const data = createData([
+            { _x: 2, x: 10, _y: 2, y: 10 },
+            { _x: 1, x: 20, _y: 3, y: 20 },
+            { _x: 3, x: 30, _y: 1, y: 30 }
+          ]);
+
+          const returnDataX = Data.getData({ data, sortKey: "x" });
+
+          expect(returnDataX).toEqual([
+            { _x: 1, x: 20, _y: 3, y: 20 },
+            { _x: 2, x: 10, _y: 2, y: 10 },
+            { _x: 3, x: 30, _y: 1, y: 30 }
+          ]);
+
+          const returnDataY = Data.getData({ data, sortKey: "y" });
+          expect(returnDataY).toEqual([
+            { _x: 3, x: 30, _y: 1, y: 30 },
+            { _x: 2, x: 10, _y: 2, y: 10 },
+            { _x: 1, x: 20, _y: 3, y: 20 }
+          ]);
+        });
+      });
+    });
+
+    it("generates a dataset from domain", () => {
+      const generatedReturn = [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 }
+      ];
+      const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] } };
+      const returnData = Data.generateData(props);
+      expect(returnData).toEqual(generatedReturn);
+    });
+
+    it("generates a dataset from domain and samples", () => {
+      const generatedReturn = [
+        { x: 0, y: 0 },
+        { x: 5, y: 5 },
+        { x: 10, y: 10 }
+      ];
+      const props = {
+        x: "x",
+        y: "y",
+        domain: { x: [0, 10], y: [0, 10] },
+        samples: 2
+      };
+      const returnData = Data.generateData(props);
+      expect(returnData).toEqual(generatedReturn);
+    });
+  });
+
+  describe("isDataComponent", () => {
+    class TestDataComponent extends React.Component {
+      static role = "area";
+    }
+    it("returns true when a component has a static role matching a whitelist", () => {
+      expect(Data.isDataComponent(<TestDataComponent />)).toBe(true);
+    });
+
+    it("returns false when a component has a role that does not match the whitelist", () => {
+      // eslint-disable-next-line react/no-multi-comp
+      class TestFooComponent extends React.Component {
+        static role = "foo";
+      }
+      expect(Data.isDataComponent(<TestFooComponent />)).toBe(false);
+    });
+
+    it("returns true when a data component is wrapped in VictoryPortal", () => {
+      expect(
+        Data.isDataComponent(
+          <VictoryPortal>
+            <TestDataComponent />
+          </VictoryPortal>
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/domain.test.js
+++ b/test/jest/victory-core/victory-util/domain.test.js
@@ -1,21 +1,5 @@
-/* eslint no-unused-expressions: 0 */
-/* eslint max-nested-callbacks: 0 */
 import React from "react";
 import { Domain, VictoryPortal } from "victory-core";
-
-/*
-  createDomainFunction,
-  formatDomain,
-  getDomain,
-  getDomainFromCategories,
-  getDomainFromData,
-  getDomainFromMinMax,
-  getDomainFromProps,
-  getDomainWithZero,
-  getMaxFromProps,
-  getMinFromProps,
-  getSymmetricDomain
-*/
 
 describe("victory-util/domain", () => {
   describe("createDomainFunction", () => {

--- a/test/jest/victory-core/victory-util/domain.test.js
+++ b/test/jest/victory-core/victory-util/domain.test.js
@@ -1,0 +1,361 @@
+/* eslint no-unused-expressions: 0 */
+/* eslint max-nested-callbacks: 0 */
+import React from "react";
+import { Domain, VictoryPortal } from "victory-core";
+
+/*
+  createDomainFunction,
+  formatDomain,
+  getDomain,
+  getDomainFromCategories,
+  getDomainFromData,
+  getDomainFromMinMax,
+  getDomainFromProps,
+  getDomainWithZero,
+  getMaxFromProps,
+  getMinFromProps,
+  getSymmetricDomain
+*/
+
+describe("victory-util/domain", () => {
+  describe("createDomainFunction", () => {
+    it("returns a function equivalent to getDomain when no props are given", () => {
+      const props = {
+        x: "x",
+        y: "y",
+        domain: { y: [1, 2] },
+        data: [
+          { x: 1, y: 3 },
+          { x: 3, y: 5 }
+        ]
+      };
+      const domainGetter = Domain.createDomainFunction();
+      expect(domainGetter(props, "x")).toEqual(Domain.getDomain(props, "x"));
+    });
+
+    it("returns a function that uses a custom getDomainFromData function when given", () => {
+      const props = {
+        x: "x",
+        y: "y",
+        data: [
+          { x: 1, y: 3 },
+          { x: 3, y: 5 }
+        ]
+      };
+      const getDomainFromData = () => [0, 10];
+      const domainGetter = Domain.createDomainFunction(getDomainFromData);
+      expect(domainGetter(props, "x")).toEqual([0, 10]);
+    });
+
+    it("returns a function that uses a custom formatDomain function when given", () => {
+      const props = { domain: [0, 1] };
+      const formatDomain = () => [0, 10];
+      const domainGetter = Domain.createDomainFunction(null, formatDomain);
+      expect(domainGetter(props, "x")).toEqual([0, 10]);
+    });
+  });
+
+  describe("formatDomain", () => {
+    const baseProps = { width: 100, height: 100, padding: 0 };
+    it("returns the domain when no domain padding is specified", () => {
+      const domain = [0, 1];
+      const paddedDomain = Domain.formatDomain(domain, baseProps, "x");
+      expect(paddedDomain).toEqual(domain);
+    });
+
+    it("pads the domain a particular number of pixels", () => {
+      const domain = [0, 100];
+      const padding = [5, 10, 20];
+      padding.forEach((pad) => {
+        const domainPadding = { x: pad };
+        const props = { ...baseProps, domainPadding };
+        const paddedDomain = Domain.formatDomain(domain, props, "x");
+        const adjustedDomain = domain[1] + pad;
+        const adjustedPercent =
+          adjustedDomain / (baseProps.width - baseProps.padding);
+        const totalPadding = adjustedPercent * pad;
+        expect(paddedDomain).toEqual([0, domain[1] + totalPadding]);
+      });
+    });
+
+    it("filters zero from the domain for log scales", () => {
+      const verySmallNumber = 1 / Number.MAX_SAFE_INTEGER;
+      const props = { scale: { y: "log" } };
+      const formattedDomain = Domain.formatDomain([0, 1], props, "y");
+      expect(formattedDomain).toEqual([verySmallNumber, 1]);
+    });
+  });
+
+  describe("getDomain", () => {
+    it("gets the domain from props if they exist", () => {
+      const props = { domain: [1, 2] };
+      const resultDomain = Domain.getDomain(props, "x");
+      expect(resultDomain).toEqual(props.domain);
+    });
+
+    it("gets the domain from data if props don't exist for a particular axis", () => {
+      const props = {
+        x: "x",
+        y: "y",
+        domain: { y: [1, 2] },
+        data: [
+          { x: 1, y: 3 },
+          { x: 3, y: 5 }
+        ]
+      };
+      const resultDomain = Domain.getDomain(props, "x");
+      expect(resultDomain).toEqual([1, 3]);
+    });
+  });
+
+  describe("getDomainFromCategories", () => {
+    it("calculates a domain from categories for the independent axis", () => {
+      const props = { categories: [1, 2, 3] };
+      const domainResult = Domain.getDomainFromCategories(props, "x");
+      expect(domainResult).toEqual([1, 3]);
+    });
+
+    it("calculates a domain from categories for the dependent axis", () => {
+      const props = { categories: { y: [1, 2, 3] } };
+      const domainResult = Domain.getDomainFromCategories(props, "y");
+      expect(domainResult).toEqual([1, 3]);
+    });
+
+    it("calculates a domain from string categories", () => {
+      const props = { categories: { x: ["cats", "kittens"] } };
+      const domainResult = Domain.getDomainFromCategories(props, "x");
+      expect(domainResult).toEqual([1, 2]);
+    });
+  });
+
+  describe("getDomainFromData", () => {
+    it("returns a domain from a dataset", () => {
+      const dataset = [
+        { _x: 1, _y: 3 },
+        { _x: 3, _y: 5 }
+      ];
+      const resultDomain = Domain.getDomainFromData({}, "x", dataset);
+      expect(resultDomain).toEqual([1, 3]);
+    });
+  });
+
+  describe("getDomainFromProps", () => {
+    it("gets the domain from a domain array", () => {
+      const props = { domain: [1, 2] };
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).toEqual(props.domain);
+    });
+
+    it("gets the domain from a domain object", () => {
+      const props = { domain: { x: [1, 2] } };
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).toEqual(props.domain.x);
+    });
+
+    it("returns undefined if the domain props is not given", () => {
+      expect(Domain.getDomainFromProps({}, "x")).toBeUndefined();
+    });
+
+    it("returns undefined if the domain for a given axis is not defined", () => {
+      const props = { domain: { y: [1, 2] } };
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).toBeUndefined();
+    });
+
+    it("returns a domain from minDomain and maxDomain if both are defined", () => {
+      const props = { minDomain: 1, maxDomain: 10 };
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).toEqual([1, 10]);
+    });
+
+    it("returns an adjusted domain if minDomain equals maxDomain", () => {
+      const props = { minDomain: 1, maxDomain: 1 };
+      const verySmallNumber = Math.pow(10, -10);
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).toEqual([1 - verySmallNumber, 1 + verySmallNumber]);
+    });
+
+    it("returns undefined if only minDomain is defined", () => {
+      const props = { minDomain: 1 };
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).toBeUndefined();
+    });
+  });
+
+  describe("getDomainFromMinMax", () => {
+    it("returns a min max array when min and max are given", () => {
+      const min = 1;
+      const max = 2;
+      const resultDomain = Domain.getDomainFromMinMax(min, max);
+      expect(resultDomain).toEqual([min, max]);
+    });
+
+    it("returns an adjusted domain if min equals max", () => {
+      const min = 1;
+      const max = 1;
+      const verySmallNumber = Math.pow(10, -10);
+      const resultDomain = Domain.getDomainFromMinMax(min, max);
+      expect(resultDomain).toEqual([1 - verySmallNumber, 1 + verySmallNumber]);
+    });
+
+    it("returns a positive domain if min and max are both zero", () => {
+      const min = 0;
+      const max = 0;
+      const verySmallNumber = Math.pow(10, -10);
+      const resultDomain = Domain.getDomainFromMinMax(min, max);
+      expect(resultDomain).toEqual([0, 2 * verySmallNumber]);
+    });
+
+    it("returns an adjusted date domain if min equals max", () => {
+      const min = new Date(1980, 1, 1);
+      const max = new Date(1980, 1, 1);
+      const resultDomain = Domain.getDomainFromMinMax(min, max);
+      expect(resultDomain).toEqual([new Date(+min - 1), new Date(+max + 1)]);
+    });
+  });
+
+  describe("getDomainWithZero", () => {
+    it("ensures that the domain includes zero for the dependent axis", () => {
+      const props = {
+        data: [
+          { x: 1, y: 3 },
+          { x: 3, y: 5 }
+        ]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).toEqual([0, 5]);
+    });
+
+    it("allows minimum domain values less than zero", () => {
+      const props = {
+        data: [
+          { x: 1, y: -3 },
+          { x: 3, y: 5 }
+        ]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).toEqual([-3, 5]);
+    });
+
+    it("allows explicit y0 values in props.data to set the minimum domain", () => {
+      const props = {
+        data: [
+          { x: 1, y: 3, y0: 2 },
+          { x: 3, y: 5, y0: 3 }
+        ]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).toEqual([2, 5]);
+    });
+
+    it("handles negative y0 values", () => {
+      const props = {
+        data: [
+          { x: 1, y: -3, y0: -7 },
+          { x: 3, y: -5, y0: -7 }
+        ]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).toEqual([-7, -3]);
+    });
+
+    it("respects props.minDomain when present", () => {
+      const props = {
+        data: [
+          { x: 1, y: 3, y0: 2 },
+          { x: 3, y: 5, y0: 2 }
+        ],
+        minDomain: { y: 4 }
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).toEqual([4, 5]);
+    });
+
+    it("does not force the independent domain to include zero", () => {
+      const props = {
+        data: [
+          { x: 1, y: 3 },
+          { x: 3, y: 5 }
+        ]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "x");
+      expect(resultDomain).toEqual([1, 3]);
+    });
+  });
+
+  describe("getMaxFromProps", () => {
+    it("returns maxDomain from props as an object", () => {
+      const props = { maxDomain: { x: 3 } };
+      const maxDomain = Domain.getMaxFromProps(props, "x");
+      expect(maxDomain).toEqual(props.maxDomain.x);
+    });
+
+    it("returns maxDomain from props as a number", () => {
+      const props = { maxDomain: 3 };
+      const maxDomain = Domain.getMaxFromProps(props, "x");
+      expect(maxDomain).toEqual(props.maxDomain);
+    });
+
+    it("returns undefined when maxDomain is not defined for a given axis", () => {
+      const props = { maxDomain: { y: 3 } };
+      const maxDomain = Domain.getMaxFromProps(props, "x");
+      expect(maxDomain).toBeUndefined();
+    });
+  });
+
+  describe("getMinFromProps", () => {
+    it("returns minDomain from props as an object", () => {
+      const props = { minDomain: { x: 3 } };
+      const minDomain = Domain.getMinFromProps(props, "x");
+      expect(minDomain).toEqual(props.minDomain.x);
+    });
+
+    it("returns minDomain from props as a number", () => {
+      const props = { minDomain: 3 };
+      const minDomain = Domain.getMinFromProps(props, "x");
+      expect(minDomain).toEqual(props.minDomain);
+    });
+
+    it("returns undefined when minDomain is not defined for a given axis", () => {
+      const props = { minDomain: { y: 3 } };
+      const minDomain = Domain.getMinFromProps(props, "x");
+      expect(minDomain).toBeUndefined();
+    });
+  });
+
+  describe("getSymmetricDomain", () => {
+    it("pads the domain by a value determined by data spacing", () => {
+      const domain = [0, 10];
+      const data = [2, 4, 6, 8];
+      const resultDomain = Domain.getSymmetricDomain(domain, data);
+      expect(resultDomain).toEqual([0, 12]);
+    });
+  });
+
+  describe("isDomainComponent", () => {
+    class TestDomainComponent extends React.Component {
+      static role = "area";
+    }
+    it("returns true when a component has a static role matching a whitelist", () => {
+      expect(Domain.isDomainComponent(<TestDomainComponent />)).toBe(true);
+    });
+
+    it("returns false when a component has a role that does not match the whitelist", () => {
+      // eslint-disable-next-line react/no-multi-comp
+      class TestFooComponent extends React.Component {
+        static role = "foo";
+      }
+      expect(Domain.isDomainComponent(<TestFooComponent />)).toBe(false);
+    });
+
+    it("returns true when a domain component is wrapped in VictoryPortal", () => {
+      expect(
+        Domain.isDomainComponent(
+          <VictoryPortal>
+            <TestDomainComponent />
+          </VictoryPortal>
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/events.test.js
+++ b/test/jest/victory-core/victory-util/events.test.js
@@ -1,0 +1,76 @@
+import { Events } from "victory-core";
+
+describe("victory-util/events", () => {
+  describe("getPartialEvents", () => {
+    it("returns a set of new event functions with partially applied arguments", () => {
+      const events = {
+        onClick: (evt, childProps, index) => {
+          return { evt, childProps, index };
+        }
+      };
+      const index = 0;
+      const childProps = { style: { fill: "green" } };
+      const result = Events.getPartialEvents(events, index, childProps);
+      expect(Object.keys(result)).toEqual(expect.arrayContaining(["onClick"]));
+      expect(Object.keys(result.onClick())).toEqual(
+        expect.arrayContaining(["evt", "childProps", "index"])
+      );
+      expect(result.onClick().index).toEqual(index);
+      expect(result.onClick().childProps).toEqual(childProps);
+    });
+  });
+
+  describe("getEvents", () => {
+    let fake;
+    beforeEach(() => {
+      fake = {
+        props: {
+          events: [
+            {
+              target: "data",
+              eventHandlers: {
+                onClick: () => {
+                  return {
+                    mutation: () => {
+                      return { foo: "foo" };
+                    }
+                  };
+                }
+              }
+            }
+          ]
+        },
+        baseProps: {
+          0: {
+            data: { foo: "bar" }
+          }
+        },
+        setState: (x) => x,
+        state: {}
+      };
+      jest.spyOn(fake, "setState");
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("returns new functions that call set state", () => {
+      const getScopedEvents = Events.getScopedEvents.bind(fake);
+      const getBoundEvents = Events.getEvents.bind(fake);
+      const index = 0;
+      const result = getBoundEvents(fake.props, "data", index, getScopedEvents);
+      expect(Object.keys(result)).toEqual(expect.arrayContaining(["onClick"]));
+      const partialEvents = Events.getPartialEvents(result, index, {});
+      expect(Object.keys(partialEvents)).toEqual(
+        expect.arrayContaining(["onClick"])
+      );
+      partialEvents.onClick();
+      expect(fake.setState).toReturnWith({
+        [index]: {
+          data: { foo: "foo" }
+        }
+      });
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/helpers.test.js
+++ b/test/jest/victory-core/victory-util/helpers.test.js
@@ -1,25 +1,28 @@
-/* eslint no-unused-expressions: 0 */
 import { Helpers } from "victory-core";
 
 describe("victory-util/helpers", () => {
   describe("omit", () => {
     const data = { x: 3, y: 2, z: 1 };
+
     it("removes omitted keys and preserves all others", () => {
       const newData = Helpers.omit(data, ["x"]);
       expect(newData.x).toBeUndefined();
       expect(newData.y).toEqual(2);
       expect(newData.z).toEqual(1);
     });
+
     it("creates a copy of the original object", () => {
       const newData = Helpers.omit(data, []);
       newData.x = 10;
       expect(data.x).toEqual(3);
       expect(newData.x).toEqual(10);
     });
+
     it("defaults to an empty object", () => {
       const newData = Helpers.omit();
       expect(newData).toEqual({});
     });
+
     it("defaults to simple shallow copy", () => {
       const newData = Helpers.omit(data);
       expect(newData).toEqual(data);
@@ -30,6 +33,7 @@ describe("victory-util/helpers", () => {
     it("defaults to an empty object", () => {
       expect(Helpers.modifyProps({})).toEqual({});
     });
+
     it("removes the theme role's style", () => {
       const role = "legend";
       const props = {
@@ -51,6 +55,7 @@ describe("victory-util/helpers", () => {
         modifiedProps
       );
     });
+
     it("uses fallbackProps", () => {
       const props = { x: 2, y: 3 };
       const fallbackProps = { x: 12, y: 13, z: 14 };
@@ -61,10 +66,12 @@ describe("victory-util/helpers", () => {
 
   describe("evaluateProp", () => {
     const data = { x: 3, y: 2 };
+
     it("evaluates functional props", () => {
       const testProp = (datum) => (datum.y > 0 ? "red" : "blue");
       expect(Helpers.evaluateProp(testProp, data)).toEqual("red");
     });
+
     it("doesn't alter non-functional props", () => {
       const testProp = "blue";
       expect(Helpers.evaluateProp(testProp, data)).toEqual("blue");
@@ -73,6 +80,7 @@ describe("victory-util/helpers", () => {
 
   describe("evaluateStyle", () => {
     const data = { x: 3, y: 2 };
+
     it("evaluates functional styles, without altering others", () => {
       const style = {
         color: (datum) => (datum.y > 0 ? "red" : "blue"),
@@ -83,6 +91,7 @@ describe("victory-util/helpers", () => {
         size: 5
       });
     });
+
     it("returns no styles if disableInlineStyles is true", () => {
       const style = {
         color: "blue"
@@ -100,6 +109,7 @@ describe("victory-util/helpers", () => {
       height: 200,
       padding: 0
     };
+
     it("returns a range based on props and axis", () => {
       const x = Helpers.getRange(props, "x");
       expect(Array.isArray(x)).toBe(true);
@@ -119,6 +129,7 @@ describe("victory-util/helpers", () => {
       data: { fill: "blue", stroke: "black" },
       labels: { fontSize: 10, fontFamily: "Helvetica" }
     };
+
     it("merges styles", () => {
       const style = { data: { fill: "red" }, labels: { fontSize: 12 } };
       const styles = Helpers.getStyles(style, defaultStyles);
@@ -145,12 +156,14 @@ describe("victory-util/helpers", () => {
         right: 40
       });
     });
+
     it("sets padding from a complete object", () => {
       const props = {
         padding: { top: 20, bottom: 40, left: 60, right: 80 }
       };
       expect(Helpers.getPadding(props)).toEqual(props.padding);
     });
+
     it("fills missing values with 0", () => {
       const props = {
         padding: { top: 40, bottom: 40 }

--- a/test/jest/victory-core/victory-util/helpers.test.js
+++ b/test/jest/victory-core/victory-util/helpers.test.js
@@ -1,0 +1,190 @@
+/* eslint no-unused-expressions: 0 */
+import { Helpers } from "victory-core";
+
+describe("victory-util/helpers", () => {
+  describe("omit", () => {
+    const data = { x: 3, y: 2, z: 1 };
+    it("removes omitted keys and preserves all others", () => {
+      const newData = Helpers.omit(data, ["x"]);
+      expect(newData.x).toBeUndefined();
+      expect(newData.y).toEqual(2);
+      expect(newData.z).toEqual(1);
+    });
+    it("creates a copy of the original object", () => {
+      const newData = Helpers.omit(data, []);
+      newData.x = 10;
+      expect(data.x).toEqual(3);
+      expect(newData.x).toEqual(10);
+    });
+    it("defaults to an empty object", () => {
+      const newData = Helpers.omit();
+      expect(newData).toEqual({});
+    });
+    it("defaults to simple shallow copy", () => {
+      const newData = Helpers.omit(data);
+      expect(newData).toEqual(data);
+    });
+  });
+
+  describe("modifyProps", () => {
+    it("defaults to an empty object", () => {
+      expect(Helpers.modifyProps({})).toEqual({});
+    });
+    it("removes the theme role's style", () => {
+      const role = "legend";
+      const props = {
+        theme: {
+          legend: {
+            style: {
+              color: "blue"
+            },
+            data: 42
+          }
+        }
+      };
+      const fallbackProps = {};
+      const modifiedProps = {
+        ...props,
+        data: 42
+      };
+      expect(Helpers.modifyProps(props, fallbackProps, role)).toEqual(
+        modifiedProps
+      );
+    });
+    it("uses fallbackProps", () => {
+      const props = { x: 2, y: 3 };
+      const fallbackProps = { x: 12, y: 13, z: 14 };
+      const modifiedProps = { x: 2, y: 3, z: 14 };
+      expect(Helpers.modifyProps(props, fallbackProps)).toEqual(modifiedProps);
+    });
+  });
+
+  describe("evaluateProp", () => {
+    const data = { x: 3, y: 2 };
+    it("evaluates functional props", () => {
+      const testProp = (datum) => (datum.y > 0 ? "red" : "blue");
+      expect(Helpers.evaluateProp(testProp, data)).toEqual("red");
+    });
+    it("doesn't alter non-functional props", () => {
+      const testProp = "blue";
+      expect(Helpers.evaluateProp(testProp, data)).toEqual("blue");
+    });
+  });
+
+  describe("evaluateStyle", () => {
+    const data = { x: 3, y: 2 };
+    it("evaluates functional styles, without altering others", () => {
+      const style = {
+        color: (datum) => (datum.y > 0 ? "red" : "blue"),
+        size: 5
+      };
+      expect(Helpers.evaluateStyle(style, data)).toEqual({
+        color: "red",
+        size: 5
+      });
+    });
+    it("returns no styles if disableInlineStyles is true", () => {
+      const style = {
+        color: "blue"
+      };
+      const props = {
+        disableInlineStyles: true
+      };
+      expect(Helpers.evaluateStyle(style, props)).toEqual({});
+    });
+  });
+
+  describe("getRange", () => {
+    const props = {
+      width: 100,
+      height: 200,
+      padding: 0
+    };
+    it("returns a range based on props and axis", () => {
+      const x = Helpers.getRange(props, "x");
+      expect(Array.isArray(x)).toBe(true);
+      expect(x).toHaveLength(2);
+      expect(x).toEqual([0, 100]);
+
+      const y = Helpers.getRange(props, "y");
+      expect(Array.isArray(y)).toBe(true);
+      expect(y).toHaveLength(2);
+      expect(y).toEqual([200, 0]);
+    });
+  });
+
+  describe("getStyles", () => {
+    const defaultStyles = {
+      parent: { border: "black" },
+      data: { fill: "blue", stroke: "black" },
+      labels: { fontSize: 10, fontFamily: "Helvetica" }
+    };
+    it("merges styles", () => {
+      const style = { data: { fill: "red" }, labels: { fontSize: 12 } };
+      const styles = Helpers.getStyles(style, defaultStyles);
+      expect(styles.parent).toEqual({
+        border: "black",
+        width: "100%",
+        height: "100%"
+      });
+      expect(styles.data).toEqual({ fill: "red", stroke: "black" });
+      expect(styles.labels).toEqual({
+        fontSize: 12,
+        fontFamily: "Helvetica"
+      });
+    });
+  });
+
+  describe("getPadding", () => {
+    it("sets padding from a single number", () => {
+      const props = { padding: 40 };
+      expect(Helpers.getPadding(props)).toEqual({
+        top: 40,
+        bottom: 40,
+        left: 40,
+        right: 40
+      });
+    });
+    it("sets padding from a complete object", () => {
+      const props = {
+        padding: { top: 20, bottom: 40, left: 60, right: 80 }
+      };
+      expect(Helpers.getPadding(props)).toEqual(props.padding);
+    });
+    it("fills missing values with 0", () => {
+      const props = {
+        padding: { top: 40, bottom: 40 }
+      };
+      expect(Helpers.getPadding(props)).toEqual({
+        top: 40,
+        bottom: 40,
+        left: 0,
+        right: 0
+      });
+    });
+  });
+
+  describe("createAccessor", () => {
+    it("creates a valid object accessor from a property key", () => {
+      const accessor = Helpers.createAccessor("k");
+      expect(accessor({ k: 42 })).toEqual(42);
+    });
+
+    it("creates a valid array accessor from an index", () => {
+      const accessor = Helpers.createAccessor(2);
+      expect(accessor([3, 4, 5])).toEqual(5);
+    });
+
+    it("creates a valid array accessor from a deeply nested path", () => {
+      const accessor = Helpers.createAccessor("x.y[0].0.z");
+      expect(accessor({ x: { y: [[{ z: 1987 }]] } })).toEqual(1987);
+    });
+
+    it("creates a value (passthrough) accessor from null/undefined", () => {
+      const nullAccessor = Helpers.createAccessor(null);
+      const undefinedAccessor = Helpers.createAccessor(undefined);
+      expect(nullAccessor("ok")).toEqual("ok");
+      expect(undefinedAccessor(14)).toEqual(14);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/label-helpers.test.js
+++ b/test/jest/victory-core/victory-util/label-helpers.test.js
@@ -1,0 +1,124 @@
+/* eslint max-nested-callbacks: 0 */
+
+import { LabelHelpers, VictoryLabel } from "victory-core";
+import { assign } from "lodash";
+import React from "react";
+import * as d3Scale from "victory-vendor/d3-scale";
+
+const scale = { x: d3Scale.scaleLinear(), y: d3Scale.scaleLinear() };
+const data = [
+  { x: 0, y: 0 },
+  { x: 0.5, y: 0.5 }
+];
+const labelComponent = <VictoryLabel />;
+const style = { labels: { fontSize: 8 } };
+
+const basicProps = { scale, data, labelComponent, style };
+
+describe("victory-util/label-helpers", () => {
+  describe("getProps", () => {
+    it("returns the correct positions given a set of props an and index", () => {
+      data.forEach((datum, index) => {
+        const labelProps = LabelHelpers.getProps(basicProps, index);
+        expect(labelProps.x).toEqual(datum.x);
+        expect(labelProps.y).toEqual(datum.y);
+      });
+    });
+    it("returns the correct label text from a labels array", () => {
+      const labels = ["one", "two"];
+      const props = assign({ labels }, basicProps);
+      data.forEach((datum, index) => {
+        const labelProps = LabelHelpers.getProps(props, index);
+        expect(labelProps.text).toEqual(labels[index]);
+      });
+    });
+    it("returns the correct label text from datum", () => {
+      const dataWithLabels = [
+        { x: 0, y: 0, label: "one" },
+        { x: 0.5, y: 0.5, label: "two" }
+      ];
+      const props = assign({}, basicProps, { data: dataWithLabels });
+      data.forEach((datum, index) => {
+        const labelProps = LabelHelpers.getProps(props, index);
+        expect(labelProps.text).toEqual(dataWithLabels[index].label);
+      });
+    });
+    it("returns the correct positions for polar labels", () => {
+      const polarScale = {
+        x: d3Scale.scaleLinear().range([0, Math.PI * 2]),
+        y: d3Scale.scaleLinear()
+      };
+      data.forEach((datum, index) => {
+        const props = assign({}, basicProps, {
+          scale: polarScale,
+          polar: true
+        });
+        const labelProps = LabelHelpers.getProps(props, index);
+        expect(labelProps.x).toEqual(datum.y * Math.cos(datum.x * Math.PI * 2));
+        // We need Math.abs here because 0 does not equal -0 :(
+        expect(Math.abs(labelProps.y)).toEqual(
+          Math.abs(-datum.y * Math.sin(datum.x * Math.PI * 2))
+        );
+      });
+    });
+  });
+
+  describe("getPolarAngle", () => {
+    it("returns zero when labelPlacement is vertical", () => {
+      const angle = LabelHelpers.getPolarAngle({ labelPlacement: "vertical" });
+      expect(angle).toEqual(0);
+    });
+    it("returns angles corresponding to perpendicular labelPlacement", () => {
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 15)
+      ).toEqual(75);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 45)
+      ).toEqual(45);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 90)
+      ).toEqual(0);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 135)
+      ).toEqual(-45);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 180)
+      ).toEqual(90);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 225)
+      ).toEqual(45);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 270)
+      ).toEqual(0);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "perpendicular" }, 315)
+      ).toEqual(-45);
+    });
+    it("returns angles corresponding to parallel labelPlacement", () => {
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 15)
+      ).toEqual(-15);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 45)
+      ).toEqual(-45);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 90)
+      ).toEqual(-90);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 135)
+      ).toEqual(45);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 180)
+      ).toEqual(0);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 225)
+      ).toEqual(-45);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 270)
+      ).toEqual(-90);
+      expect(
+        LabelHelpers.getPolarAngle({ labelPlacement: "parallel" }, 315)
+      ).toEqual(45);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/label-helpers.test.js
+++ b/test/jest/victory-core/victory-util/label-helpers.test.js
@@ -1,8 +1,7 @@
 /* eslint max-nested-callbacks: 0 */
-
-import { LabelHelpers, VictoryLabel } from "victory-core";
 import { assign } from "lodash";
 import React from "react";
+import { LabelHelpers, VictoryLabel } from "victory-core";
 import * as d3Scale from "victory-vendor/d3-scale";
 
 const scale = { x: d3Scale.scaleLinear(), y: d3Scale.scaleLinear() };

--- a/test/jest/victory-core/victory-util/point-path-helpers.test.js
+++ b/test/jest/victory-core/victory-util/point-path-helpers.test.js
@@ -1,0 +1,74 @@
+import { PointPathHelpers as PathHelpers } from "victory-core";
+
+describe("point-path-helpers", () => {
+  const x = 0;
+  const y = 0;
+  const size = 1;
+  describe("circle", () => {
+    it("draws a path for a circle at the correct location", () => {
+      const pathResult = PathHelpers.circle(x, y, size);
+      expect(pathResult).toContain(`M ${x}, ${y}`);
+    });
+  });
+
+  describe("square", () => {
+    it("draws a path for a square at the correct location", () => {
+      const pathResult = PathHelpers.square(x, y, size);
+      const baseSize = 0.87 * size;
+      expect(pathResult).toContain(`M ${x - baseSize}, ${y + baseSize}`);
+    });
+  });
+
+  describe("diamond", () => {
+    it("draws a path for a diamond at the correct location", () => {
+      const pathResult = PathHelpers.diamond(0, 0, 1);
+      const baseSize = 0.87 * size;
+      const length = Math.sqrt(2 * (baseSize * baseSize));
+      expect(pathResult).toContain(
+        `M ${Math.round(x)}, ${Math.round(y + length)}`
+      );
+    });
+  });
+
+  describe("triangleUp", () => {
+    it("draws a path for a triangleUp at the correct location", () => {
+      const pathResult = PathHelpers.triangleUp(0, 0, 1);
+      expect(pathResult).toContain(`M ${x - size}, ${y + size}`);
+    });
+  });
+
+  describe("triangleDown", () => {
+    it("draws a path for a triangleDown at the correct location", () => {
+      const pathResult = PathHelpers.triangleDown(0, 0, 1);
+      expect(pathResult).toContain(`M ${x - size}, ${y - size}`);
+    });
+  });
+
+  describe("plus", () => {
+    it("draws a path for a plus at the correct location", () => {
+      const pathResult = PathHelpers.plus(0, 0, 1);
+      const baseSize = 1.1 * size;
+      const distance = baseSize / 1.5;
+      expect(pathResult).toContain(`M ${x - distance / 2}, ${y + baseSize}`);
+    });
+  });
+
+  describe("minus", () => {
+    it("draws a path for a minus at the correct location", () => {
+      const pathResult = PathHelpers.minus(0, 0, 1);
+      const baseSize = 1.1 * size;
+      const lineHeight = baseSize - baseSize * 0.3;
+      expect(pathResult).toContain(`M ${x - baseSize}, ${y + lineHeight / 2}`);
+    });
+  });
+
+  describe("star", () => {
+    it("draws a path for a star at the correct location", () => {
+      const pathResult = PathHelpers.star(0, 0, 1);
+      const angle = Math.PI / 5;
+      const baseSize = 1.35 * size;
+      expect(pathResult).toContain(`M ${baseSize * Math.sin(angle) + x}`);
+      expect(pathResult).toContain(`${baseSize * Math.cos(angle) + y}`);
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/prop-types.test.js
+++ b/test/jest/victory-core/victory-util/prop-types.test.js
@@ -1,0 +1,361 @@
+/* global console */
+/* eslint no-unused-expressions: 0 */
+import PropTypes from "prop-types";
+import { PropTypes as CustomPropTypes } from "victory-core";
+
+describe("victory-util/prop-types", () => {
+  /* eslint-disable no-console */
+  describe("deprecated", () => {
+    const shouldWarn = (message) => {
+      expect(console.warn).toBeCalledTimes(1);
+      expect(console.warn).toBeCalledWith(message);
+    };
+
+    const shouldError = (message) => {
+      expect(console.error).toBeCalledTimes(1);
+      expect(console.error).toBeCalledWith(message);
+    };
+
+    const shouldNotError = () => {
+      expect(console.error).notCalled;
+    };
+
+    const validate = (prop) => {
+      return CustomPropTypes.deprecated(PropTypes.string, "Read more at link")(
+        {
+          pName: prop
+        },
+        "pName",
+        "ComponentName"
+      );
+    };
+
+    beforeEach(() => {
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+      jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("Should warn about deprecation and validate OK", () => {
+      validate("value");
+      shouldWarn(
+        '"pName" property of "ComponentName" has been deprecated Read more at link'
+      );
+      shouldNotError();
+    });
+
+    it(`Should warn about deprecation and throw validation error when property
+       value is not OK`, () => {
+      validate({});
+      shouldWarn(
+        '"pName" property of "ComponentName" has been deprecated Read more at link'
+      );
+      shouldError(
+        "Warning: Failed pName type: Invalid pName `pName` of type `object` supplied to " +
+          "`ComponentName`, expected `string`."
+      );
+    });
+  });
+  /* eslint-enable no-console */
+
+  describe("allOfType", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.allOfType([
+        CustomPropTypes.nonNegative,
+        CustomPropTypes.integer
+      ])({ testProp: prop }, "testProp", "TestComponent");
+    };
+
+    it("returns an error if the first validator is false", () => {
+      const result = validate(-1);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a non-negative number."
+      );
+    });
+
+    it("returns an error if the second validator is false", () => {
+      const result = validate(1.3);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be an integer."
+      );
+    });
+
+    it("does not return an error if both validators are true", () => {
+      const result = validate(3);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+  });
+
+  describe("nonNegative", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.nonNegative(
+        { testProp: prop },
+        "testProp",
+        "TestComponent"
+      );
+    };
+
+    it("returns an error for non numeric values", () => {
+      const result = validate("a");
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a non-negative number."
+      );
+    });
+
+    it("returns an error for negative numeric values", () => {
+      const result = validate(-1);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a non-negative number."
+      );
+    });
+
+    it("does not return an error for positive numeric values", () => {
+      const result = validate(1);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+
+    it("does not return an error for zero", () => {
+      const result = validate(0);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+  });
+
+  describe("integer", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.integer(
+        { testProp: prop },
+        "testProp",
+        "TestComponent"
+      );
+    };
+
+    it("returns an error for non numeric values", () => {
+      const result = validate("a");
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be an integer."
+      );
+    });
+
+    it("returns an error for non-integer numeric values", () => {
+      const result = validate(2.4);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be an integer."
+      );
+    });
+
+    it("does not return an error for integers", () => {
+      let result = validate(3);
+      expect(result).not.toBeInstanceOf(Error);
+      result = validate(-3);
+      expect(result).not.toBeInstanceOf(Error);
+      result = validate(0);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+  });
+
+  describe("greaterThanZero", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.greaterThanZero(
+        { testProp: prop },
+        "testProp",
+        "TestComponent"
+      );
+    };
+
+    it("returns an error for non numeric values", () => {
+      const result = validate("a");
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a number greater than zero."
+      );
+    });
+
+    it("returns an error for zero", () => {
+      const result = validate(0);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a number greater than zero."
+      );
+    });
+
+    it("returns an error for negative numbers", () => {
+      const result = validate(-3);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a number greater than zero."
+      );
+    });
+
+    it("does not return an error for numbers greater than zero", () => {
+      let result = validate(0.1);
+      expect(result).not.toBeInstanceOf(Error);
+      result = validate(5);
+      expect(result).not.toBeInstanceOf(Error);
+      result = validate(1);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+  });
+
+  describe("domain", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.domain(
+        { testProp: prop },
+        "testProp",
+        "TestComponent"
+      );
+    };
+
+    it("returns an error for non array values", () => {
+      const result = validate("a");
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be an array of two unique numeric values."
+      );
+    });
+
+    it("returns an error when the length of the array is not two", () => {
+      const result = validate([1]);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be an array of two unique numeric values."
+      );
+    });
+
+    it("returns an error when the values of the array are equal", () => {
+      const result = validate([1, 1]);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be an array of two unique numeric values."
+      );
+    });
+
+    it("does not return an error for two element ascending arrays", () => {
+      const result = validate([0, 1]);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+
+    it("does not return an error for two element descending arrays", () => {
+      const result = validate([1, 0]);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+
+    it("does not return an error arrays of dates", () => {
+      const result = validate([new Date(1980, 1, 1), new Date(1990, 1, 1)]);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+  });
+
+  describe("scale", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.scale(
+        { testProp: prop },
+        "testProp",
+        "TestComponent"
+      );
+    };
+
+    it("returns an error for non function values", () => {
+      const result = validate("a");
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a d3 scale."
+      );
+    });
+
+    it("returns an error when the function does not have a domain, range, and copy methods", () => {
+      const testFunc = () => {
+        "oops";
+      };
+      const result = validate(testFunc);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be a d3 scale."
+      );
+    });
+
+    it.skip("does not return an error when the function is a d3 scale", () => {
+      // const testFunc = d3.scale.linear; TODO: Mock this rather than depending on d3
+      // const result = validate(testFunc);
+      // expect(result).not.to.be.an.instanceOf(Error);
+    });
+  });
+
+  describe("homogeneousArray", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.homogeneousArray(
+        { testProp: prop },
+        "testProp",
+        "TestComponent"
+      );
+    };
+
+    it("returns an error for non array values", () => {
+      const result = validate("a");
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain(
+        "`testProp` in `TestComponent` must be an array."
+      );
+    });
+
+    it("returns an error when the array has elements of different types", () => {
+      const result = validate([1, "a"]);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toEqual(
+        "Expected `testProp` in `TestComponent` to be a homogeneous array, but found " +
+          "types `Number` and `String`."
+      );
+    });
+
+    it("does not return an error for empty arrays", () => {
+      const result = validate([]);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+
+    it("does not return an error for arrays with one item", () => {
+      const result = validate(["a"]);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+
+    it("does not return an error for arrays where all elements are the same type", () => {
+      const result = validate([1, 0]);
+      expect(result).not.toBeInstanceOf(Error);
+    });
+  });
+
+  describe("matchDataLength", () => {
+    const validate = function (prop, dataProp) {
+      const props = { testProp: prop, data: dataProp };
+      return CustomPropTypes.matchDataLength(
+        props,
+        "testProp",
+        "TestComponent"
+      );
+    };
+
+    it("does not return an error when prop is undefined", () => {
+      expect(validate()).not.toBeInstanceOf(Error);
+    });
+
+    it("does not return an error when prop has same length as data", () => {
+      expect(validate([{}, {}], [1, 2])).not.toBeInstanceOf(Error);
+    });
+
+    it("returns an error when prop doesn't have same length as data", () => {
+      const result = validate([{}], [1, 2]);
+      expect(result).toBeInstanceOf(Error);
+      expect(result).toHaveProperty(
+        "message",
+        "Length of data and testProp arrays must match."
+      );
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/scale.test.js
+++ b/test/jest/victory-core/victory-util/scale.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable max-nested-callbacks */
-
 import { Scale } from "victory-core";
 import * as d3Scale from "victory-vendor/d3-scale";
 

--- a/test/jest/victory-core/victory-util/scale.test.js
+++ b/test/jest/victory-core/victory-util/scale.test.js
@@ -1,0 +1,131 @@
+/* eslint-disable max-nested-callbacks */
+
+import { Scale } from "victory-core";
+import * as d3Scale from "victory-vendor/d3-scale";
+
+describe("victory-util/scale", () => {
+  describe("getBaseScale", () => {
+    it("returns a scale from `getScaleFromProps` when string props are provided", () => {
+      const props = { scale: "log" };
+      const baseScale = Scale.getBaseScale(props, "x");
+      expect(baseScale).toBeInstanceOf(Function);
+      expect(baseScale.base).toBeInstanceOf(Function); // This is a unique check for log scales
+    });
+
+    it("returns a scale from `getScaleFromProps` when a d3 scale is provided", () => {
+      const props = { scale: d3Scale.scaleLog() };
+      const baseScale = Scale.getBaseScale(props, "x");
+      expect(baseScale).toBeInstanceOf(Function);
+      expect(baseScale.base).toBeInstanceOf(Function); // This is a unique check for log scales
+    });
+
+    it("returns a default scale when data is provided", () => {
+      const props = { data: [{ x: 0, y: 1 }] };
+      const baseScale = Scale.getBaseScale(props, "x");
+      expect(baseScale).toBeInstanceOf(Function);
+      expect(baseScale.domain).toBeInstanceOf(Function);
+    });
+
+    it("returns a default scale when nothing is provided", () => {
+      const baseScale = Scale.getBaseScale({}, "x");
+      expect(baseScale).toBeInstanceOf(Function);
+      expect(baseScale.domain).toBeInstanceOf(Function);
+    });
+  });
+
+  describe("getScaleFromProps", () => {
+    it("returns a scale when a single scale is provided in props", () => {
+      const props = { scale: "log" };
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(propsScale).toBeInstanceOf(Function);
+      expect(propsScale.base).toBeInstanceOf(Function); // This is a unique check for log scales
+    });
+
+    it("returns a scale when a scale object contains a scale for an axis", () => {
+      const props = { scale: { x: "log" } };
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(propsScale).toBeInstanceOf(Function);
+      expect(propsScale.base).toBeInstanceOf(Function); // This is a unique check for log scales
+    });
+
+    it("returns undefined when a scale object does not contain a scale for an axis", () => {
+      const props = { scale: { y: "log" } };
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(propsScale).toBeUndefined();
+    });
+
+    it("returns undefined when an invalid scale is provided in props", () => {
+      const props = { scale: "foo" };
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(propsScale).toBeUndefined();
+    });
+
+    it("returns undefined when no scale prop is provided", () => {
+      const propsScale = Scale.getScaleFromProps({}, "x");
+      expect(propsScale).toBeUndefined();
+    });
+  });
+
+  describe("getScaleType", () => {
+    it("returns 'log' for log scales", () => {
+      const props = { scale: { x: d3Scale.scaleLog() } };
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(scaleType).toEqual("log");
+    });
+
+    it("returns a string value given a string prop", () => {
+      const props = { scale: { x: "linear" } };
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(scaleType).toEqual("linear");
+    });
+
+    it("uses data to distinguish between time and linear scales", () => {
+      const props = { scale: { x: d3Scale.scaleLinear() } };
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(scaleType).toEqual("linear");
+    });
+
+    it("returns 'linear' when no scale is set", () => {
+      const props = {};
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(scaleType).toEqual("linear");
+    });
+
+    it("returns 'time' when no scale is set, and data contains dates", () => {
+      const props = {
+        x: "x",
+        y: "y",
+        data: [{ x: new Date("2016-01-13"), y: 1 }]
+      };
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(scaleType).toEqual("time");
+    });
+  });
+
+  describe("getType", () => {
+    it("returns undefined on unknown function type", () => {
+      const scaleType = Scale.getType(function () {});
+      expect(scaleType).toBeUndefined();
+    });
+
+    it("returns a string value given a string prop", () => {
+      const scaleType = Scale.getType("linear");
+      expect(scaleType).toEqual("linear");
+    });
+
+    it("returns 'log' for log scales", () => {
+      const scaleType = Scale.getType(d3Scale.scaleLog());
+      expect(scaleType).toEqual("log");
+    });
+
+    it("matches 'quantile'", () => {
+      const scaleType = Scale.getType(d3Scale.scaleQuantile());
+      expect(scaleType).toEqual("quantile");
+    });
+
+    it("returns undefined for scaleLinear", () => {
+      const scaleType = Scale.getType(d3Scale.scaleLinear());
+      expect(scaleType).toBeUndefined();
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/selection.test.js
+++ b/test/jest/victory-core/victory-util/selection.test.js
@@ -1,0 +1,49 @@
+import { Selection } from "victory-core";
+import * as d3Scale from "victory-vendor/d3-scale";
+
+describe("helpers/selection", () => {
+  describe("getBounds", () => {
+    it("returns min / max bounds", () => {
+      const x1 = 10;
+      const x2 = 5;
+      const y1 = 0;
+      const y2 = 1;
+      const scale = { x: d3Scale.scaleLinear(), y: d3Scale.scaleLinear() };
+      const props = { x1, x2, y1, y2, scale };
+      const bounds = Selection.getBounds(props);
+      expect(bounds).toEqual({ x: [x2, x1], y: [y1, y2] });
+    });
+  });
+
+  describe("getDomainCoordinates", () => {
+    it("returns coordinates corresponding to domain min max", () => {
+      const scale = {
+        x: d3Scale.scaleLinear(),
+        y: d3Scale.scaleLinear()
+      };
+      const coords = Selection.getDomainCoordinates({ scale });
+      expect(coords).toEqual({ x: [0, 1], y: [0, 1] });
+    });
+  });
+
+  describe("getDataCoordinates", () => {
+    it("returns coordinates corresponding to point x, y", () => {
+      const scale = {
+        x: d3Scale.scaleLinear(),
+        y: d3Scale.scaleLinear()
+      };
+      const coords = Selection.getDataCoordinates({}, scale, 1, 1);
+      expect(coords).toEqual({ x: 1, y: 1 });
+    });
+    it("returns polar coordinates corresponding to point x, y", () => {
+      const scale = {
+        x: d3Scale.scaleLinear().range([0, Math.PI * 2]),
+        y: d3Scale.scaleLinear()
+      };
+      const x = Math.PI;
+      const y = 0;
+      const coords = Selection.getDataCoordinates({ polar: true }, scale, x, y);
+      expect(coords).toEqual({ x: 0, y: Math.PI });
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/style.test.js
+++ b/test/jest/victory-core/victory-util/style.test.js
@@ -1,0 +1,26 @@
+import { Style } from "victory-core";
+
+describe("toTransformString", () => {
+  it("returns an empty string if no transform definitions are given", () => {
+    expect(Style.toTransformString({})).toEqual("");
+  });
+
+  it("returns a string with two transform instructions when an object is given", () => {
+    expect(
+      Style.toTransformString({
+        rotate: [45, 0, 1],
+        skewY: [65]
+      })
+    ).toEqual("rotate(45,0,1) skewY(65)");
+  });
+
+  it("returns a string with two transform instructions when two objects are given", () => {
+    expect(
+      Style.toTransformString({ rotate: [45, 0, 1] }, { skewY: [65] })
+    ).toEqual("rotate(45,0,1) skewY(65)");
+  });
+
+  it("returns at least the subsequent transforms if the first is undefined", () => {
+    expect(Style.toTransformString(undefined, { skewY: [65] })).toEqual("skewY(65)");
+  });
+});

--- a/test/jest/victory-core/victory-util/style.test.js
+++ b/test/jest/victory-core/victory-util/style.test.js
@@ -21,6 +21,8 @@ describe("toTransformString", () => {
   });
 
   it("returns at least the subsequent transforms if the first is undefined", () => {
-    expect(Style.toTransformString(undefined, { skewY: [65] })).toEqual("skewY(65)");
+    expect(Style.toTransformString(undefined, { skewY: [65] })).toEqual(
+      "skewY(65)"
+    );
   });
 });

--- a/test/jest/victory-core/victory-util/textsize.test.js
+++ b/test/jest/victory-core/victory-util/textsize.test.js
@@ -1,0 +1,175 @@
+import { TextSize } from "victory-core";
+
+const testString = "ABC";
+
+describe("victory-util/textsize", () => {
+  describe("convertLengthToPixels", () => {
+    it("translate pixels as number of pixels", () => {
+      expect(TextSize.convertLengthToPixels("20px")).toEqual(20);
+    });
+    it("translate absolute measurement length units to particular number of pixels", () => {
+      expect(TextSize.convertLengthToPixels("10pt")).toEqual(13.3);
+    });
+    it("translate relative measurement length units to particular number of pixels", () => {
+      expect(TextSize.convertLengthToPixels("1.5em", 16)).toEqual(24);
+    });
+  });
+
+  describe("approximateWidth", () => {
+    it("return zero width when no style", () => {
+      expect(TextSize.approximateTextSize(testString).width).toEqual(0);
+    });
+    it("return correct width with signed angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          angle: -45,
+          fontSize: 14
+        }).width.toFixed(2)
+      ).toEqual("31.71");
+    });
+    it("return correct width with pixel fontsize", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: "14px"
+        }).width.toFixed(2)
+      ).toEqual("28.74");
+    });
+    it("return appropriate width with defined fontSize", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12
+        }).width.toFixed(2)
+      ).toEqual("24.64");
+    });
+    it("consider font", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 16
+        }).width.toFixed(2)
+      ).toEqual("32.85");
+    });
+    it("consider letterSpacing", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          letterSpacing: "1px"
+        }).width.toFixed(2)
+      ).toEqual("26.64");
+    });
+    it("consider angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          angle: 30
+        }).width.toFixed(2)
+      ).toEqual("28.24");
+    });
+    it("not consider lineHeight without angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          lineHeight: 2
+        }).width.toFixed(2)
+      ).toEqual("24.64");
+    });
+    it("consider lineHeight with angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          lineHeight: 2,
+          angle: 30
+        }).width.toFixed(2)
+      ).toEqual("35.14");
+    });
+    it("return width of widest string in text", () => {
+      expect(
+        TextSize.approximateTextSize("ABC\nDEFGH\nIJK", {
+          fontSize: 12
+        }).width.toFixed(2)
+      ).toEqual("41.94");
+    });
+
+    it("returns width of widest string in array if array has an empty string", () => {
+      expect(
+        TextSize.approximateTextSize(["06-14-20", ""], {
+          fontSize: 12
+        }).width.toFixed(2)
+      ).toEqual("47.93");
+    });
+  });
+
+  describe("approximateHeight", () => {
+    it("return zero width when no style", () => {
+      expect(TextSize.approximateTextSize(testString).height).toEqual(0);
+    });
+    it("return correct height with signed angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          angle: -45,
+          fontSize: 14
+        }).height.toFixed(2)
+      ).toEqual("33.29");
+    });
+    it("return correct height with pixel fontsize", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: "14px"
+        }).height.toFixed(2)
+      ).toEqual("16.90");
+    });
+    it("return appropriate height with expected precision", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12
+        }).height.toFixed(2)
+      ).toEqual("14.49");
+    });
+    it("consider font", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 16
+        }).height.toFixed(2)
+      ).toEqual("19.32");
+    });
+    it("consider angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          angle: 30
+        }).height.toFixed(2)
+      ).toEqual("25.48");
+    });
+    it("not consider letterSpacing without angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          letterSpacing: "1px"
+        }).height.toFixed(2)
+      ).toEqual("14.49");
+    });
+    it("consider letterSpacing with angle", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          angle: 30,
+          letterSpacing: "1px"
+        }).height.toFixed(2)
+      ).toEqual("26.53");
+    });
+    it("consider lineHeight", () => {
+      expect(
+        TextSize.approximateTextSize(testString, {
+          fontSize: 12,
+          lineHeight: 2
+        }).height.toFixed(2)
+      ).toEqual("28.98");
+    });
+    it("consider multiLines text", () => {
+      expect(
+        TextSize.approximateTextSize(`ABC\n${"DBCDEFG"}\n123`, {
+          fontSize: 12
+        }).height.toFixed(2)
+      ).toEqual("43.47");
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/transitions.test.js
+++ b/test/jest/victory-core/victory-util/transitions.test.js
@@ -1,5 +1,5 @@
-import { Transitions } from "victory-core";
 import React from "react";
+import { Transitions } from "victory-core";
 
 describe("getInitialTransitionState", () => {
   const makeChild = (data) => {

--- a/test/jest/victory-core/victory-util/transitions.test.js
+++ b/test/jest/victory-core/victory-util/transitions.test.js
@@ -1,0 +1,143 @@
+import { Transitions } from "victory-core";
+import React from "react";
+
+describe("getInitialTransitionState", () => {
+  const makeChild = (data) => {
+    return React.createElement("div", { data });
+  };
+
+  it("returns a 'falsey' transition object if children are not given", () => {
+    const result = Transitions.getInitialTransitionState(null, null);
+    expect(result).toEqual({
+      childrenTransitions: [],
+      nodesWillExit: false,
+      nodesWillEnter: false,
+      nodesShouldEnter: false
+    });
+  });
+
+  it("it returns childTransitions entering and exiting false for identical data", () => {
+    const child = makeChild([
+      { x: 1, y: 1 },
+      { x: 2, y: 3 }
+    ]);
+    const result = Transitions.getInitialTransitionState(child, child);
+    expect(result).toEqual({
+      childrenTransitions: [{ entering: false, exiting: false }],
+      nodesWillExit: false,
+      nodesWillEnter: false,
+      nodesShouldEnter: false
+    });
+  });
+
+  it("it returns childTransitions with exiting data", () => {
+    const child1 = makeChild([
+      { x: 1, y: 1 },
+      { x: 2, y: 3 }
+    ]);
+    const child2 = makeChild([{ x: 1, y: 1 }]);
+    const result = Transitions.getInitialTransitionState(child1, child2);
+    expect(result).toEqual({
+      childrenTransitions: [{ entering: false, exiting: { 1: true } }],
+      nodesWillExit: true,
+      nodesWillEnter: false,
+      nodesShouldEnter: false
+    });
+  });
+
+  it("it returns childTransitions with entering data", () => {
+    const child1 = makeChild([{ x: 1, y: 1 }]);
+    const child2 = makeChild([
+      { x: 1, y: 1 },
+      { x: 2, y: 3 }
+    ]);
+    const result = Transitions.getInitialTransitionState(child1, child2);
+    expect(result).toEqual({
+      childrenTransitions: [{ entering: { 1: true }, exiting: false }],
+      nodesWillExit: false,
+      nodesWillEnter: true,
+      nodesShouldEnter: false
+    });
+  });
+});
+
+describe("getTransitionPropsFactory", () => {
+  const toZero = jest.fn().mockImplementation(() => ({ y: 0 }));
+  const makeChild = (data) => {
+    return {
+      type: {
+        defaultTransitions: {
+          onExit: { duration: 1, before: toZero },
+          onEnter: { duration: 2, before: toZero }
+        }
+      },
+      props: { data, animate: { duration: 0 } }
+    };
+  };
+
+  const callback = jest.fn();
+
+  it("returns a function that describes data exiting", () => {
+    const exitingState = {
+      childrenTransitions: [{ entering: false, exiting: { 1: true } }],
+      nodesWillExit: true,
+      nodesWillEnter: false,
+      nodesShouldEnter: false,
+      nodesShouldLoad: true,
+      nodesDoneLoad: true
+    };
+    const result = Transitions.getTransitionPropsFactory(
+      {},
+      exitingState,
+      callback
+    );
+    const child = makeChild([
+      { x: 1, y: 1 },
+      { x: 2, y: 3 }
+    ]);
+    const calledResult = result(child);
+    expect(result).toBeInstanceOf(Function);
+    expect(Object.keys(calledResult)).toEqual(
+      expect.arrayContaining(["animate", "data"])
+    );
+    expect(calledResult.data).toEqual([
+      { x: 1, y: 1 },
+      { x: 2, y: 0 }
+    ]);
+    expect(calledResult.animate.duration).toEqual(
+      child.type.defaultTransitions.onExit.duration
+    );
+  });
+
+  it("returns a function that describes data entering", () => {
+    const enteringState = {
+      childrenTransitions: [{ entering: { 1: true }, exiting: false }],
+      nodesWillExit: false,
+      nodesWillEnter: true,
+      nodesShouldEnter: false,
+      nodesShouldLoad: true,
+      nodesDoneLoad: true
+    };
+    const result = Transitions.getTransitionPropsFactory(
+      {},
+      enteringState,
+      callback
+    );
+    const child = makeChild([
+      { x: 1, y: 1 },
+      { x: 2, y: 3 }
+    ]);
+    const calledResult = result(child);
+    expect(result).toBeInstanceOf(Function);
+    expect(calledResult).toBeInstanceOf(Object);
+    expect(calledResult).toBeInstanceOf(Object);
+    expect(Object.keys(calledResult)).toEqual(
+      expect.arrayContaining(["animate", "data"])
+    );
+
+    expect(calledResult.data).toEqual([
+      { x: 1, y: 1 },
+      { x: 2, y: 0 }
+    ]);
+  });
+});

--- a/test/jest/victory-core/victory-util/wrapper.test.js
+++ b/test/jest/victory-core/victory-util/wrapper.test.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-unused-expressions,react/no-multi-comp */
+import { Wrapper } from "victory-core";
+import React from "react";
+import { VictoryAxis } from "victory-axis";
+import { VictoryLine } from "victory-line";
+
+describe("helpers/wrapper", () => {
+  const getVictoryLine = (props) => React.createElement(VictoryLine, props);
+  const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);
+
+  describe("getDomain", () => {
+    const victoryLine = getVictoryLine({ domain: [0, 3] });
+    const xAxis = getVictoryAxis({ dependentAxis: false });
+    const yAxis = getVictoryAxis({ dependentAxis: true });
+    const childComponents = [victoryLine, xAxis, yAxis];
+
+    it("calculates a domain from props", () => {
+      const props = { domain: { x: [1, 2], y: [2, 3] } };
+      const domainResultX = Wrapper.getDomain(props, "x", childComponents);
+      expect(domainResultX).toEqual([1, 2]);
+    });
+
+    it("calculates a domain from child components", () => {
+      const props = { children: childComponents };
+      const domainResultX = Wrapper.getDomain(props, "x", childComponents);
+      expect(domainResultX).toEqual(victoryLine.props.domain);
+    });
+  });
+
+  describe("getStringsFromData", () => {
+    it("returns an array of strings from a data prop", () => {
+      const props = {
+        data: [
+          { x: "one", y: 1 },
+          { x: "red", y: 2 },
+          { x: "cat", y: 3 }
+        ]
+      };
+      const childComponents = [getVictoryLine(props)];
+      const dataStrings = Wrapper.getStringsFromData(childComponents).x;
+      expect(dataStrings).toEqual(["one", "red", "cat"]);
+    });
+
+    it("returns an array of strings from array-type data", () => {
+      const props = {
+        data: [
+          ["one", 1],
+          ["red", 2],
+          ["cat", 3]
+        ],
+        x: 0,
+        y: 1
+      };
+      const childComponents = [getVictoryLine(props)];
+      const dataStrings = Wrapper.getStringsFromData(childComponents).x;
+      expect(dataStrings).toEqual(["one", "red", "cat"]);
+    });
+
+    it("only returns strings, if data is mixed", () => {
+      const props = {
+        data: [
+          { x: 1, y: 1 },
+          { x: "three", y: 3 }
+        ]
+      };
+      const childComponents = [getVictoryLine(props)];
+      expect(Wrapper.getStringsFromData(childComponents).x).toEqual(["three"]);
+    });
+
+    it("returns an empty array when no strings are present", () => {
+      const props = {
+        data: [
+          { x: 1, y: 1 },
+          { x: 3, y: 3 }
+        ]
+      };
+      const childComponents = [getVictoryLine(props)];
+      expect(Wrapper.getStringsFromData(childComponents).x).toEqual([]);
+    });
+
+    it("returns an empty array when no children are given", () => {
+      expect(Wrapper.getStringsFromData([])).toEqual({ x: [], y: [] });
+    });
+  });
+});

--- a/test/jest/victory-core/victory-util/wrapper.test.js
+++ b/test/jest/victory-core/victory-util/wrapper.test.js
@@ -1,7 +1,6 @@
-/* eslint-disable no-unused-expressions,react/no-multi-comp */
-import { Wrapper } from "victory-core";
 import React from "react";
 import { VictoryAxis } from "victory-axis";
+import { Wrapper } from "victory-core";
 import { VictoryLine } from "victory-line";
 
 describe("helpers/wrapper", () => {


### PR DESCRIPTION
This is part of the work for #2195.

* Copies existing spec files, runs codemod to change expectations
* Replaces enzyme with RTL

Note: This does not include the tests for `add-events`. These tests were the most complex to convert (there is a lot of mocking going on in the current test implementation), and this `addEvents` HOC is also one of my top priorities for refactoring out of the codebase. I personally am okay with letting these tests go for now, and then adding additional test coverage once we have a better solution for all this shared logic. 