### PR TITLE
Disable func-style eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     "plugin:react-hooks/recommended"
   ],
   rules: {
+    "func-style": "off",
     "react/sort-comp": "off",
     "import/no-unresolved": [2, { ignore: ["victory*"] }],
     "max-statements": 0,

--- a/docs/src/partials/markdown/index.js
+++ b/docs/src/partials/markdown/index.js
@@ -1,6 +1,4 @@
 /* eslint-disable react/no-multi-comp */
-/* eslint-disable func-style */
-/* eslint-disable react/no-multi-comp */
 /* eslint-disable no-magic-numbers */
 import React from "react";
 import ReactDOM from "react-dom";

--- a/docs/static-config-helpers/get-md-files.js
+++ b/docs/static-config-helpers/get-md-files.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 const fs = require("fs");
 const klaw = require("klaw");
 const path = require("path");

--- a/docs/static-config-helpers/md-data-transforms.js
+++ b/docs/static-config-helpers/md-data-transforms.js
@@ -1,5 +1,4 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [0, 1, 2, 3] }]*/
-/*eslint-disable func-style*/
 const _ = require("lodash");
 const getMdFiles = require("./get-md-files");
 

--- a/packages/victory-chart/src/helper-methods.js
+++ b/packages/victory-chart/src/helper-methods.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 
 import React from "react";

--- a/packages/victory-core/src/victory-util/axis.js
+++ b/packages/victory-core/src/victory-util/axis.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 import React from "react";
 import {
   assign,

--- a/packages/victory-core/src/victory-util/collection.js
+++ b/packages/victory-core/src/victory-util/collection.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 
 function isNonEmptyArray(collection) {

--- a/packages/victory-core/src/victory-util/data.js
+++ b/packages/victory-core/src/victory-util/data.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import React from "react";
 import {

--- a/packages/victory-core/src/victory-util/default-transitions.js
+++ b/packages/victory-core/src/victory-util/default-transitions.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 export function continuousTransitions() {
   return {
     onLoad: {

--- a/packages/victory-core/src/victory-util/domain.js
+++ b/packages/victory-core/src/victory-util/domain.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import React from "react";
 import {

--- a/packages/victory-core/src/victory-util/events.js
+++ b/packages/victory-core/src/victory-util/events.js
@@ -1,4 +1,4 @@
-/* eslint-disable func-style,no-use-before-define */
+/* eslint-disable no-use-before-define */
 import {
   assign,
   isEmpty,

--- a/packages/victory-core/src/victory-util/helpers.js
+++ b/packages/victory-core/src/victory-util/helpers.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import React from "react";
 import { defaults, isFunction, property, pick, assign, keys } from "lodash";

--- a/packages/victory-core/src/victory-util/immutable.js
+++ b/packages/victory-core/src/victory-util/immutable.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 export const IMMUTABLE_ITERABLE = "@@__IMMUTABLE_ITERABLE__@@";
 export const IMMUTABLE_RECORD = "@@__IMMUTABLE_RECORD__@@";
 export const IMMUTABLE_LIST = "@@__IMMUTABLE_LIST__@@";

--- a/packages/victory-core/src/victory-util/label-helpers.js
+++ b/packages/victory-core/src/victory-util/label-helpers.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import * as Helpers from "./helpers";
 import { defaults } from "lodash";

--- a/packages/victory-core/src/victory-util/log.js
+++ b/packages/victory-core/src/victory-util/log.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-console */
 
 // TODO: Use "warning" npm module like React is switching to.
-// eslint-disable-next-line func-style
 export function warn(message) {
   if (process.env.NODE_ENV !== "production") {
     if (console && console.warn) {

--- a/packages/victory-core/src/victory-util/prop-types.js
+++ b/packages/victory-core/src/victory-util/prop-types.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /*eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import { isFunction, find, isRegExp } from "lodash";
 import * as Log from "./log";

--- a/packages/victory-core/src/victory-util/scale.js
+++ b/packages/victory-core/src/victory-util/scale.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import { includes, isFunction, isPlainObject } from "lodash";
 import * as Helpers from "./helpers";

--- a/packages/victory-core/src/victory-util/selection.js
+++ b/packages/victory-core/src/victory-util/selection.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 
 import * as Collection from "./collection";

--- a/packages/victory-core/src/victory-util/style.js
+++ b/packages/victory-core/src/victory-util/style.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /**
  * Given an object with CSS/SVG transform definitions, return the string value
  * for use with the `transform` CSS property or SVG attribute. Note that we

--- a/packages/victory-core/src/victory-util/transitions.js
+++ b/packages/victory-core/src/victory-util/transitions.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 import { assign, defaults, identity, keys } from "lodash";
 import React from "react";
 

--- a/packages/victory-core/src/victory-util/wrapper.js
+++ b/packages/victory-core/src/victory-util/wrapper.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 import {
   assign,
   defaults,

--- a/packages/victory-group/src/helper-methods.js
+++ b/packages/victory-group/src/helper-methods.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import { assign } from "lodash";
 import React from "react";

--- a/packages/victory-stack/src/helper-methods.js
+++ b/packages/victory-stack/src/helper-methods.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
 import { assign, keys, orderBy } from "lodash";
 import React from "react";


### PR DESCRIPTION
We are disabling this eslint rule in many places, and personally I don't think enforcing `const` over `function` syntax has a lot of value. Any objections to disabling it and moving on with our lives? 