### PR TITLE
TypeScript: Mark `data` as `readonly`

### DIFF
--- a/packages/victory-core/src/victory-util/common-props.tsx
+++ b/packages/victory-core/src/victory-util/common-props.tsx
@@ -21,7 +21,7 @@ import { NumberOrCallback, StringOrCallback } from "../types/callbacks";
 
 export interface VictoryDatableProps {
   categories?: CategoryPropType;
-  data?: any[];
+  data?: readonly any[];
   dataComponent?: React.ReactElement;
   domain?: DomainPropType;
   domainPadding?: DomainPaddingPropType;


### PR DESCRIPTION
# What
Marks `data` as `readonly`.
We don't mutate the data, so this doesn't break anything, and doesn't require any other changes.

Fixes #2309