### PR TITLE
Convert tests for victory error bar

### DIFF
--- a/packages/victory-errorbar/src/error-bar.js
+++ b/packages/victory-errorbar/src/error-bar.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 import React from "react";
 import PropTypes from "prop-types";
-import { Helpers, CommonProps, Line } from "victory-core";
+import { Helpers, CommonProps, Line, UserProps } from "victory-core";
 import { assign } from "lodash";
 
 const renderBorder = (props, error, type) => {
@@ -17,7 +17,8 @@ const renderBorder = (props, error, type) => {
     x1: vertical ? error[type] : props.x - props.borderWidth,
     x2: vertical ? error[type] : props.x + props.borderWidth,
     y1: vertical ? props.y - props.borderWidth : error[type],
-    y2: vertical ? props.y + props.borderWidth : error[type]
+    y2: vertical ? props.y + props.borderWidth : error[type],
+    "data-type": `border-${type}`
   });
 };
 
@@ -34,7 +35,8 @@ const renderCross = (props, error, type) => {
     x1: props.x,
     x2: vertical ? props.x : error[type],
     y1: props.y,
-    y2: vertical ? error[type] : props.y
+    y2: vertical ? error[type] : props.y,
+    "data-type": `cross-${type}`
   });
 };
 
@@ -80,7 +82,8 @@ const evaluateProps = (props) => {
 
 const ErrorBar = (props) => {
   props = evaluateProps(props);
-  const { ariaLabel, tabIndex } = props;
+  const userProps = UserProps.getSafeUserProps(props);
+  const { tabIndex, ariaLabel } = props;
   const error = calculateError(props);
   const children = [
     error.right ? renderBorder(props, error, "right") : null,
@@ -94,7 +97,7 @@ const ErrorBar = (props) => {
   ].filter(Boolean);
   return React.cloneElement(
     props.groupComponent,
-    { "aria-label": ariaLabel, tabIndex },
+    { tabIndex, "aria-label": ariaLabel, ...userProps },
     children
   );
 };

--- a/test/jest/rendering-utils.js
+++ b/test/jest/rendering-utils.js
@@ -1,5 +1,0 @@
-import { render } from "@testing-library/react";
-
-export const renderInSvg = (component) => {
-  return render(component, { wrapper: "svg" });
-};

--- a/test/jest/victory-core/victory-accessible-group/victory-accessible-group.test.js
+++ b/test/jest/victory-core/victory-accessible-group/victory-accessible-group.test.js
@@ -1,11 +1,12 @@
+import { render } from "@testing-library/react";
 import React from "react";
-import { renderInSvg } from "../../rendering-utils";
 import { VictoryAccessibleGroup } from "victory-core";
 
 describe("components/victory-accessible-group", () => {
   it("renders an g with an aria-label", () => {
-    const { container } = renderInSvg(
-      <VictoryAccessibleGroup aria-label="test-aria-label" />
+    const { container } = render(
+      <VictoryAccessibleGroup aria-label="test-aria-label" />,
+      { wrapper: "svg" }
     );
     expect(container.querySelector("g")).toMatchInlineSnapshot(`
       <g
@@ -16,8 +17,9 @@ describe("components/victory-accessible-group", () => {
   });
 
   it("renders an g with a tabIndex and className", () => {
-    const { container } = renderInSvg(
-      <VictoryAccessibleGroup tabIndex={5} className="accessibility" />
+    const { container } = render(
+      <VictoryAccessibleGroup tabIndex={5} className="accessibility" />,
+      { wrapper: "svg" }
     );
     expect(container.querySelector("g")).toMatchInlineSnapshot(`
       <g
@@ -28,12 +30,13 @@ describe("components/victory-accessible-group", () => {
   });
 
   it("renders an g with a desc node if given", () => {
-    const { container } = renderInSvg(
+    const { container } = render(
       <VictoryAccessibleGroup
         aria-label="desc node tests"
         desc="test description"
         aria-describedby="describes group"
-      />
+      />,
+      { wrapper: "svg" }
     );
     expect(container.querySelector("g")).toMatchInlineSnapshot(`
       <g
@@ -51,11 +54,12 @@ describe("components/victory-accessible-group", () => {
   });
 
   it("uses the desc getAttribute value for descId and aria-describedby if no aria-describedby getAttribute value", () => {
-    const { container } = renderInSvg(
+    const { container } = render(
       <VictoryAccessibleGroup
         aria-label="desc node tests"
         desc="applies to both aria-describeby and descId"
-      />
+      />,
+      { wrapper: "svg" }
     );
     expect(container.querySelector("g")).toMatchInlineSnapshot(`
       <g

--- a/test/jest/victory-core/victory-label/victory-label.test.js
+++ b/test/jest/victory-core/victory-label/victory-label.test.js
@@ -1,16 +1,16 @@
 import React from "react";
 import { VictoryLabel, Log } from "victory-core";
-import { screen, fireEvent } from "@testing-library/react";
-import { renderInSvg } from "../../rendering-utils";
+import { screen, fireEvent, render } from "@testing-library/react";
 
 describe("components/victory-label", () => {
   it("accepts user props", () => {
-    renderInSvg(
+    render(
       <VictoryLabel
         data-testid="victory-label"
         aria-label="test-aria-label"
         text="label"
-      />
+      />,
+      { wrapper: "svg" }
     );
 
     expect(screen.getByTestId("victory-label")).toBeDefined();
@@ -18,15 +18,18 @@ describe("components/victory-label", () => {
   });
 
   it("has expected content with render", () => {
-    const { container } = renderInSvg(<VictoryLabel text="such text, wow" />);
+    const { container } = render(<VictoryLabel text="such text, wow" />, {
+      wrapper: "svg"
+    });
     expect(container.querySelector("tspan").innerHTML).toMatchInlineSnapshot(
       `"such text, wow"`
     );
   });
 
   it("sets dx and dy for text element", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel dx={30} dy={30} text="such text, wow" />
+    const { container } = render(
+      <VictoryLabel dx={30} dy={30} text="such text, wow" />,
+      { wrapper: "svg" }
     );
     const output = container.querySelector("text");
     expect(output.getAttribute("dx")).toEqual("30");
@@ -35,8 +38,9 @@ describe("components/victory-label", () => {
   });
 
   it("sets x and y for text element", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel x="100%" y={30} text="such text, wow" />
+    const { container } = render(
+      <VictoryLabel x="100%" y={30} text="such text, wow" />,
+      { wrapper: "svg" }
     );
     const output = container.querySelector("text");
     expect(output.getAttribute("x")).toEqual("100%");
@@ -44,28 +48,31 @@ describe("components/victory-label", () => {
   });
 
   it("has a transform property that rotates the text to match the labelAngle getAttribute", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel angle={46} text="such text, wow" />
+    const { container } = render(
+      <VictoryLabel angle={46} text="such text, wow" />,
+      { wrapper: "svg" }
     );
     const output = container.querySelector("text");
     expect(output.getAttribute("transform")).toContain("rotate(46");
   });
 
   it("accepts the angle getAttribute as a function", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel angle={() => 46} text="such text, wow" />
+    const { container } = render(
+      <VictoryLabel angle={() => 46} text="such text, wow" />,
+      { wrapper: "svg" }
     );
     const output = container.querySelector("text");
     expect(output.getAttribute("transform")).toContain("rotate(46");
   });
 
   it("strips px from fontSize", () => {
-    const { container } = renderInSvg(
+    const { container } = render(
       <VictoryLabel
         style={{ fontSize: "10px" }}
         text="such text, wow"
         data-font-size={(props) => props.style.fontSize}
-      />
+      />,
+      { wrapper: "svg" }
     );
     const output = container.querySelector("text");
     expect(output.getAttribute("data-font-size")).toEqual("10");
@@ -75,36 +82,40 @@ describe("components/victory-label", () => {
     // This suppresses the console warning for invalid fontSize prop
     jest.spyOn(Log, "warn").mockImplementation(() => {});
 
-    const { container } = renderInSvg(
-      <VictoryLabel style={{ fontSize: "foo" }} text="such text, wow" />
+    const { container } = render(
+      <VictoryLabel style={{ fontSize: "foo" }} text="such text, wow" />,
+      { wrapper: "svg" }
     );
     const output = container.querySelector("tspan");
     expect(output.getAttribute("style")).toContain("font-size: 14px");
   });
 
   it("renders an array of text as seperate tspans", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel text={["one", "two", "three"]} />
+    const { container } = render(
+      <VictoryLabel text={["one", "two", "three"]} />,
+      { wrapper: "svg" }
     );
     const output = container.querySelectorAll("tspan");
     expect(output.length).toEqual(3);
   });
 
   it("renders splits newlines into tspans", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel text={"one\ntwo\nthree"} />
-    );
+    const { container } = render(<VictoryLabel text={"one\ntwo\nthree"} />, {
+      wrapper: "svg"
+    });
     const output = container.querySelectorAll("tspan");
     expect(output.length).toEqual(3);
   });
 
   it("renders title and desc if provided ", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel text="title and desc" title="title" desc="desc" />
+    const { container } = render(
+      <VictoryLabel text="title and desc" title="title" desc="desc" />,
+      { wrapper: "svg" }
     );
 
-    const { container: container2 } = renderInSvg(
-      <VictoryLabel text="title and desc" />
+    const { container: container2 } = render(
+      <VictoryLabel text="title and desc" />,
+      { wrapper: "svg" }
     );
 
     const title = container.querySelectorAll("title");
@@ -122,11 +133,12 @@ describe("components/victory-label", () => {
 
   it("renders tspan styles independently when `style` is an array", () => {
     const fill = ["red", "green", "blue"];
-    const { container } = renderInSvg(
+    const { container } = render(
       <VictoryLabel
         text={"one\ntwo\nthree"}
         style={[{ fill: fill[0] }, { fill: fill[1] }, { fill: fill[2] }]}
-      />
+      />,
+      { wrapper: "svg" }
     );
     const output = container.querySelectorAll("tspan");
     output.forEach((tspan, index) => {
@@ -137,8 +149,9 @@ describe("components/victory-label", () => {
   describe("event handling", () => {
     it("attaches an to the parent object", () => {
       const clickHandler = jest.fn();
-      const { container } = renderInSvg(
-        <VictoryLabel text="hi" events={{ onClick: clickHandler }} />
+      const { container } = render(
+        <VictoryLabel text="hi" events={{ onClick: clickHandler }} />,
+        { wrapper: "svg" }
       );
       fireEvent.click(container.querySelector("text"));
       expect(clickHandler).toHaveBeenCalled();
@@ -146,8 +159,9 @@ describe("components/victory-label", () => {
   });
 
   it("renders 'tspan' elements inline when `inline` getAttribute is passed", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel text={["Inline", "label", "testing"]} inline dx={5} />
+    const { container } = render(
+      <VictoryLabel text={["Inline", "label", "testing"]} inline dx={5} />,
+      { wrapper: "svg" }
     );
 
     const output = container.querySelectorAll("tspan");
@@ -164,11 +178,12 @@ describe("components/victory-label", () => {
   it("passes lineHeight as an array if provided", () => {
     const lineHeight = [1, 2, 3];
     const expectedDy = [0, 21, 35];
-    const { container } = renderInSvg(
+    const { container } = render(
       <VictoryLabel
         text={["lineHeight", "array", "testing"]}
         lineHeight={lineHeight}
-      />
+      />,
+      { wrapper: "svg" }
     );
 
     const output = container.querySelectorAll("tspan");
@@ -183,11 +198,12 @@ describe("components/victory-label", () => {
 
   it("defaults lineHeight to 1 if an empty array is provided for lineHeight", () => {
     const expectedDy = [0, 14, 14, 14];
-    const { container } = renderInSvg(
+    const { container } = render(
       <VictoryLabel
         text={["lineHeight", "empty", "array", "testing"]}
         lineHeight={[]}
-      />
+      />,
+      { wrapper: "svg" }
     );
 
     const output = container.querySelectorAll("tspan");
@@ -197,8 +213,9 @@ describe("components/victory-label", () => {
   });
 
   it("defaults style to `defaultStyles` if an empty array is provided for `style`", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel text={["style", "empty", "array", "testing"]} style={[]} />
+    const { container } = render(
+      <VictoryLabel text={["style", "empty", "array", "testing"]} style={[]} />,
+      { wrapper: "svg" }
     );
 
     expect(
@@ -209,8 +226,9 @@ describe("components/victory-label", () => {
   });
 
   it("passes id if provided as a string", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel text="Some VictoryLabel" id="my-custom-id" />
+    const { container } = render(
+      <VictoryLabel text="Some VictoryLabel" id="my-custom-id" />,
+      { wrapper: "svg" }
     );
 
     const output = container.querySelectorAll("text");
@@ -220,8 +238,9 @@ describe("components/victory-label", () => {
   });
 
   it("passes id if provided as a number", () => {
-    const { container } = renderInSvg(
-      <VictoryLabel text="Some VictoryLabel" id={12345} />
+    const { container } = render(
+      <VictoryLabel text="Some VictoryLabel" id={12345} />,
+      { wrapper: "svg" }
     );
 
     const output = container.querySelectorAll("text");
@@ -231,11 +250,12 @@ describe("components/victory-label", () => {
   });
 
   it("runs function if id provided as a function", () => {
-    const { container } = renderInSvg(
+    const { container } = render(
       <VictoryLabel
         text="Some VictoryLabel"
         id={() => `created-in-function-${Math.random()}`}
-      />
+      />,
+      { wrapper: "svg" }
     );
 
     const output = container.querySelectorAll("text");

--- a/test/jest/victory-core/victory-primitives/clip-path.test.js
+++ b/test/jest/victory-core/victory-primitives/clip-path.test.js
@@ -1,6 +1,6 @@
+import { render } from "@testing-library/react";
 import React from "react";
 import { ClipPath } from "victory-core";
-import { renderInSvg } from "../../rendering-utils";
 
 describe("victory-primitives/clip-path", () => {
   const baseProps = {
@@ -18,10 +18,11 @@ describe("victory-primitives/clip-path", () => {
   };
 
   it("should render a children", () => {
-    const { container } = renderInSvg(
+    const { container } = render(
       <ClipPath {...baseProps}>
         <rect data-testid="rect" />
-      </ClipPath>
+      </ClipPath>,
+      { wrapper: "svg" }
     );
 
     expect(container.querySelector("clipPath")).toMatchInlineSnapshot(`
@@ -36,7 +37,9 @@ describe("victory-primitives/clip-path", () => {
   });
 
   it("should render a clipPath with the passed id", () => {
-    const { container } = renderInSvg(<ClipPath {...baseProps} />);
+    const { container } = render(<ClipPath {...baseProps} />, {
+      wrapper: "svg"
+    });
 
     expect(container.querySelector("clipPath")).toMatchInlineSnapshot(`
       <clippath

--- a/test/jest/victory-core/victory-primitives/curve.test.js
+++ b/test/jest/victory-core/victory-primitives/curve.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Curve } from "victory-line";
-import { renderInSvg } from "../../rendering-utils";
 import * as d3Scale from "victory-vendor/d3-scale";
+import { render } from "@testing-library/react";
 
 describe("victory-primitives/curve", () => {
   const baseProps = {
@@ -20,7 +20,7 @@ describe("victory-primitives/curve", () => {
   };
 
   it("should render a single curve for consecutive data", () => {
-    const { container } = renderInSvg(<Curve {...baseProps} />);
+    const { container } = render(<Curve {...baseProps} />, { wrapper: "svg" });
     expect(container.querySelector("path")).toMatchInlineSnapshot(`
       <path
         d="M1,4L1.1666666666666667,4.166666666666667C1.3333333333333333,4.333333333333333,1.6666666666666667,4.666666666666667,2,5.166666666666667C2.3333333333333335,5.666666666666667,2.6666666666666665,6.333333333333333,3,7.166666666666667C3.3333333333333335,8,3.6666666666666665,9,4,10.333333333333334C4.333333333333333,11.666666666666666,4.666666666666667,13.333333333333334,4.833333333333333,14.166666666666666L5,15"

--- a/test/jest/victory-core/victory-primitives/line.test.js
+++ b/test/jest/victory-core/victory-primitives/line.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Line } from "victory-core";
-import { renderInSvg } from "../../rendering-utils";
+import { render } from "@testing-library/react";
 
 describe("victory-primitives/line", () => {
   const baseProps = {
@@ -11,7 +11,7 @@ describe("victory-primitives/line", () => {
   };
 
   it("should render a line element with the correct coordinates", () => {
-    const { container } = renderInSvg(<Line {...baseProps} />);
+    const { container } = render(<Line {...baseProps} />, { wrapper: "svg" });
     expect(container.querySelector("line")).toMatchInlineSnapshot(`
       <line
         vector-effect="non-scaling-stroke"

--- a/test/jest/victory-core/victory-primitives/point.test.js
+++ b/test/jest/victory-core/victory-primitives/point.test.js
@@ -1,7 +1,7 @@
+import { render } from "@testing-library/react";
 import { assign } from "lodash";
 import React from "react";
 import { Point, PointPathHelpers as pathHelpers } from "victory-core";
-import { renderInSvg } from "../../rendering-utils";
 
 describe("victory-primitives/point", () => {
   const baseProps = {
@@ -27,7 +27,7 @@ describe("victory-primitives/point", () => {
         // eslint-disable-next-line max-nested-callbacks
         .mockImplementation(() => `${symbol} symbol`);
       const props = assign({}, baseProps, { symbol });
-      const { container } = renderInSvg(<Point {...props} />);
+      const { container } = render(<Point {...props} />, { wrapper: "svg" });
       const directions = container.querySelector("path").getAttribute("d");
 
       expect(stub).toHaveBeenCalledTimes(1);

--- a/test/jest/victory-core/victory-primitives/slice.test.js
+++ b/test/jest/victory-core/victory-primitives/slice.test.js
@@ -1,6 +1,6 @@
+import { render } from "@testing-library/react";
 import React from "react";
 import { Slice } from "victory-pie";
-import { renderInSvg } from "../../rendering-utils";
 
 describe("victory-primitives/slice", () => {
   describe("rendering", () => {
@@ -14,8 +14,9 @@ describe("victory-primitives/slice", () => {
         return EXPECTED_D_ATTR;
       };
 
-      const { container } = renderInSvg(
-        <Slice pathFunction={pathFunction} slice={slice} />
+      const { container } = render(
+        <Slice pathFunction={pathFunction} slice={slice} />,
+        { wrapper: "svg" }
       );
 
       expect(container.querySelector("path")).toMatchInlineSnapshot(`

--- a/test/jest/victory-errorbars/error-bar.test.js
+++ b/test/jest/victory-errorbars/error-bar.test.js
@@ -1,0 +1,108 @@
+import { render } from "@testing-library/react";
+import { forEach, omit } from "lodash";
+import React from "react";
+import { ErrorBar } from "victory-errorbar";
+import * as d3Scale from "victory-vendor/d3-scale";
+
+describe("victory-primitives/error-bar", () => {
+  const baseProps = {
+    x: 4,
+    y: 5,
+    errorX: [1, 3],
+    errorY: [0.2, 2],
+    scale: {
+      x: d3Scale.scaleLinear(),
+      y: d3Scale.scaleLinear()
+    },
+    borderWidth: 20
+  };
+
+  const compareLineCoordinates = (line, coordinates) => {
+    forEach(coordinates, (coordinateValue, coordinateName) => {
+      expect(parseFloat(line.getAttribute(coordinateName), 10)).toEqual(
+        parseFloat(coordinateValue, 10)
+      );
+    });
+  };
+
+  it("should render eight lines", () => {
+    const { container } = render(<ErrorBar {...baseProps} />, {
+      wrapper: "svg"
+    });
+    const lines = container.querySelectorAll("line");
+
+    const expectedCoordinates = [
+      // Right Border (positiveErrorX, positiveErrorX, y - borderWidth, y + borderWidth)
+      { x1: 1, x2: 1, y1: -15, y2: 25 },
+      // Left Border(negativeErrorX, negativeErrorX, y - borderWidth, y + borderWidth)
+      { x1: 3, x2: 3, y1: -15, y2: 25 },
+      // Bottom Border(x - borderWidth, x + borderWidth, negativeErrorY, negativeErrorY)
+      { x1: -16, x2: 24, y1: 0.2, y2: 0.2 },
+      // Top Border(x - borderWidth, x + borderWidth, positiveErrorY, positiveErrorY)
+      { x1: -16, x2: 24, y1: 2, y2: 2 },
+      // Right Cross(x, positiveErrorX, y, y)
+      { x1: 4, x2: 1, y1: 5, y2: 5 },
+      // Left Cross(x, negativeErrorX, y, y)
+      { x1: 4, x2: 3, y1: 5, y2: 5 },
+      // Bottom Cross(x, x, y, negativeErrorY)
+      { x1: 4, x2: 4, y1: 5, y2: 0.2 },
+      // Bottom Cross(x, x, y, positiveErrorY)
+      { x1: 4, x2: 4, y1: 5, y2: 2 }
+    ];
+
+    expect(lines.length).toEqual(8);
+    lines.forEach((line, i) => {
+      compareLineCoordinates(line, expectedCoordinates[i]);
+    });
+  });
+
+  it("should render four lines when only x error type is supplied", () => {
+    const xErrorProps = omit(baseProps, ["errorY"]);
+
+    const { container } = render(<ErrorBar {...xErrorProps} />, {
+      wrapper: "svg"
+    });
+    const lines = container.querySelectorAll("line");
+
+    const expectedCoordinates = [
+      // Right Border (positiveErrorX, positiveErrorX, y - borderWidth, y + borderWidth)
+      { x1: 1, x2: 1, y1: -15, y2: 25 },
+      // Left Border(negativeErrorX, negativeErrorX, y - borderWidth, y + borderWidth)
+      { x1: 3, x2: 3, y1: -15, y2: 25 },
+      // Right Cross(x, positiveErrorX, y, y)
+      { x1: 4, x2: 1, y1: 5, y2: 5 },
+      // Left Cross(x, negativeErrorX, y, y)
+      { x1: 4, x2: 3, y1: 5, y2: 5 }
+    ];
+
+    expect(lines.length).toEqual(4);
+    lines.forEach((line, i) => {
+      compareLineCoordinates(line, expectedCoordinates[i]);
+    });
+  });
+
+  it("should render four lines when only y error type is supplied", () => {
+    const yErrorProps = omit(baseProps, ["errorX"]);
+
+    const { container } = render(<ErrorBar {...yErrorProps} />, {
+      wrapper: "svg"
+    });
+    const lines = container.querySelectorAll("line");
+
+    const expectedCoordinates = [
+      // Bottom Border(x - borderWidth, x + borderWidth, negativeErrorY, negativeErrorY)
+      { x1: -16, x2: 24, y1: 0.2, y2: 0.2 },
+      // Top Border(x - borderWidth, x + borderWidth, positiveErrorY, positiveErrorY)
+      { x1: -16, x2: 24, y1: 2, y2: 2 },
+      // Bottom Cross(x, x, y, negativeErrorY)
+      { x1: 4, x2: 4, y1: 5, y2: 0.2 },
+      // Bottom Cross(x, x, y, positiveErrorY)
+      { x1: 4, x2: 4, y1: 5, y2: 2 }
+    ];
+
+    expect(lines.length).toEqual(4);
+    lines.forEach((line, i) => {
+      compareLineCoordinates(line, expectedCoordinates[i]);
+    });
+  });
+});

--- a/test/jest/victory-errorbars/victory-errorbars.test.js
+++ b/test/jest/victory-errorbars/victory-errorbars.test.js
@@ -1,0 +1,1087 @@
+/*eslint-disable max-nested-callbacks */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { fromJS } from "immutable";
+import { range } from "lodash";
+import React from "react";
+import { ErrorBar, VictoryErrorBar } from "victory-errorbar";
+import * as d3Scale from "victory-vendor/d3-scale";
+
+const defaultProps = {
+  dataComponent: (
+    <ErrorBar
+      data-testid="error-bar"
+      data-x={(props) => props.datum._x}
+      data-y={(props) => props.datum._y}
+    />
+  )
+};
+
+const getCoordinatesForLineWithType = (node, type) => {
+  const line = node.querySelector(`line[data-type="${type}"]`);
+  return ["x1", "x2", "y1", "y2"].map((attr) =>
+    parseFloat(line.getAttribute(attr), 10)
+  );
+};
+
+describe("components/victory-errorbar", () => {
+  describe("default component rendering", () => {
+    it("accepts user props", () => {
+      render(
+        <VictoryErrorBar data-testid="victory-errorbar" aria-label="Chart" />
+      );
+
+      expect(screen.getByTestId("victory-errorbar")).toBeDefined();
+      expect(screen.getByLabelText("Chart")).toBeDefined();
+    });
+
+    it("renders an svg with the correct width and height", () => {
+      const { container } = render(<VictoryErrorBar />);
+      const svg = container.querySelector("svg");
+      expect(svg.style.width).toEqual("100%");
+      expect(svg.style.height).toEqual("100%");
+    });
+
+    it("renders an svg with the correct viewBox", () => {
+      const { container } = render(<VictoryErrorBar />);
+      const svg = container.querySelector("svg");
+      const viewBoxValue = `0 0 ${450} ${300}`;
+      expect(svg.getAttribute("viewBox")).toEqual(viewBoxValue);
+    });
+
+    it("renders 4 errors", () => {
+      render(<VictoryErrorBar {...defaultProps} />);
+      const errorbars = screen.getAllByTestId("error-bar");
+      expect(errorbars.length).toEqual(4);
+    });
+  });
+
+  it("does not render data with null x or y values", () => {
+    const data = [
+      { x: 15, y: 35, errorX: 1, errorY: 3 },
+      { x: null, y: 42, errorX: 3, errorY: 2 },
+      { x: 25, y: null, errorX: 5, errorY: 5 }
+    ];
+    render(<VictoryErrorBar data={data} {...defaultProps} />);
+    expect(screen.getAllByTestId("error-bar")).toHaveLength(1);
+  });
+
+  const immutableRenderDataTest = {
+    createData: (x) => fromJS(x),
+    testLabel: "with immutable data"
+  };
+  const renderDataTest = {
+    createData: (x) => x,
+    testLabel: "with js data"
+  };
+
+  [renderDataTest, immutableRenderDataTest].forEach(
+    ({ createData, testLabel }) => {
+      describe(`symmetric error, rendering data ${testLabel}`, () => {
+        it("renders injected errors for {x, y}", () => {
+          const data = createData(
+            range(10).map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 }))
+          );
+          render(<VictoryErrorBar data={data} {...defaultProps} />);
+
+          const errors = screen.getAllByTestId("error-bar");
+          expect(errors).toHaveLength(10);
+        });
+
+        it("renders errors for {x, y}", () => {
+          const data = createData(
+            range(10).map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 }))
+          );
+          render(<VictoryErrorBar data={data} {...defaultProps} />);
+          const errors = screen.getAllByTestId("error-bar");
+          expect(errors.length).toEqual(10);
+        });
+
+        it("sorts data by sortKey getAttribute", () => {
+          const data = createData(
+            range(5)
+              .map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 }))
+              .reverse()
+          );
+          render(<VictoryErrorBar data={data} sortKey="x" {...defaultProps} />);
+          const xValues = screen
+            .getAllByTestId("error-bar")
+            .map((node) => parseInt(node.getAttribute("data-x")));
+          expect(xValues).toEqual([0, 1, 2, 3, 4]);
+        });
+
+        it("reversed sorted data with the sortOrder getAttribute", () => {
+          const data = createData(
+            range(5)
+              .map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 }))
+              .reverse()
+          );
+          render(
+            <VictoryErrorBar
+              data={data}
+              sortKey="x"
+              sortOrder="descending"
+              {...defaultProps}
+            />
+          );
+          const yValues = screen
+            .getAllByTestId("error-bar")
+            .map((node) => parseInt(node.getAttribute("data-y")));
+          expect(yValues).toEqual([4, 3, 2, 1, 0]);
+        });
+
+        it("renders errors with error bars, check total svg lines", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const { container } = render(
+            <VictoryErrorBar
+              data={createData([
+                { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+                { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+                { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+              ])}
+              {...svgDimensions}
+            />
+          );
+          expect(container.querySelectorAll("line")).toHaveLength(24);
+        });
+
+        it("should check right border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              name="error"
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].x + data[i].errorX);
+            const xScaleMax = xScale.range()[1];
+            const positiveErrorX = errorX >= xScaleMax ? xScaleMax : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-right"
+            );
+            expect(x1).toEqual(positiveErrorX);
+            expect(x2).toEqual(positiveErrorX);
+            expect(y1).toEqual(yScale(data[i].y) - borderWidth);
+            expect(y2).toEqual(yScale(data[i].y) + borderWidth);
+          });
+        });
+
+        it("should check left border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].x - data[i].errorX);
+            const xScaleMin = xScale.range()[0];
+            const negativeErrorX = errorX <= xScaleMin ? xScaleMin : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-left"
+            );
+            expect(x1).toEqual(negativeErrorX);
+            expect(x2).toEqual(negativeErrorX);
+            expect(y1).toEqual(yScale(data[i].y) - borderWidth);
+            expect(y2).toEqual(yScale(data[i].y) + borderWidth);
+          });
+        });
+
+        it("should check bottom border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y + data[i].errorY);
+            const yScaleMin = yScale.range()[1];
+            const negativeErrorY = errorY <= yScaleMin ? yScaleMin : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-bottom"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x) - borderWidth);
+            expect(x2).toEqual(xScale(data[i].x) + borderWidth);
+            expect(y1).toEqual(negativeErrorY);
+            expect(y2).toEqual(negativeErrorY);
+          });
+        });
+
+        it("should check top border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y - data[i].errorY);
+            const yScaleMax = yScale.range()[0];
+            const positiveErrorY = errorY >= yScaleMax ? yScaleMax : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-top"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x) - borderWidth);
+            expect(x2).toEqual(xScale(data[i].x) + borderWidth);
+            expect(y1).toEqual(positiveErrorY);
+            expect(y2).toEqual(positiveErrorY);
+          });
+        });
+
+        it("should check top cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y - data[i].errorY);
+            const yScaleMax = yScale.range()[0];
+            const positiveErrorY = errorY >= yScaleMax ? yScaleMax : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-top"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(xScale(data[i].x));
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(positiveErrorY);
+          });
+        });
+
+        it("should check bottom cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y + data[i].errorY);
+            const yScaleMin = yScale.range()[1];
+            const negativeErrorY = errorY <= yScaleMin ? yScaleMin : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-bottom"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(xScale(data[i].x));
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(negativeErrorY);
+          });
+        });
+
+        it("should check left cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].x - data[i].errorX);
+            const xScaleMin = xScale.range()[0];
+            const negativeErrorX = errorX <= xScaleMin ? xScaleMin : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-left"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(negativeErrorX);
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(yScale(data[i].y));
+          });
+        });
+
+        it("should check right cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: 0.1, errorY: 0.2 },
+            { x: 2, y: 3, errorX: 0.1, errorY: 0.2 },
+            { x: 5, y: 5, errorX: 0.1, errorY: 0.2 }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.1, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.2, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].errorX + data[i].x);
+            const xScaleMax = xScale.range()[1];
+            const positiveErrorX = errorX >= xScaleMax ? xScaleMax : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-right"
+            );
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(positiveErrorX);
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(yScale(data[i].y));
+          });
+        });
+      });
+
+      describe(`asymmetric error, rendering data ${testLabel}`, () => {
+        it("renders injected errors for {x, y}", () => {
+          const data = createData(
+            range(10).map((i) => ({
+              x: i,
+              y: i,
+              errorX: [0.1, 0.2],
+              errorY: [0.2, 0.5]
+            }))
+          );
+          render(<VictoryErrorBar data={data} {...defaultProps} />);
+
+          const errors = screen.getAllByTestId("error-bar");
+          expect(errors).toHaveLength(10);
+        });
+
+        it("renders errors for {x, y}", () => {
+          const data = createData(
+            range(10).map((i) => ({
+              x: i,
+              y: i,
+              errorX: [0.1, 0.2],
+              errorY: [0.2, 1]
+            }))
+          );
+          render(<VictoryErrorBar data={data} {...defaultProps} />);
+          const errors = screen.getAllByTestId("error-bar");
+          expect(errors).toHaveLength(10);
+        });
+
+        it("renders errors with error bars, check total svg lines", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const { container } = render(
+            <VictoryErrorBar
+              data={createData([
+                { x: 0, y: 0, errorX: [0.1, 0.5], errorY: [0.2, 0.3] },
+                { x: 2, y: 3, errorX: [0.1, 0.5], errorY: [0.2, 0.4] },
+                { x: 5, y: 5, errorX: [0.1, 0.5], errorY: [0.2, 0.1] }
+              ])}
+              {...svgDimensions}
+            />
+          );
+          expect(container.querySelectorAll("line")).toHaveLength(24);
+        });
+
+        it("should check right border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].x + data[i].errorX[0]);
+            const xScaleMax = xScale.range()[1];
+            const positiveErrorX = errorX >= xScaleMax ? xScaleMax : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-right"
+            );
+
+            expect(x1).toEqual(positiveErrorX);
+            expect(x2).toEqual(positiveErrorX);
+            expect(y1).toEqual(yScale(data[i].y) - borderWidth);
+            expect(y2).toEqual(yScale(data[i].y) + borderWidth);
+          });
+        });
+
+        it("should check left border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].x - data[i].errorX[1]);
+            const xScaleMin = xScale.range()[0];
+            const negativeErrorX = errorX <= xScaleMin ? xScaleMin : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-left"
+            );
+
+            expect(x1).toEqual(negativeErrorX);
+            expect(x2).toEqual(negativeErrorX);
+            expect(y1).toEqual(yScale(data[i].y) - borderWidth);
+            expect(y2).toEqual(yScale(data[i].y) + borderWidth);
+          });
+        });
+
+        it("should check bottom border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y + data[i].errorY[0]);
+            const yScaleMin = yScale.range()[1];
+            const negativeErrorY = errorY <= yScaleMin ? yScaleMin : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-bottom"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x) - borderWidth);
+            expect(x2).toEqual(xScale(data[i].x) + borderWidth);
+            expect(y1).toEqual(negativeErrorY);
+            expect(y2).toEqual(negativeErrorY);
+          });
+        });
+
+        it("should check top border of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const borderWidth = 10;
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              borderWidth={borderWidth}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y - data[i].errorY[1]);
+            const yScaleMax = yScale.range()[0];
+            const positiveErrorY = errorY >= yScaleMax ? yScaleMax : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "border-top"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x) - borderWidth);
+            expect(x2).toEqual(xScale(data[i].x) + borderWidth);
+            expect(y1).toEqual(positiveErrorY);
+            expect(y2).toEqual(positiveErrorY);
+          });
+        });
+
+        it("should check top cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y - data[i].errorY[1]);
+            const yScaleMax = yScale.range()[0];
+            const positiveErrorY = errorY >= yScaleMax ? yScaleMax : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-top"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(xScale(data[i].x));
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(positiveErrorY);
+          });
+        });
+
+        it("should check bottom cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorY = yScale(data[i].y + data[i].errorY[0]);
+            const yScaleMin = yScale.range()[1];
+            const negativeErrorY = errorY <= yScaleMin ? yScaleMin : errorY;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-bottom"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(xScale(data[i].x));
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(negativeErrorY);
+          });
+        });
+
+        it("should check left cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].x - data[i].errorX[1]);
+            const xScaleMin = xScale.range()[0];
+            const negativeErrorX = errorX <= xScaleMin ? xScaleMin : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-left"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(negativeErrorX);
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(yScale(data[i].y));
+          });
+        });
+
+        it("should check right cross line of error bars positions", () => {
+          const svgDimensions = { width: 350, height: 200, padding: 75 };
+          const data = [
+            { x: 0, y: 0, errorX: [0.1, 0.3], errorY: [0.2, 0.5] },
+            { x: 2, y: 3, errorX: [0.1, 0.2], errorY: [0.2, 0.3] },
+            { x: 5, y: 5, errorX: [0.1, 0.6], errorY: [0.2, 0.1] }
+          ];
+          render(
+            <VictoryErrorBar
+              data={createData(data)}
+              {...svgDimensions}
+              {...defaultProps}
+            />
+          );
+
+          const xScale = d3Scale
+            .scaleLinear()
+            .domain([-0.3, 5.1])
+            .range([
+              svgDimensions.padding,
+              svgDimensions.width - svgDimensions.padding
+            ]);
+
+          const yScale = d3Scale
+            .scaleLinear()
+            .domain([-0.5, 5.2])
+            .range([
+              svgDimensions.height - svgDimensions.padding,
+              svgDimensions.padding
+            ]);
+
+          const bars = screen.getAllByTestId("error-bar");
+          bars.forEach((node, i) => {
+            const errorX = xScale(data[i].x + data[i].errorX[0]);
+            const xScaleMax = xScale.range()[1];
+            const positiveErrorX = errorX >= xScaleMax ? xScaleMax : errorX;
+
+            const [x1, x2, y1, y2] = getCoordinatesForLineWithType(
+              node,
+              "cross-right"
+            );
+
+            expect(x1).toEqual(xScale(data[i].x));
+            expect(x2).toEqual(positiveErrorX);
+            expect(y1).toEqual(yScale(data[i].y));
+            expect(y2).toEqual(yScale(data[i].y));
+          });
+        });
+      });
+    }
+  );
+
+  describe("event handling", () => {
+    it("attaches an event to the parent svg", () => {
+      const clickHandler = jest.fn();
+      const { container } = render(
+        <VictoryErrorBar
+          events={[
+            {
+              target: "parent",
+              eventHandlers: { onClick: clickHandler }
+            }
+          ]}
+        />
+      );
+      const svg = container.querySelector("svg");
+      fireEvent.click(svg);
+      expect(clickHandler).toBeCalled();
+    });
+
+    it("attaches an event to data, click border lines", () => {
+      const clickHandler = jest.fn();
+      render(
+        <VictoryErrorBar
+          events={[
+            {
+              target: "data",
+              eventHandlers: { onClick: clickHandler }
+            }
+          ]}
+          {...defaultProps}
+        />
+      );
+      const bars = screen.getAllByTestId("error-bar");
+      bars.forEach((node) => {
+        // click the border line
+        fireEvent.click(node.querySelectorAll("line")[3]);
+
+        expect(clickHandler).toBeCalled();
+      });
+    });
+
+    it("attaches an event to data, click cross lines", () => {
+      const clickHandler = jest.fn();
+      render(
+        <VictoryErrorBar
+          events={[
+            {
+              target: "data",
+              eventHandlers: { onClick: clickHandler }
+            }
+          ]}
+          {...defaultProps}
+        />
+      );
+      const bars = screen.getAllByTestId("error-bar");
+      bars.forEach((node) => {
+        // click the cross line
+        fireEvent.click(node.querySelectorAll("line")[7]);
+        expect(clickHandler).toBeCalled();
+      });
+    });
+
+    describe("accessibility", () => {
+      it("adds an aria label-label and tabIndex to Error Bar primitive", () => {
+        const data = [
+          { x: 35, y: 50, error: 0.2 },
+          { x: 10, y: 43, error: 0.15 },
+          { x: 45, y: 65, error: 0.5 }
+        ];
+        const { container } = render(
+          <VictoryErrorBar
+            data={data}
+            dataComponent={
+              <ErrorBar
+                data-testid="error-bar"
+                ariaLabel={({ datum }) => `error bar chart, x ${datum.x}`}
+                tabIndex={({ index }) => index + 2}
+              />
+            }
+          />
+        );
+
+        expect(container.querySelectorAll("g")).toHaveLength(4);
+        expect(screen.getAllByTestId("error-bar")).toHaveLength(3);
+
+        screen.getAllByTestId("error-bar").forEach((g, i) => {
+          expect(g.getAttribute("aria-label")).toEqual(
+            `error bar chart, x ${data[i].x}`
+          );
+          expect(parseInt(g.getAttribute("tabindex"), 10)).toEqual(i + 2);
+        });
+      });
+    });
+  });
+});

--- a/test/jest/victory-errorbars/victory-errorbars.test.js
+++ b/test/jest/victory-errorbars/victory-errorbars.test.js
@@ -330,6 +330,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorY = yScale(data[i].y - data[i].errorY);
             const yScaleMax = yScale.range()[0];
@@ -379,6 +380,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorY = yScale(data[i].y - data[i].errorY);
             const yScaleMax = yScale.range()[0];
@@ -428,6 +430,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorY = yScale(data[i].y + data[i].errorY);
             const yScaleMin = yScale.range()[1];
@@ -477,6 +480,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorX = xScale(data[i].x - data[i].errorX);
             const xScaleMin = xScale.range()[0];
@@ -526,6 +530,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorX = xScale(data[i].errorX + data[i].x);
             const xScaleMax = xScale.range()[1];
@@ -622,6 +627,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorX = xScale(data[i].x + data[i].errorX[0]);
             const xScaleMax = xScale.range()[1];
@@ -673,6 +679,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorX = xScale(data[i].x - data[i].errorX[1]);
             const xScaleMin = xScale.range()[0];
@@ -724,6 +731,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorY = yScale(data[i].y + data[i].errorY[0]);
             const yScaleMin = yScale.range()[1];
@@ -775,6 +783,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorY = yScale(data[i].y - data[i].errorY[1]);
             const yScaleMax = yScale.range()[0];
@@ -824,6 +833,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorY = yScale(data[i].y - data[i].errorY[1]);
             const yScaleMax = yScale.range()[0];
@@ -873,6 +883,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorY = yScale(data[i].y + data[i].errorY[0]);
             const yScaleMin = yScale.range()[1];
@@ -922,6 +933,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorX = xScale(data[i].x - data[i].errorX[1]);
             const xScaleMin = xScale.range()[0];
@@ -971,6 +983,7 @@ describe("components/victory-errorbar", () => {
             ]);
 
           const bars = screen.getAllByTestId("error-bar");
+          expect(bars).toHaveLength(3);
           bars.forEach((node, i) => {
             const errorX = xScale(data[i].x + data[i].errorX[0]);
             const xScaleMax = xScale.range()[1];

--- a/test/jest/victory-tooltip/flyout.test.js
+++ b/test/jest/victory-tooltip/flyout.test.js
@@ -1,7 +1,7 @@
 /*eslint-disable max-nested-callbacks,no-unused-expressions,max-len */
 import React from "react";
 import { Flyout } from "victory-tooltip";
-import { renderInSvg } from "../rendering-utils";
+import { render } from "@testing-library/react";
 
 describe("victory-primitives/flyout", () => {
   const baseProps = {
@@ -17,7 +17,9 @@ describe("victory-primitives/flyout", () => {
   };
   describe("rendering", () => {
     it("renders a flyout path", () => {
-      const { container } = renderInSvg(<Flyout {...baseProps} />);
+      const { container } = render(<Flyout {...baseProps} />, {
+        wrapper: "svg"
+      });
       const path = container.querySelector("path");
 
       // Make sure the path is rendered:


### PR DESCRIPTION
This is part of #2195 

This also includes removing the `renderInSvg` function and using `{ wrapper: 'svg' }` instead. I meant to push up this change as a separate PR, but it ended up here instead.