### PR TITLE
TypeScript: fix a few build issues

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -13,6 +13,7 @@ module.exports = {
     "@babel/transform-spread",
     "@babel/transform-template-literals",
     "@babel/proposal-object-rest-spread",
+    "@babel/proposal-optional-chaining",
     "@babel/plugin-proposal-export-namespace-from"
   ],
   ignore: ["**/*.d.ts"],

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/plugin-proposal-class-properties": "7.16.7",
     "@babel/plugin-proposal-export-namespace-from": "^7.16.7",
     "@babel/plugin-proposal-object-rest-spread": "7.17.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.17.12",
     "@babel/plugin-transform-arrow-functions": "7.16.7",
     "@babel/plugin-transform-block-scoping": "7.16.7",
     "@babel/plugin-transform-classes": "7.16.7",

--- a/packages/victory-core/src/victory-animation/victory-animation.tsx
+++ b/packages/victory-core/src/victory-animation/victory-animation.tsx
@@ -76,6 +76,10 @@ export interface AnimationInfo {
   terminating?: boolean;
 }
 
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
 export class VictoryAnimation extends React.Component<
   VictoryAnimationProps,
   VictoryAnimationState
@@ -140,7 +144,6 @@ export class VictoryAnimation extends React.Component<
   };
 
   static contextType = TimerContext;
-  context!: React.ContextType<typeof TimerContext>;
   private interpolator: null | ((value: number) => AnimationStyle);
   private queue: AnimationStyle[];
   private ease: any;

--- a/packages/victory-core/src/victory-portal/victory-portal.tsx
+++ b/packages/victory-core/src/victory-portal/victory-portal.tsx
@@ -10,6 +10,10 @@ export interface VictoryPortalProps {
   groupComponent?: React.ReactElement;
 }
 
+export interface VictoryPortal {
+  context: React.ContextType<typeof PortalContext>;
+}
+
 export class VictoryPortal extends React.Component<VictoryPortalProps> {
   static displayName = "VictoryPortal";
 
@@ -25,7 +29,6 @@ export class VictoryPortal extends React.Component<VictoryPortalProps> {
   };
 
   static contextType = PortalContext;
-  context!: React.ContextType<typeof PortalContext>;
   private checkedContext!: boolean;
   private renderInPlace!: boolean;
   private element!: React.ReactElement;
@@ -33,7 +36,7 @@ export class VictoryPortal extends React.Component<VictoryPortalProps> {
 
   componentDidMount() {
     if (!this.checkedContext) {
-      if (typeof this.context?.portalUpdate !== "function") {
+      if (typeof this.context.portalUpdate !== "function") {
         const msg =
           "`renderInPortal` is not supported outside of `VictoryContainer`. " +
           "Component will be rendered in place";

--- a/packages/victory-core/src/victory-transition/victory-transition.tsx
+++ b/packages/victory-core/src/victory-transition/victory-transition.tsx
@@ -39,6 +39,10 @@ interface VictoryTransitionState {
   childrenTransitions?: unknown;
 }
 
+export interface VictoryTransition {
+  context: React.ContextType<typeof TimerContext>;
+}
+
 export class VictoryTransition extends React.Component<
   VictoryTransitionProps,
   VictoryTransitionState
@@ -52,7 +56,6 @@ export class VictoryTransition extends React.Component<
   };
 
   static contextType = TimerContext;
-  context!: React.ContextType<typeof TimerContext>;
   private continuous: boolean;
   private timer: Timer;
   private transitionProps: any;

--- a/packages/victory-core/src/victory-util/add-events.js
+++ b/packages/victory-core/src/victory-util/add-events.js
@@ -13,7 +13,7 @@ import {
 } from "lodash";
 import * as Events from "./events";
 import isEqual from "react-fast-compare";
-import VictoryTransition from "../victory-transition/victory-transition";
+import { VictoryTransition } from "../victory-transition/victory-transition";
 
 // DISCLAIMER:
 // This file is not currently tested, and it is first on the list of files


### PR DESCRIPTION
# Fixes:
- Use named import for `addEvents > Transition` dependency
- Properly type the `context` property for class components, so that it doesn't get initialized
- Adds "optional chaining" transpilation to Babel

# Testing
These issues were all found in React Native, although it's not specific to that.
To test:
```
cd demo/rn
yarn start
```
Open in iOS simulator, and verify that all demos are working as expected.

![image](https://user-images.githubusercontent.com/430608/171964137-692cca70-d4a1-4705-b4cd-47c0be7e1027.png)
