### PR TITLE
Build enhancements for move tests PR

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -75,9 +75,15 @@ module.exports = {
       packages: "lerna exec --ignore victory-vendor -- nps typecheck.src"
     },
     types: {
-      base: "tsc -p ./tsconfig.build.json --emitDeclarationOnly --rootDir src",
-      lib: "nps types.base -- -- --outDir lib",
-      es: "nps types.base -- -- --outDir es"
+      create:
+        "tsc -p ./tsconfig.build.json --emitDeclarationOnly --rootDir src",
+      "create-lib": 'nps "types.create --outDir lib"',
+      "create-es": 'nps "types.create --outDir es"',
+      copy: "cpx 'src/**/*.d.ts'",
+      "copy-lib": 'nps "types.copy lib"',
+      "copy-es": 'nps "types.copy es"',
+      lib: npsUtils.concurrent.nps("types.create-lib", "types.copy-lib"),
+      es: npsUtils.concurrent.nps("types.create-es", "types.copy-es")
     },
     check: {
       ci: npsUtils.series.nps(
@@ -95,8 +101,30 @@ module.exports = {
       default: npsUtils.series.nps("lint", "test")
     },
     watch: {
-      es: "lerna exec --parallel --ignore victory-native --ignore victory-vendor -- cross-env BABEL_ENV=es babel src --out-dir es --config-file ../../.babelrc.build.js --copy-files --extensions .tsx,.ts,.jsx,.js --watch",
-      lib: "lerna exec --parallel --ignore victory-native --ignore victory-vendor -- cross-env BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.build.js --copy-files --extensions .tsx,.ts,.jsx,.js --watch",
+      debug:
+        'lerna exec --scope victory-area -- nps \\"types.copy es --watch\\"',
+      "types-create-lib":
+        'lerna exec --parallel --ignore victory-native --ignore victory-vendor -- nps \\"types.create --outDir lib --watch\\"',
+      "types-create-es":
+        'lerna exec --parallel --ignore victory-native --ignore victory-vendor -- nps \\"types.create --outDir es --watch\\"',
+      "types-copy-lib":
+        'lerna exec --parallel --ignore victory-native --ignore victory-vendor -- nps \\"types.copy lib --watch\\"',
+      "types-copy-es":
+        'lerna exec --parallel --ignore victory-native --ignore victory-vendor -- nps \\"types.copy es --watch\\"',
+      "babel-es":
+        "lerna exec --parallel --ignore victory-native --ignore victory-vendor -- cross-env BABEL_ENV=es babel src --out-dir es --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js --watch",
+      "babel-lib":
+        "lerna exec --parallel --ignore victory-native --ignore victory-vendor -- cross-env BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js --watch",
+      lib: npsUtils.concurrent.nps(
+        "watch.babel-lib",
+        "watch.types-create-lib",
+        "watch.types-copy-lib"
+      ),
+      es: npsUtils.concurrent.nps(
+        "watch.babel-es",
+        "watch.types-create-es",
+        "watch.types-copy-es"
+      ),
       core: npsUtils.concurrent.nps("watch.es", "watch.lib"),
       // `victory-vendor` is built 1x up front and not watched.
       default: npsUtils.series.nps("build-package-libs-vendor", "watch.core")
@@ -113,9 +141,9 @@ module.exports = {
       "lerna version --no-git-tag-version --no-push --loglevel silly",
     // TODO: organize build scripts once build perf is sorted out
     "babel-es":
-      "cross-env BABEL_ENV=es babel src --out-dir es --config-file ../../.babelrc.build.js --copy-files --extensions .tsx,.ts,.jsx,.js",
+      "cross-env BABEL_ENV=es babel src --out-dir es --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js",
     "babel-lib":
-      "cross-env BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.build.js --copy-files --extensions .tsx,.ts,.jsx,.js",
+      "cross-env BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js",
     "build-es": npsUtils.series.nps("clean.es", "babel-es", "types.es"),
     "build-lib": npsUtils.series.nps("clean.lib", "babel-lib", "types.lib"),
     "build-libs": npsUtils.series.nps("build-lib", "build-es"),

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-preset-react-native": "^4.0.1",
     "chromatic": "^5.0.0",
+    "cpx2": "^4.2.0",
     "cross-env": "^7.0.3",
     "emotion-theming": "^10.0.27",
     "eslint": "^7.32.0",

--- a/packages/victory-area/tsconfig.build.json
+++ b/packages/victory-area/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-area/tsconfig.json
+++ b/packages/victory-area/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-axis/tsconfig.build.json
+++ b/packages/victory-axis/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-axis/tsconfig.json
+++ b/packages/victory-axis/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-bar/tsconfig.build.json
+++ b/packages/victory-bar/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-bar/tsconfig.json
+++ b/packages/victory-bar/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-box-plot/tsconfig.build.json
+++ b/packages/victory-box-plot/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-box-plot/tsconfig.json
+++ b/packages/victory-box-plot/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-brush-container/tsconfig.build.json
+++ b/packages/victory-brush-container/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-brush-container/tsconfig.json
+++ b/packages/victory-brush-container/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-brush-line/tsconfig.build.json
+++ b/packages/victory-brush-line/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-brush-line/tsconfig.json
+++ b/packages/victory-brush-line/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-candlestick/tsconfig.build.json
+++ b/packages/victory-candlestick/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-candlestick/tsconfig.json
+++ b/packages/victory-candlestick/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-canvas/tsconfig.build.json
+++ b/packages/victory-canvas/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-canvas/tsconfig.json
+++ b/packages/victory-canvas/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-chart/tsconfig.build.json
+++ b/packages/victory-chart/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-chart/tsconfig.json
+++ b/packages/victory-chart/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-core/tsconfig.build.json
+++ b/packages/victory-core/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-core/tsconfig.json
+++ b/packages/victory-core/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-create-container/tsconfig.build.json
+++ b/packages/victory-create-container/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-create-container/tsconfig.json
+++ b/packages/victory-create-container/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-cursor-container/tsconfig.build.json
+++ b/packages/victory-cursor-container/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-cursor-container/tsconfig.json
+++ b/packages/victory-cursor-container/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-errorbar/tsconfig.build.json
+++ b/packages/victory-errorbar/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-errorbar/tsconfig.json
+++ b/packages/victory-errorbar/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-group/tsconfig.build.json
+++ b/packages/victory-group/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-group/tsconfig.json
+++ b/packages/victory-group/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-histogram/tsconfig.build.json
+++ b/packages/victory-histogram/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-histogram/tsconfig.json
+++ b/packages/victory-histogram/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-legend/tsconfig.build.json
+++ b/packages/victory-legend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-legend/tsconfig.json
+++ b/packages/victory-legend/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-line/tsconfig.build.json
+++ b/packages/victory-line/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-line/tsconfig.json
+++ b/packages/victory-line/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-native/tsconfig.build.json
+++ b/packages/victory-native/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-native/tsconfig.json
+++ b/packages/victory-native/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-pie/tsconfig.build.json
+++ b/packages/victory-pie/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-pie/tsconfig.json
+++ b/packages/victory-pie/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-polar-axis/tsconfig.build.json
+++ b/packages/victory-polar-axis/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-polar-axis/tsconfig.json
+++ b/packages/victory-polar-axis/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-scatter/tsconfig.build.json
+++ b/packages/victory-scatter/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-scatter/tsconfig.json
+++ b/packages/victory-scatter/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-selection-container/tsconfig.build.json
+++ b/packages/victory-selection-container/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-selection-container/tsconfig.json
+++ b/packages/victory-selection-container/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-shared-events/tsconfig.build.json
+++ b/packages/victory-shared-events/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-shared-events/tsconfig.json
+++ b/packages/victory-shared-events/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-stack/tsconfig.build.json
+++ b/packages/victory-stack/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-stack/tsconfig.json
+++ b/packages/victory-stack/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-tooltip/tsconfig.build.json
+++ b/packages/victory-tooltip/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-tooltip/tsconfig.json
+++ b/packages/victory-tooltip/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-vendor/tsconfig.json
+++ b/packages/victory-vendor/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-voronoi-container/tsconfig.build.json
+++ b/packages/victory-voronoi-container/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-voronoi-container/tsconfig.json
+++ b/packages/victory-voronoi-container/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-voronoi/tsconfig.build.json
+++ b/packages/victory-voronoi/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-voronoi/tsconfig.json
+++ b/packages/victory-voronoi/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory-zoom-container/tsconfig.build.json
+++ b/packages/victory-zoom-container/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory-zoom-container/tsconfig.json
+++ b/packages/victory-zoom-container/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/packages/victory/tsconfig.build.json
+++ b/packages/victory/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["**/*.test.*", "es", "lib"]
 }

--- a/packages/victory/tsconfig.json
+++ b/packages/victory/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["es", "lib"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7407,6 +7407,25 @@ cp-file@^7.0.0:
     nested-error-stacks "^2.0.0"
     p-event "^4.1.0"
 
+cpx2@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/cpx2/-/cpx2-4.2.0.tgz#d65c52fc1e804f6567f57868cd1e88aaab367316"
+  integrity sha512-Ik81d7J849x0dGpR/8TBLXc1MwkFuv29kkstgLau8IOQwptrEENsXefC4o+tnkTjiFnXbsaz08/6YSZdJER+nQ==
+  dependencies:
+    debounce "^1.2.0"
+    debug "^4.1.1"
+    duplexer "^0.1.1"
+    fs-extra "^10.0.0"
+    glob-gitignore "^1.0.14"
+    glob2base "0.0.12"
+    ignore "^5.1.8"
+    minimatch "^3.0.4"
+    p-map "^4.0.0"
+    resolve "^1.12.0"
+    safe-buffer "^5.2.0"
+    shell-quote "^1.7.1"
+    subarg "^1.0.0"
+
 cpy-cli@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cpy-cli/-/cpy-cli-1.0.1.tgz#67fb5a4a2dec28ca8abff375de4b9e71f6a7561c"
@@ -7787,6 +7806,11 @@ dayjs@^1.8.15:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.2.tgz#fa0f5223ef0d6724b3d8327134890cfe3d72fbe5"
   integrity sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw==
+
+debounce@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -9211,6 +9235,11 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-index@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
+  integrity sha512-uJ5vWrfBKMcE6y2Z8834dwEZj9mNGxYa3t3I53OwFeuZ8D9oc2E5zcsrkuhX6h4iYrjhiv0T3szQmxlAV9uxDg==
+
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
@@ -9688,6 +9717,18 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
+glob-gitignore@^1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/glob-gitignore/-/glob-gitignore-1.0.14.tgz#8b708cb029e73bd388d22f7f935213aa93a1e7c2"
+  integrity sha512-YuAEPqL58bOQDqDF2kMv009rIjSAtPs+WPzyGbwRWK+wD0UWQVRoP34Pz6yJ6ivco65C9tZnaIt0I3JCuQ8NZQ==
+  dependencies:
+    glob "^7.1.3"
+    ignore "^5.0.5"
+    lodash.difference "^4.5.0"
+    lodash.union "^4.6.0"
+    make-array "^1.0.5"
+    util.inherits "^1.0.3"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -9719,6 +9760,13 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob2base@0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
+  integrity sha512-ZyqlgowMbfj2NPjxaZZ/EtsXlOch28FRXgMd64vqZWk1bT9+wvSRLYD1om9M7QfQru51zJPAT17qXm4/zd+9QA==
+  dependencies:
+    find-index "^0.1.1"
 
 glob@7.1.2:
   version "7.1.2"
@@ -10344,7 +10392,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.5, ignore@^5.2.0:
+ignore@^5.0.5, ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -12061,6 +12109,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -12125,6 +12178,11 @@ lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
+lodash.union@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
+  integrity sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==
 
 lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -12245,6 +12303,11 @@ macos-release@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
   integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
+
+make-array@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/make-array/-/make-array-1.0.5.tgz#326a7635c756a9f61ce0b2a6fdd5cc3460419bcb"
+  integrity sha512-sgK2SAzxT19rWU+qxKUcn6PAh/swiIiz2F8C2cZjLc1z4iwYIfdoihqFIDQ8BDzAGtWPYJ6Sr13K1j/DXynDLA==
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -12883,7 +12946,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -15865,7 +15928,7 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shell-quote@^1.6.1:
+shell-quote@^1.6.1, shell-quote@^1.7.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
@@ -16598,6 +16661,13 @@ styled-components@^5.3.5:
     hoist-non-react-statics "^3.0.0"
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
+
+subarg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
+  integrity sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==
+  dependencies:
+    minimist "^1.1.0"
 
 sudo-prompt@^9.0.0:
   version "9.2.1"
@@ -17536,6 +17606,11 @@ util-promisify@^2.1.0:
   integrity sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
+
+util.inherits@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/util.inherits/-/util.inherits-1.0.3.tgz#a9c626a0d06d34829d47ba56cab1278d745f9ce6"
+  integrity sha512-gMirHcfcq5D87nXDwbZqf5vl65S0mpMZBsHXJsXOO3Hc3G+JoQLwgaJa1h+PL7h3WhocnuLqoe8CuvMlztkyCA==
 
 util.promisify@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Separates out `.d.ts` copying from `babel` to a dedicated copy task (using `cpx2`)
- Adds watch support for babel, tsc, and copying

If we like this I think goal is merging commit back to #2301 