### PR TITLE
Local VSC settings to ignore built files in search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/es": true,
+    "**/lib": true
+  }
+}


### PR DESCRIPTION
`.vscode` is git-ignored, and I'm generally a fan of keeping IDE settings out of repos. However, I'm proposing we add a small amount of workspace/local settings to make search more useful. With the es/cjs build folders, searching for a file ends up showing triple the results. This PR excludes the es/lib results from that search.

![image](https://user-images.githubusercontent.com/12721310/175980143-d3d63edc-894b-4690-972c-f4d627f48caa.png)
