### PR TITLE
Remove dependency on use-context-selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "ts-jest": "^28.0.3",
     "ts-loader": "^9.3.0",
     "typescript": "^4.7.3",
-    "use-context-selector": "^1.4.1",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.9.0",

--- a/packages/victory-core/src/victory-state/victory-provider.tsx
+++ b/packages/victory-core/src/victory-state/victory-provider.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { createContext, useContextSelector } from "use-context-selector";
+import { createContext, useContext } from "react";
 import { D3ScaleFn, DomainTuple, ForAxes } from "../types/prop-types";
 import { FormattedDatum, getData } from "./helpers/get-data";
 import { getDomain } from "./helpers/get-domain";
@@ -81,17 +81,12 @@ export function VictoryProvider({
   );
 }
 
-type ContextValue = ContextType | null;
-
 export function useVictoryContext<T>(selector: (value: ContextType) => T): T {
-  return useContextSelector<ContextValue, T>(VictoryContext, (context) => {
-    if (!context) {
-      throw new Error(
-        "useVictoryContext must be used within a VictoryProvider",
-      );
-    }
-    return selector(context);
-  });
+  const context = useContext(VictoryContext);
+  if (!context) {
+    throw new Error("useVictoryContext must be used within a VictoryProvider");
+  }
+  return selector(context);
 }
 
 export function useScale() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17593,11 +17593,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-context-selector@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.4.1.tgz#eb96279965846b72915d7f899b8e6ef1d768b0ae"
-  integrity sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA==
-
 use-subscription@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.7.0.tgz#c7505263315deac9fd2581cdf4ab1e3ff2585d0f"


### PR DESCRIPTION
This removes our dependency on use-context-selector in favor of vanilla context. Once we have a more fully-featured re-write, we can do some performance comparisons and measure whether something like `use-context-selector` provides noticeable performance gains, and reconsider introducing something similar. 

Fixes #2322 