### PR TITLE
Enable `eslint-comments`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,9 +12,11 @@ module.exports = {
   extends: [
     "formidable/configurations/es6-react",
     "prettier",
-    "plugin:react-hooks/recommended"
+    "plugin:react-hooks/recommended",
+    "plugin:eslint-comments/recommended"
   ],
   rules: {
+    "eslint-comments/disable-enable-pair": "off",
     "func-style": "off",
     "react/sort-comp": "off",
     "import/no-unresolved": [2, { ignore: ["victory*"] }],

--- a/demo/js/components/victory-label-demo.js
+++ b/demo/js/components/victory-label-demo.js
@@ -262,7 +262,6 @@ export default class App extends React.Component {
                 "as an array."
               ]}
               style={[{ fontSize: 20, fill: "green" }, { fontSize: 30 }]}
-              // eslint-disable-next-line no-magic-numbers
               lineHeight={[2, 2, 3, 1]}
               verticalAnchor="middle"
             />

--- a/demo/ts/components/victory-label-demo.tsx
+++ b/demo/ts/components/victory-label-demo.tsx
@@ -216,7 +216,6 @@ export default class App extends React.Component<any, {}> {
               "as an array."
             ]}
             style={[{ fontSize: 50, fill: "green" }, { fontSize: 60 }]}
-            // eslint-disable-next-line no-magic-numbers
             lineHeight={[2, 2, 3, 1]}
             verticalAnchor="start"
           />

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint": "^7.32.0",
     "eslint-config-formidable": "^2.0.1",
     "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^25.2.2",

--- a/packages/victory-create-container/src/create-container.js
+++ b/packages/victory-create-container/src/create-container.js
@@ -128,7 +128,6 @@ const checkBehaviorName = (behavior, behaviors) => {
 const makeCreateContainerFunction =
   (mixinMap, Container) =>
   (behaviorA, behaviorB, ...invalid) => {
-    // eslint-disable-line
     const behaviors = keys(mixinMap);
 
     checkBehaviorName(behaviorA, behaviors);

--- a/test/client/spec/victory-core/victory-primitives/slice.spec.js
+++ b/test/client/spec/victory-core/victory-primitives/slice.spec.js
@@ -21,7 +21,7 @@ describe("victory-primitives/slice", () => {
       );
 
       expect(wrapper.html()).to.eql(
-        `<path d="${EXPECTED_D_ATTR}" role="presentation" shape-rendering="auto"></path>` // eslint-disable-line max-len
+        `<path d="${EXPECTED_D_ATTR}" role="presentation" shape-rendering="auto"></path>`
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9564,6 +9564,14 @@ eslint-module-utils@^2.7.3:
     debug "^3.2.7"
     find-up "^2.1.0"
 
+eslint-plugin-eslint-comments@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-filenames@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
@@ -11683,7 +11691,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.2.0:
+ignore@^5.0.5, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==


### PR DESCRIPTION
This plugin enforces some rules for `// eslint-disable` style comments.  
Mainly, this requires us to clean-up any comments that are no longer necessary!