### PR TITLE
Fix duplicate user props

### DIFF
--- a/packages/victory-area/src/victory-area.js
+++ b/packages/victory-area/src/victory-area.js
@@ -108,13 +108,11 @@ class VictoryArea extends React.Component {
     }
 
     const children = this.renderContinuousData(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-bar/src/victory-bar.js
+++ b/packages/victory-bar/src/victory-bar.js
@@ -116,13 +116,12 @@ class VictoryBar extends React.Component {
     }
 
     const children = this.renderData(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-box-plot/src/victory-box-plot.js
+++ b/packages/victory-box-plot/src/victory-box-plot.js
@@ -309,13 +309,11 @@ class VictoryBoxPlot extends React.Component {
     }
 
     const children = this.renderBoxPlot(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-candlestick/src/victory-candlestick.js
+++ b/packages/victory-candlestick/src/victory-candlestick.js
@@ -296,13 +296,12 @@ class VictoryCandlestick extends React.Component {
     }
 
     const children = this.renderCandleData(props, this.shouldRenderDatum);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.js
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import * as CustomPropTypes from "../victory-util/prop-types";
 import * as Helpers from "../victory-util/helpers";
+import * as UserProps from "../victory-util/user-props";
 import { assign, defaults, isObject, uniqueId } from "lodash";
 import ClipPath from "../victory-primitives/clip-path";
 import Circle from "../victory-primitives/circle";
@@ -84,6 +85,7 @@ export default class VictoryClipContainer extends React.Component {
   }
 
   renderClippedGroup(props, clipId) {
+    const userProps = UserProps.getSafeUserProps(props);
     const {
       style,
       events,
@@ -106,7 +108,7 @@ export default class VictoryClipContainer extends React.Component {
     );
     return React.cloneElement(
       groupComponent,
-      { ...groupProps, "aria-label": props["aria-label"], tabIndex },
+      { ...groupProps, tabIndex, ...userProps },
       [clipComponent, ...React.Children.toArray(children)]
     );
   }

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -14,7 +14,6 @@ import {
 import * as Events from "./events";
 import isEqual from "react-fast-compare";
 import VictoryTransition from "../victory-transition/victory-transition";
-import * as UserProps from "../victory-util/user-props";
 
 const datumHasXandY = (datum) => {
   return !isNil(datum._x) && !isNil(datum._y);
@@ -330,7 +329,6 @@ export default (WrappedComponent, options) => {
 
     renderData(props, shouldRenderDatum = datumHasXandY) {
       const { dataComponent, labelComponent, groupComponent } = props;
-      const userProps = UserProps.getSafeUserProps(props);
       const dataComponents = this.dataKeys.reduce(
         (validDataComponents, _dataKey, index) => {
           const dataProps = this.getComponentProps(
@@ -363,8 +361,7 @@ export default (WrappedComponent, options) => {
         .filter(Boolean);
 
       const children = [...dataComponents, ...labelComponents];
-      const group = React.cloneElement(groupComponent, userProps, children);
-      return this.renderContainer(group, children);
+      return this.renderContainer(groupComponent, children);
     }
   };
 };

--- a/packages/victory-core/src/victory-util/user-props.js
+++ b/packages/victory-core/src/victory-util/user-props.js
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 /*
   USER_PROPS_SAFELIST is to contain any string deemed safe for user props.
   The startsWidth array will contain the start of any accepted user-prop that 
@@ -78,4 +80,15 @@ export const getSafeUserProps = (props) => {
         return [key, getValue(value, props)];
       })
   );
+};
+
+/**
+ * Wraps a component and adds safe user props
+ *
+ * @param {ReactNode} component: parent component
+ * @param {Object} props: props to be filtered
+ * @returns {ReactNode} modified component
+ */
+export const withSafeUserProps = (component, props) => {
+  return React.cloneElement(component, getSafeUserProps(props));
 };

--- a/packages/victory-errorbar/src/victory-errorbar.js
+++ b/packages/victory-errorbar/src/victory-errorbar.js
@@ -106,13 +106,12 @@ class VictoryErrorBar extends React.Component {
     }
 
     const children = this.renderData(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-histogram/src/victory-histogram.js
+++ b/packages/victory-histogram/src/victory-histogram.js
@@ -122,14 +122,11 @@ export class VictoryHistogram extends React.Component {
 
     const children = this.renderData(props);
 
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(this.props)
-    );
-
-    return props.standalone
-      ? this.renderContainer(container, children)
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-line/src/victory-line.js
+++ b/packages/victory-line/src/victory-line.js
@@ -111,13 +111,12 @@ class VictoryLine extends React.Component {
     }
 
     const children = this.renderContinuousData(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 export default addEvents(VictoryLine, options);

--- a/packages/victory-pie/src/victory-pie.js
+++ b/packages/victory-pie/src/victory-pie.js
@@ -256,13 +256,12 @@ class VictoryPie extends React.Component {
     }
 
     const children = this.renderData(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-scatter/src/victory-scatter.js
+++ b/packages/victory-scatter/src/victory-scatter.js
@@ -99,13 +99,12 @@ class VictoryScatter extends React.Component {
     }
 
     const children = this.renderData(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/packages/victory-voronoi/src/victory-voronoi.js
+++ b/packages/victory-voronoi/src/victory-voronoi.js
@@ -78,13 +78,12 @@ class VictoryVoronoi extends React.Component {
     }
 
     const children = this.renderData(props);
-    const container = React.cloneElement(
-      props.containerComponent,
-      UserProps.getSafeUserProps(props)
-    );
-    return props.standalone
-      ? this.renderContainer(container, children)
+
+    const component = props.standalone
+      ? this.renderContainer(props.containerComponent, children)
       : children;
+
+    return UserProps.withSafeUserProps(component, props);
   }
 }
 

--- a/test/jest/rendering-utils.js
+++ b/test/jest/rendering-utils.js
@@ -1,6 +1,5 @@
 import { render } from "@testing-library/react";
-import * as React from "react";
 
 export const renderInSvg = (component) => {
-  return render(<svg>{component}</svg>);
+  return render(component, { wrapper: "svg" });
 };

--- a/test/jest/victory-area/victory-area.test.js
+++ b/test/jest/victory-area/victory-area.test.js
@@ -1,17 +1,43 @@
+import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { curveCatmullRom } from "victory-vendor/d3-shape";
 import { range } from "lodash";
 import React from "react";
 import { Area, VictoryArea } from "victory-area";
+import { VictoryChart } from "victory-chart";
+import { curveCatmullRom } from "victory-vendor/d3-shape";
 import { calculateD3Path } from "../../svg-test-helper";
 
 describe("components/victory-area", () => {
   describe("default component rendering", () => {
-    it("accepts user props", () => {
-      render(<VictoryArea data-testid="victory-area" aria-label="Chart" />);
+    it("attaches safe user props to the container component", () => {
+      render(
+        <VictoryArea
+          data-testid="victory-area"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />
+      );
 
-      expect(screen.queryByTestId("victory-area")).toBeDefined();
+      const container = screen.getByTestId("victory-area");
       expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.nodeName).toEqual("svg");
+    });
+
+    it("attaches safe user props to the group component if the component is rendered inside a VictoryChart", () => {
+      render(
+        <VictoryArea
+          data-testid="victory-area"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />,
+        { wrapper: VictoryChart }
+      );
+
+      const container = screen.getByTestId("victory-area");
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.nodeName).toEqual("g");
     });
 
     it("renders an svg with the correct viewbox", () => {

--- a/test/jest/victory-area/victory-area.test.js
+++ b/test/jest/victory-area/victory-area.test.js
@@ -1,4 +1,3 @@
-import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { range } from "lodash";
 import React from "react";

--- a/test/jest/victory-bar/victory-bar.test.js
+++ b/test/jest/victory-bar/victory-bar.test.js
@@ -5,12 +5,24 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import { range } from "lodash";
 import { VictoryBar, Bar } from "victory-bar";
 import { isBar, getBarHeight } from "../../svg-test-helper";
+import "@testing-library/jest-dom";
 
 describe("components/victory-bar", () => {
   describe("default component rendering", () => {
-    it("accepts user props", () => {
-      render(<VictoryBar data-testid="victory-bar" aria-label="Chart" />);
-      expect(screen.getAllByLabelText("Chart")).toBeDefined();
+    it("attaches safe user props to the container component", () => {
+      render(
+        <VictoryBar
+          data-testid="victory-bar"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />
+      );
+
+      expect(screen.getByTestId("victory-bar")).toBeDefined();
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(screen.getByTestId("victory-bar")).not.toHaveAttribute(
+        "unsafe-prop"
+      );
     });
 
     it("renders an svg with the correct width and height", () => {

--- a/test/jest/victory-bar/victory-bar.test.js
+++ b/test/jest/victory-bar/victory-bar.test.js
@@ -3,6 +3,7 @@
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import { range } from "lodash";
+import { VictoryChart } from "victory-chart";
 import { VictoryBar, Bar } from "victory-bar";
 import { isBar, getBarHeight } from "../../svg-test-helper";
 import "@testing-library/jest-dom";
@@ -18,11 +19,26 @@ describe("components/victory-bar", () => {
         />
       );
 
-      expect(screen.getByTestId("victory-bar")).toBeDefined();
+      const container = screen.getByTestId("victory-bar");
       expect(screen.getByLabelText("Chart")).toBeDefined();
-      expect(screen.getByTestId("victory-bar")).not.toHaveAttribute(
-        "unsafe-prop"
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.tagName).toEqual("svg");
+    });
+
+    it("attaches safe user props to the group component if the component is rendered inside a VictoryChart", () => {
+      render(
+        <VictoryBar
+          data-testid="victory-bar"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />,
+        { wrapper: VictoryChart }
       );
+
+      const container = screen.getByTestId("victory-bar");
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.tagName).toEqual("g");
     });
 
     it("renders an svg with the correct width and height", () => {

--- a/test/jest/victory-bar/victory-bar.test.js
+++ b/test/jest/victory-bar/victory-bar.test.js
@@ -6,7 +6,6 @@ import { range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryBar, Bar } from "victory-bar";
 import { isBar, getBarHeight } from "../../svg-test-helper";
-import "@testing-library/jest-dom";
 
 describe("components/victory-bar", () => {
   describe("default component rendering", () => {

--- a/test/jest/victory-box-plot/victory-box-plot.test.js
+++ b/test/jest/victory-box-plot/victory-box-plot.test.js
@@ -1,8 +1,10 @@
 /*eslint-disable react/prop-types */
-import React from "react";
+import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import { VictoryBoxPlot } from "victory-box-plot";
-import { LineSegment, Whisker, Border } from "victory-core";
+import { VictoryChart } from "victory-chart";
+import { Border, LineSegment, Whisker } from "victory-core";
 
 const TEST_GROUP_ID = "test-group-id";
 const dataset = [
@@ -26,12 +28,35 @@ const renderWithTestGroup = (data = dataset) => {
 
 describe("components/victory-box-plot", () => {
   describe("default component rendering", () => {
-    it("accepts user props", () => {
+    it("attaches safe user props to the container component", () => {
       render(
-        <VictoryBoxPlot data-testid="victory-boxplot" aria-label="Chart" />
+        <VictoryBoxPlot
+          data-testid="victory-boxplot"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />
       );
 
+      const container = screen.getByTestId("victory-boxplot");
       expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.nodeName).toEqual("svg");
+    });
+
+    it("attaches safe user props to the group component if the component is rendered inside a VictoryChart", () => {
+      render(
+        <VictoryBoxPlot
+          data-testid="victory-boxplot"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />,
+        { wrapper: VictoryChart }
+      );
+
+      const container = screen.getByTestId("victory-boxplot");
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.nodeName).toEqual("g");
     });
 
     it("renders an svg with the correct width and height", () => {

--- a/test/jest/victory-box-plot/victory-box-plot.test.js
+++ b/test/jest/victory-box-plot/victory-box-plot.test.js
@@ -1,5 +1,4 @@
 /*eslint-disable react/prop-types */
-import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { VictoryBoxPlot } from "victory-box-plot";

--- a/test/jest/victory-candlestick/victory-candlestick.test.js
+++ b/test/jest/victory-candlestick/victory-candlestick.test.js
@@ -1,8 +1,10 @@
 /*eslint-disable max-nested-callbacks */
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { range } from "lodash";
-import { VictoryCandlestick, Candle } from "victory-candlestick";
+import React from "react";
+import { Candle, VictoryCandlestick } from "victory-candlestick";
+import { VictoryChart } from "victory-chart";
 
 const MyCandle = () => <div data-testid="my-candle" />;
 
@@ -13,16 +15,35 @@ const dataSet = [
 
 describe("components/victory-candlestick", () => {
   describe("default component rendering", () => {
-    it("accepts user props", () => {
+    it("attaches safe user props to the container component", () => {
       render(
         <VictoryCandlestick
           data-testid="victory-candlestick"
           aria-label="Chart"
+          unsafe-prop="test"
         />
       );
 
-      const svgNode = screen.getByTestId("victory-candlestick");
-      expect(svgNode.getAttribute("aria-label")).toEqual("Chart");
+      const container = screen.getByTestId("victory-candlestick");
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.nodeName).toEqual("svg");
+    });
+
+    it("attaches safe user props to the group component if the component is rendered inside a VictoryChart", () => {
+      render(
+        <VictoryCandlestick
+          data-testid="victory-candlestick"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />,
+        { wrapper: VictoryChart }
+      );
+
+      const container = screen.getByTestId("victory-candlestick");
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.nodeName).toEqual("g");
     });
 
     it("renders an svg with the correct width and height", () => {

--- a/test/jest/victory-candlestick/victory-candlestick.test.js
+++ b/test/jest/victory-candlestick/victory-candlestick.test.js
@@ -1,5 +1,4 @@
 /*eslint-disable max-nested-callbacks */
-import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { range } from "lodash";
 import React from "react";

--- a/test/jest/victory-line/victory-line.test.js
+++ b/test/jest/victory-line/victory-line.test.js
@@ -4,14 +4,24 @@ import { VictoryLine, Curve } from "victory-line";
 import { calculateD3Path } from "../../svg-test-helper";
 import { curveCatmullRom } from "victory-vendor/d3-shape";
 import { range, random } from "lodash";
+import "@testing-library/jest-dom";
 
 describe("components/victory-line", () => {
   describe("default component rendering", () => {
-    it("accepts user props", () => {
-      render(<VictoryLine data-testid="victory-line" aria-label="Chart" />);
+    it("attaches safe user props to the container component", () => {
+      render(
+        <VictoryLine
+          data-testid="victory-line"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />
+      );
 
-      expect(screen.queryByTestId("victory-line")).toBeDefined();
+      expect(screen.getByTestId("victory-line")).toBeDefined();
       expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(screen.getByTestId("victory-line")).not.toHaveAttribute(
+        "unsafe-prop"
+      );
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/jest/victory-line/victory-line.test.js
+++ b/test/jest/victory-line/victory-line.test.js
@@ -1,10 +1,11 @@
-import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { VictoryLine, Curve } from "victory-line";
-import { calculateD3Path } from "../../svg-test-helper";
-import { curveCatmullRom } from "victory-vendor/d3-shape";
-import { range, random } from "lodash";
 import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { random, range } from "lodash";
+import React from "react";
+import { VictoryChart } from "victory-chart";
+import { Curve, VictoryLine } from "victory-line";
+import { curveCatmullRom } from "victory-vendor/d3-shape";
+import { calculateD3Path } from "../../svg-test-helper";
 
 describe("components/victory-line", () => {
   describe("default component rendering", () => {
@@ -17,11 +18,26 @@ describe("components/victory-line", () => {
         />
       );
 
-      expect(screen.getByTestId("victory-line")).toBeDefined();
+      const container = screen.getByTestId("victory-line");
       expect(screen.getByLabelText("Chart")).toBeDefined();
-      expect(screen.getByTestId("victory-line")).not.toHaveAttribute(
-        "unsafe-prop"
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.nodeName).toEqual("svg");
+    });
+
+    it("attaches safe user props to the group component if the component is rendered inside a VictoryChart", () => {
+      render(
+        <VictoryLine
+          data-testid="victory-line"
+          aria-label="Chart"
+          unsafe-prop="test"
+        />,
+        { wrapper: VictoryChart }
       );
+
+      const container = screen.getByTestId("victory-line");
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+      expect(container).not.toHaveAttribute("unsafe-prop");
+      expect(container.tagName).toEqual("g");
     });
 
     it("renders an svg with the correct viewBox", () => {

--- a/test/jest/victory-line/victory-line.test.js
+++ b/test/jest/victory-line/victory-line.test.js
@@ -1,4 +1,3 @@
-import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { random, range } from "lodash";
 import React from "react";


### PR DESCRIPTION
This fixes a bug that Paul and I were running into where the user props like `data-testid` and `aria-label` were being passed in to both the container and the group component, so even when we were rendering a victory data component as a standalone component (without a container or VictoryChart wrapper), `screen.getByTestId` was returning multiple nodes in the tests rather than the parent wrapper component.

In order to fix this, I removed the user props logic from the `renderData` function in `add-events`, and passed the user props into the root component that was returned from a Victory component rather than the container. This ensures that the props will be passed into either the `svg` or the `g` component, depending on whether there is another container present. I also added some additional test coverage around this, which we should add to other component tests as we convert them. 