### PR TITLE
Fix for #2329 (use-animation-state crashing charts)

### DIFF
--- a/packages/victory-chart/src/victory-chart.test.js
+++ b/packages/victory-chart/src/victory-chart.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { VictoryChart } from "victory-chart";
 import { VictoryAxis } from "victory-axis";
+import { VictoryLine } from "victory";
 import { render, screen, fireEvent } from "@testing-library/react";
 
 describe("components/victory-chart", () => {
@@ -96,6 +97,18 @@ describe("components/victory-chart", () => {
       fireEvent.click(svg);
 
       expect(clickHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe("animation", () => {
+    it("handles basic animation parameters without crashing", () => {
+      const { container } = render(
+        <VictoryChart animate={{ duration: 2000, easing: "bounce" }}>
+          <VictoryLine />
+        </VictoryChart>,
+      );
+
+      expect(container.querySelector("svg")).toBeTruthy();
     });
   });
 });

--- a/packages/victory-core/src/victory-util/hooks/use-animation-state.js
+++ b/packages/victory-core/src/victory-util/hooks/use-animation-state.js
@@ -60,7 +60,7 @@ export const useAnimationState = (initialState = INITIAL_STATE) => {
   // This is a copy of Wrapper.setAnimationState
   const setAnimationState = React.useCallback(
     (props, nextProps) => {
-      if (!props?.animate) {
+      if (!props || !props.animate) {
         return;
       }
       if (props.animate.parentState) {

--- a/packages/victory-core/src/victory-util/hooks/use-animation-state.js
+++ b/packages/victory-core/src/victory-util/hooks/use-animation-state.js
@@ -24,7 +24,7 @@ export const useAnimationState = (initialState = INITIAL_STATE) => {
   // This is a copy of Wrapper.getAnimationProps
   const getAnimationProps = React.useCallback(
     (props, child, index) => {
-      if (!props.animate) {
+      if (!props?.animate) {
         return child.props.animate;
       }
       const getFilteredState = () => {
@@ -60,7 +60,7 @@ export const useAnimationState = (initialState = INITIAL_STATE) => {
   // This is a copy of Wrapper.setAnimationState
   const setAnimationState = React.useCallback(
     (props, nextProps) => {
-      if (!props.animate) {
+      if (!props?.animate) {
         return;
       }
       if (props.animate.parentState) {


### PR DESCRIPTION
I'm not exactly sure why this is _just now_ becoming an issue, but somehow a `props` value is `undefined` (I think on just first render) and it was throwing because of a property-lookup on `undefined`. Seems like _maybe_ because `usePreviousProps` is always going to return `undefined` on first render until the `useEffect` therein kicks in.

Nevertheless, this fix seems to resolve the issue reported in #2329.