### PR TITLE
[FIX] Replace references to non-existent PropTypes.function with PropTypes.func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1244,7 +1244,7 @@ VictoryCore
   - `externalEventMutations` prop format:
   ````js
   externalEventMutations: PropTypes.arrayOf(PropTypes.shape({
-   callback: PropTypes.function,
+   callback: PropTypes.func,
    childName: PropTypes.oneOfType([
      PropTypes.string,
      PropTypes.array
@@ -1254,7 +1254,7 @@ VictoryCore
      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
      PropTypes.string
    ]),
-   mutation: PropTypes.function,
+   mutation: PropTypes.func,
    target: PropTypes.oneOfType([
      PropTypes.string,
      PropTypes.array

--- a/docs/src/content/common-props/common-props.md
+++ b/docs/src/content/common-props/common-props.md
@@ -402,14 +402,14 @@ Occasionally is it necessary to trigger events in Victory's event system from so
 ```jsx
 externalEventMutations: PropTypes.arrayOf(
   PropTypes.shape({
-    callback: PropTypes.function,
+    callback: PropTypes.func,
     childName: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     eventKey: PropTypes.oneOfType([
       PropTypes.array,
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string
     ]),
-    mutation: PropTypes.function,
+    mutation: PropTypes.func,
     target: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
   })
 );
@@ -763,9 +763,9 @@ _examples:_
   />
 </VictoryChart>
 ```
-In this example, a [discontinous scale plugin from d3fc](https://github.com/d3fc/d3fc/blob/master/packages/d3fc-discontinuous-scale/README.md) can be used to create a custom scale function to skip weekends along the x-axis. 
+In this example, a [discontinous scale plugin from d3fc](https://github.com/d3fc/d3fc/blob/master/packages/d3fc-discontinuous-scale/README.md) can be used to create a custom scale function to skip weekends along the x-axis.
 
-_note_: The data set has already been filtered to only include weekdays. 
+_note_: The data set has already been filtered to only include weekdays.
 
 ```playground_norender
 function App() {
@@ -787,9 +787,9 @@ function App() {
 
   return (
     <VictoryChart scale={{ x: discontinuousScale }}>
-      <VictoryArea 
-        data={data} 
-        style={{data: { fill: 'lightblue', stroke: 'teal' }}} 
+      <VictoryArea
+        data={data}
+        style={{data: { fill: 'lightblue', stroke: 'teal' }}}
       />
     </VictoryChart>
   );

--- a/docs/src/content/docs/victory-shared-events.md
+++ b/docs/src/content/docs/victory-shared-events.md
@@ -96,7 +96,7 @@ Occasionally is it necessary to trigger events in Victory's event system from so
 ```jsx
 externalEventMutations: PropTypes.arrayOf(
   PropTypes.shape({
-    callback: PropTypes.function,
+    callback: PropTypes.func,
     childName: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     eventKey: PropTypes.oneOfType([
       PropTypes.array,
@@ -106,7 +106,7 @@ externalEventMutations: PropTypes.arrayOf(
       ]),
       PropTypes.string
     ]),
-    mutation: PropTypes.function,
+    mutation: PropTypes.func,
     target: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
   })
 );

--- a/docs/src/content/guides/events.md
+++ b/docs/src/content/guides/events.md
@@ -167,14 +167,14 @@ Occasionally is it necessary to trigger events in Victory's event system from so
 ```jsx
 externalEventMutations: PropTypes.arrayOf(
   PropTypes.shape({
-    callback: PropTypes.function,
+    callback: PropTypes.func,
     childName: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     eventKey: PropTypes.oneOfType([
       PropTypes.array,
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string
     ]),
-    mutation: PropTypes.function,
+    mutation: PropTypes.func,
     target: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
   })
 );

--- a/packages/victory-core/src/victory-util/common-props.js
+++ b/packages/victory-core/src/victory-util/common-props.js
@@ -120,7 +120,7 @@ export const baseProps = {
   ),
   externalEventMutations: PropTypes.arrayOf(
     PropTypes.shape({
-      callback: PropTypes.function,
+      callback: PropTypes.func,
       childName: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
       eventKey: PropTypes.oneOfType([
         PropTypes.array,
@@ -130,7 +130,7 @@ export const baseProps = {
         ]),
         PropTypes.string
       ]),
-      mutation: PropTypes.function,
+      mutation: PropTypes.func,
       target: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
     })
   ),

--- a/packages/victory-legend/src/victory-legend.js
+++ b/packages/victory-legend/src/victory-legend.js
@@ -86,7 +86,7 @@ class VictoryLegend extends React.Component {
     ),
     externalEventMutations: PropTypes.arrayOf(
       PropTypes.shape({
-        callback: PropTypes.function,
+        callback: PropTypes.func,
         childName: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
         eventKey: PropTypes.oneOfType([
           PropTypes.array,
@@ -96,7 +96,7 @@ class VictoryLegend extends React.Component {
           ]),
           PropTypes.string
         ]),
-        mutation: PropTypes.function,
+        mutation: PropTypes.func,
         target: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
       })
     ),

--- a/packages/victory-pie/src/victory-pie.js
+++ b/packages/victory-pie/src/victory-pie.js
@@ -120,7 +120,7 @@ class VictoryPie extends React.Component {
     ),
     externalEventMutations: PropTypes.arrayOf(
       PropTypes.shape({
-        callback: PropTypes.function,
+        callback: PropTypes.func,
         childName: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
         eventKey: PropTypes.oneOfType([
           PropTypes.array,
@@ -130,7 +130,7 @@ class VictoryPie extends React.Component {
           ]),
           PropTypes.string
         ]),
-        mutation: PropTypes.function,
+        mutation: PropTypes.func,
         target: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
       })
     ),

--- a/packages/victory-shared-events/src/victory-shared-events.js
+++ b/packages/victory-shared-events/src/victory-shared-events.js
@@ -57,7 +57,7 @@ export default class VictorySharedEvents extends React.Component {
     ),
     externalEventMutations: PropTypes.arrayOf(
       PropTypes.shape({
-        callback: PropTypes.function,
+        callback: PropTypes.func,
         childName: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
         eventKey: PropTypes.oneOfType([
           PropTypes.array,
@@ -67,7 +67,7 @@ export default class VictorySharedEvents extends React.Component {
           ]),
           PropTypes.string
         ]),
-        mutation: PropTypes.function,
+        mutation: PropTypes.func,
         target: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
       })
     ),


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/victory/issues/2063

Several places in Victory reference non-existent `PropTypes.function` validator. This seem to be a common error, as exactly the same case is pointed out in `prop-types` codebase:
https://github.com/facebook/prop-types/blob/4de0644a10a554d0a556daa39f029369bc007ea5/checkPropTypes.js#L55-L57

This causes warning in console:
```
'Warning: Failed prop type: VictoryScatter: prop type externalEventMutations[0].callback is invalid; it must be a function, usually from the prop-types package, but received undefined.'
```

This PR replaces validators with `PropTypes.func` (https://github.com/facebook/prop-types#usage)
