### PR TITLE
victory-vendor: script cleanup and exports enhancements

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -99,7 +99,7 @@ module.exports = {
       es: "rimraf es",
       dist: "rimraf dist",
       default: npsUtils.concurrent.nps("clean.es", "clean.lib", "clean.dist"),
-      all: "lerna exec --parallel -- nps clean"
+      all: "lerna exec --parallel --ignore victory-vendor -- nps clean"
     },
     "compile-ts": "tsc --project tsconfig.json --noEmit",
     // Version testing helpers

--- a/packages/victory-vendor/package.json
+++ b/packages/victory-vendor/package.json
@@ -16,10 +16,13 @@
   "author": "Formidable",
   "license": "MIT AND ISC",
   "exports": {
+    "./package.json": "./package.json",
     "./d3-*": {
       "import": "./es/d3-*.js",
       "default": "./lib/d3-*.js"
-    }
+    },
+    "./es/d3-*": "./es/d3-*.js",
+    "./lib/d3-*": "./lib/d3-*.js"
   },
   "scripts": {
     "version": "yarn run build",

--- a/packages/victory-vendor/package.json
+++ b/packages/victory-vendor/package.json
@@ -20,9 +20,7 @@
     "./d3-*": {
       "import": "./es/d3-*.js",
       "default": "./lib/d3-*.js"
-    },
-    "./es/d3-*": "./es/d3-*.js",
-    "./lib/d3-*": "./lib/d3-*.js"
+    }
   },
   "scripts": {
     "version": "yarn run build",

--- a/packages/victory-vendor/scripts/build.js
+++ b/packages/victory-vendor/scripts/build.js
@@ -80,16 +80,14 @@ const main = async () => {
   const EsmBasePath = path.resolve(__dirname, `../es`);
   const CjsBasePath = path.resolve(__dirname, `../lib`);
   const VendorBasePath = path.resolve(__dirname, `../lib-vendor`);
+  const baseDirs = [EsmBasePath, CjsBasePath, VendorBasePath];
+  const cleanGlobs = [].concat(baseDirs, path.resolve(__dirname, "../d3-*"));
+
   log("Cleaning old vendor directories.");
+  await Promise.all(cleanGlobs.map((glob) => rimrafP(glob)));
+  log("Creating empty vendor directories.");
   await Promise.all(
-    [
-      EsmBasePath,
-      CjsBasePath,
-      VendorBasePath,
-      path.resolve(__dirname, "../d3-*")
-    ].map((libPath) =>
-      rimrafP(libPath).then(() => fs.mkdir(libPath, { recursive: true }))
-    )
+    baseDirs.map((libPath) => fs.mkdir(libPath, { recursive: true }))
   );
 
   // Transpile.


### PR DESCRIPTION
Adds the following to our `package.json:exports` for more flexible consumption:

- Add `package.json:exports` for `package.json`. This is generally useful to have for npm packages using exports to introspect the project itself.
- Add `package.json:exports` for `lib/*` consumers can point to CommonJS directly.
- Add `package.json:exports` for `es/*` consumers can point to ESM directly.

Additional things:

- Fix our `build.js` script to not errantly output an empty `victory-vendor/d3-*` directory.

Fixes #2250