### PR TITLE
[WIP] fix(#2108) get label text size from dom rendering

### DIFF
--- a/packages/victory-core/src/victory-util/textsize.test.ts
+++ b/packages/victory-core/src/victory-util/textsize.test.ts
@@ -17,171 +17,246 @@ describe("victory-util/textsize", () => {
 
   describe("approximateWidth", () => {
     it("return zero width when no style", () => {
-      expect(TextSize.approximateTextSize(testString, undefined, true).width).toEqual(0);
+      expect(
+        TextSize.approximateTextSize(testString, undefined, true).width,
+      ).toEqual(0);
     });
     it("return correct width with signed angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          angle: -45,
-          fontSize: 14,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            angle: -45,
+            fontSize: 14,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("31.71");
     });
     it("return correct width with pixel fontsize", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: "14px",
-        }, true).width.toFixed(2),  
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: "14px",
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("28.74");
     });
     it("return appropriate width with defined fontSize", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("24.64");
     });
     it("consider font", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 16,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 16,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("32.85");
     });
     it("consider letterSpacing", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          letterSpacing: "1px",
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            letterSpacing: "1px",
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("26.64");
     });
     it("consider angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          angle: 30,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            angle: 30,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("28.24");
     });
     it("not consider lineHeight without angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          lineHeight: 2,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            lineHeight: 2,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("24.64");
     });
     it("consider lineHeight with angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          lineHeight: 2,
-          angle: 30,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            lineHeight: 2,
+            angle: 30,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("35.14");
     });
     it("return width of widest string in text", () => {
       expect(
-        TextSize.approximateTextSize("ABC\nDEFGH\nIJK", {
-          fontSize: 12,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          "ABC\nDEFGH\nIJK",
+          {
+            fontSize: 12,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("41.94");
     });
 
     it("returns width of widest string in array if array has an empty string", () => {
       expect(
-        TextSize.approximateTextSize(["06-14-20", ""], {
-          fontSize: 12,
-        }, true).width.toFixed(2),
+        TextSize.approximateTextSize(
+          ["06-14-20", ""],
+          {
+            fontSize: 12,
+          },
+          true,
+        ).width.toFixed(2),
       ).toEqual("47.93");
     });
   });
 
   describe("approximateHeight", () => {
     it("return zero width when no style", () => {
-      expect(TextSize.approximateTextSize(testString, undefined, true).height).toEqual(0);
+      expect(
+        TextSize.approximateTextSize(testString, undefined, true).height,
+      ).toEqual(0);
     });
     it("return correct height with signed angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          angle: -45,
-          fontSize: 14,
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            angle: -45,
+            fontSize: 14,
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("33.29");
     });
     it("return correct height with pixel fontsize", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: "14px",
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: "14px",
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("16.90");
     });
     it("return appropriate height with expected precision", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("14.49");
     });
     it("consider font", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 16,
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 16,
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("19.32");
     });
     it("consider angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          angle: 30,
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            angle: 30,
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("25.48");
     });
     it("not consider letterSpacing without angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          letterSpacing: "1px",
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            letterSpacing: "1px",
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("14.49");
     });
     it("consider letterSpacing with angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          angle: 30,
-          letterSpacing: "1px",
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            angle: 30,
+            letterSpacing: "1px",
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("26.53");
     });
     it("consider lineHeight", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
-          fontSize: 12,
-          lineHeight: 2,
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          testString,
+          {
+            fontSize: 12,
+            lineHeight: 2,
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("28.98");
     });
     it("consider multiLines text", () => {
       expect(
-        TextSize.approximateTextSize(`ABC\n${"DBCDEFG"}\n123`, {
-          fontSize: 12,
-        }, true).height.toFixed(2),
+        TextSize.approximateTextSize(
+          `ABC\n${"DBCDEFG"}\n123`,
+          {
+            fontSize: 12,
+          },
+          true,
+        ).height.toFixed(2),
       ).toEqual("43.47");
     });
   });
 
   describe("dom measurement", () => {
-    const createSpy = jest.spyOn(document, "createElement");
-
-    it('should append and remove a div to the body', () => {
-      TextSize.approximateTextSize(testString, {
-        fontSize: 12,
-        lineHeight: 2,
-      });
-
+    it("should append and remove a div to the body", () => {
+      const createSpy = jest.spyOn(document, "createElement");
+      TextSize.approximateTextSize(testString, undefined);
       expect(createSpy).toHaveBeenCalled();
     });
   });

--- a/packages/victory-core/src/victory-util/textsize.test.ts
+++ b/packages/victory-core/src/victory-util/textsize.test.ts
@@ -16,49 +16,36 @@ describe("victory-util/textsize", () => {
   });
 
   describe("approximateWidth", () => {
-    const { window } = global;
-
-    // Jsdom does not have a window width/height so it is very difficult to test
-    // the _measureWithDOM function.
-    // Default to testing the approximation function
-    beforeAll(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      delete global.window;
-    });
-    afterAll(() => {
-      global.window = window;
-    });
     it("return zero width when no style", () => {
-      expect(TextSize.approximateTextSize(testString).width).toEqual(0);
+      expect(TextSize.approximateTextSize(testString, undefined, true).width).toEqual(0);
     });
     it("return correct width with signed angle", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           angle: -45,
           fontSize: 14,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("31.71");
     });
     it("return correct width with pixel fontsize", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           fontSize: "14px",
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),  
       ).toEqual("28.74");
     });
     it("return appropriate width with defined fontSize", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("24.64");
     });
     it("consider font", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           fontSize: 16,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("32.85");
     });
     it("consider letterSpacing", () => {
@@ -66,7 +53,7 @@ describe("victory-util/textsize", () => {
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
           letterSpacing: "1px",
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("26.64");
     });
     it("consider angle", () => {
@@ -74,7 +61,7 @@ describe("victory-util/textsize", () => {
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
           angle: 30,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("28.24");
     });
     it("not consider lineHeight without angle", () => {
@@ -82,7 +69,7 @@ describe("victory-util/textsize", () => {
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
           lineHeight: 2,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("24.64");
     });
     it("consider lineHeight with angle", () => {
@@ -91,14 +78,14 @@ describe("victory-util/textsize", () => {
           fontSize: 12,
           lineHeight: 2,
           angle: 30,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("35.14");
     });
     it("return width of widest string in text", () => {
       expect(
         TextSize.approximateTextSize("ABC\nDEFGH\nIJK", {
           fontSize: 12,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("41.94");
     });
 
@@ -106,42 +93,42 @@ describe("victory-util/textsize", () => {
       expect(
         TextSize.approximateTextSize(["06-14-20", ""], {
           fontSize: 12,
-        }).width.toFixed(2),
+        }, true).width.toFixed(2),
       ).toEqual("47.93");
     });
   });
 
   describe("approximateHeight", () => {
     it("return zero width when no style", () => {
-      expect(TextSize.approximateTextSize(testString).height).toEqual(0);
+      expect(TextSize.approximateTextSize(testString, undefined, true).height).toEqual(0);
     });
     it("return correct height with signed angle", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           angle: -45,
           fontSize: 14,
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("33.29");
     });
     it("return correct height with pixel fontsize", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           fontSize: "14px",
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("16.90");
     });
     it("return appropriate height with expected precision", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("14.49");
     });
     it("consider font", () => {
       expect(
         TextSize.approximateTextSize(testString, {
           fontSize: 16,
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("19.32");
     });
     it("consider angle", () => {
@@ -149,7 +136,7 @@ describe("victory-util/textsize", () => {
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
           angle: 30,
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("25.48");
     });
     it("not consider letterSpacing without angle", () => {
@@ -157,7 +144,7 @@ describe("victory-util/textsize", () => {
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
           letterSpacing: "1px",
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("14.49");
     });
     it("consider letterSpacing with angle", () => {
@@ -166,7 +153,7 @@ describe("victory-util/textsize", () => {
           fontSize: 12,
           angle: 30,
           letterSpacing: "1px",
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("26.53");
     });
     it("consider lineHeight", () => {
@@ -174,15 +161,28 @@ describe("victory-util/textsize", () => {
         TextSize.approximateTextSize(testString, {
           fontSize: 12,
           lineHeight: 2,
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("28.98");
     });
     it("consider multiLines text", () => {
       expect(
         TextSize.approximateTextSize(`ABC\n${"DBCDEFG"}\n123`, {
           fontSize: 12,
-        }).height.toFixed(2),
+        }, true).height.toFixed(2),
       ).toEqual("43.47");
+    });
+  });
+
+  describe("dom measurement", () => {
+    const createSpy = jest.spyOn(document, "createElement");
+
+    it('should append and remove a div to the body', () => {
+      TextSize.approximateTextSize(testString, {
+        fontSize: 12,
+        lineHeight: 2,
+      });
+
+      expect(createSpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/victory-core/src/victory-util/textsize.test.ts
+++ b/packages/victory-core/src/victory-util/textsize.test.ts
@@ -16,6 +16,19 @@ describe("victory-util/textsize", () => {
   });
 
   describe("approximateWidth", () => {
+    const { window } = global;
+
+    // Jsdom does not have a window width/height so it is very difficult to test
+    // the _measureWithDOM function.
+    // Default to testing the approximation function
+    beforeAll(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      delete global.window;
+    });
+    afterAll(() => {
+      global.window = window;
+    });
     it("return zero width when no style", () => {
       expect(TextSize.approximateTextSize(testString).width).toEqual(0);
     });

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -255,36 +255,35 @@ const _measureWithDOM = (
 
   const containerElement = document.createElementNS(
     "http://www.w3.org/2000/svg",
-    "g",
+    "text",
   );
   element.appendChild(containerElement);
 
   element.style.position = "fixed";
   element.style.top = "-9999px";
   element.style.left = "-9999px";
+  element.style.height = "auto";
+  element.style.width = "auto";
 
   document.body.appendChild(element);
 
   const lines = _splitToLines(text);
-  let aggregatedHeight = 0;
+  // let aggregatedHeight = 0;
   for (const [i, line] of lines.entries()) {
     const textElement = document.createElementNS(
       "http://www.w3.org/2000/svg",
-      "text",
+      "tspan",
     );
     const params = _prepareParams(style, i);
-    textElement.setAttribute("transform", `rotate(${params.angle})`);
-    textElement.setAttribute("fontSize", `${params.fontSize}px`);
-    textElement.setAttribute("line-height", params.lineHeight);
-    textElement.setAttribute("font-family", params.fontFamily);
-    textElement.setAttribute("letter-spacing", params.letterSpacing);
-    textElement.setAttribute("x", "0");
-    textElement.setAttribute("y", aggregatedHeight.toString());
+    textElement.style.fontFamily = "arial";
+    textElement.style.transform = `rotate(${params.angle})`;
+    textElement.style.fontSize = `${params.fontSize}px`;
+    textElement.style.lineHeight = params.lineHeight;
+    textElement.style.fontFamily = params.fontFamily;
+    textElement.style.letterSpacing = params.letterSpacing;
     textElement.textContent = line;
 
     containerElement.appendChild(textElement);
-
-    aggregatedHeight += textElement.getBBox().height;
   }
 
   const result = {

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -273,7 +273,7 @@ const _measureWithDOM = (
       "text",
     );
     const params = _prepareParams(style, i);
-    textElement.setAttribute("transform", "rotate(90)");
+    textElement.setAttribute("transform", `rotate(${params.angle})`);
     textElement.setAttribute("fontSize", `${params.fontSize}px`);
     textElement.setAttribute("line-height", params.lineHeight);
     textElement.setAttribute("font-family", params.fontFamily);

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -325,7 +325,7 @@ export const _approximateTextSizeInternal = {
       window.document !== undefined &&
       window.document.createElement !== undefined;
 
-    if (isClient && !approximate){
+    if (isClient && !approximate) {
       return _measureWithDOM(text, style);
     } else {
       return _approximateFromFont(text, style);

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -250,31 +250,46 @@ const _measureWithDOM = (
   text: string | string[],
   style?: TextSizeStyleInterface,
 ): { width: number; height: number } => {
-  const element = document.createElement("div");
-  element.style.position = "absolute";
+  const element = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  element.setAttribute("xlink", "http://www.w3.org/1999/xlink");
+
+  const containerElement = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "g",
+  );
+  element.appendChild(containerElement);
+
+  element.style.position = "fixed";
   element.style.top = "-9999px";
   element.style.left = "-9999px";
-  if (style && style.angle) {
-    element.style.transform = `rotate(${style?.angle}deg)`;
-  }
-
-  const lines = _splitToLines(text);
-  for (const [i, line] of lines.entries()) {
-    const lineElement = document.createElement("div");
-    const params = _prepareParams(style, i);
-    lineElement.textContent = line;
-    lineElement.style.fontSize = `${params.fontSize}px`;
-    lineElement.style.lineHeight = params.lineHeight;
-    lineElement.style.fontFamily = params.fontFamily;
-    lineElement.style.letterSpacing = params.letterSpacing;
-    element.appendChild(lineElement);
-  }
 
   document.body.appendChild(element);
 
+  const lines = _splitToLines(text);
+  let aggregatedHeight = 0;
+  for (const [i, line] of lines.entries()) {
+    const textElement = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "text",
+    );
+    const params = _prepareParams(style, i);
+    textElement.setAttribute("transform", "rotate(90)");
+    textElement.setAttribute("fontSize", `${params.fontSize}px`);
+    textElement.setAttribute("line-height", params.lineHeight);
+    textElement.setAttribute("font-family", params.fontFamily);
+    textElement.setAttribute("letter-spacing", params.letterSpacing);
+    textElement.setAttribute("x", "0");
+    textElement.setAttribute("y", aggregatedHeight.toString());
+    textElement.textContent = line;
+
+    containerElement.appendChild(textElement);
+
+    aggregatedHeight += textElement.getBBox().height;
+  }
+
   const result = {
-    width: element.clientWidth,
-    height: element.clientHeight,
+    width: containerElement.getBBox().width,
+    height: containerElement.getBBox().height,
   };
 
   element.remove();

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -262,13 +262,10 @@ const _measureWithDOM = (
   element.style.position = "fixed";
   element.style.top = "-9999px";
   element.style.left = "-9999px";
-  element.style.height = "auto";
-  element.style.width = "auto";
 
   document.body.appendChild(element);
 
   const lines = _splitToLines(text);
-  // let aggregatedHeight = 0;
   for (const [i, line] of lines.entries()) {
     const textElement = document.createElementNS(
       "http://www.w3.org/2000/svg",
@@ -286,10 +283,8 @@ const _measureWithDOM = (
     containerElement.appendChild(textElement);
   }
 
-  const result = {
-    width: containerElement.getBBox().width,
-    height: containerElement.getBBox().height,
-  };
+  const { width, height } = containerElement.getBBox();
+  const result = { width, height };
 
   element.remove();
 

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -186,7 +186,10 @@ export const convertLengthToPixels = (
   return result;
 };
 
-const _prepareParams = (inputStyle: TextSizeStyleInterface | undefined, index: number) => {
+const _prepareParams = (
+  inputStyle: TextSizeStyleInterface | undefined,
+  index: number,
+) => {
   const lineStyle = Array.isArray(inputStyle) ? inputStyle[index] : inputStyle;
   const style = defaults({}, lineStyle, defaultStyle);
   return assign({}, style, {
@@ -244,25 +247,27 @@ const _approximateTextHeightInternal = (text: string | string[], style) => {
 };
 
 const _measureWithDOM = (
-  text: string | string[], 
-  style?: TextSizeStyleInterface
-): { width: number, height: number} => {
-  if (typeof window === 'undefined' ||
-      typeof window.document === 'undefined' || 
-      typeof window.document.createElement === 'undefined') {
-    throw new Error('Cannot measure text in a non-browser environment');
+  text: string | string[],
+  style?: TextSizeStyleInterface,
+): { width: number; height: number } => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.document === "undefined" ||
+    typeof window.document.createElement === "undefined"
+  ) {
+    throw new Error("Cannot measure text in a non-browser environment");
   }
-  
+
   const element = document.createElement("div");
   element.style.position = "absolute";
   element.style.top = "-9999px";
   element.style.left = "-9999px";
-  if (style && style.angle){
+  if (style && style.angle) {
     element.style.transform = `rotate(${style?.angle}deg)`;
   }
-  
+
   const lines = _splitToLines(text);
-  for(const [i, line] of lines.entries()) {
+  for (const [i, line] of lines.entries()) {
     const lineElement = document.createElement("div");
     const params = _prepareParams(style, i);
     lineElement.textContent = line;
@@ -283,12 +288,12 @@ const _measureWithDOM = (
   element.remove();
 
   return result;
-}
+};
 
 const _approximateFromFont = (
   text: string | string[],
-  style?: TextSizeStyleInterface
-): { width: number, height: number } => {
+  style?: TextSizeStyleInterface,
+): { width: number; height: number } => {
   const angle = Array.isArray(style)
     ? style[0] && style[0].angle
     : style && style.angle;
@@ -304,7 +309,7 @@ const _approximateFromFont = (
     width: widthWithRotate,
     height: heightWithRotate * coefficients.heightOverlapCoef,
   };
-}
+};
 
 export interface TextSizeStyleInterface {
   angle?: number;
@@ -321,7 +326,7 @@ export const _approximateTextSizeInternal = {
     // to the less accurate approximation algorithm.
     try {
       return _measureWithDOM(text, style);
-    } catch(e) {
+    } catch (e) {
       return _approximateFromFont(text, style);
     }
   },

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -321,9 +321,9 @@ export const _approximateTextSizeInternal = {
     // Attempt to first measure the element in DOM. If there is no DOM, fallback
     // to the less accurate approximation algorithm.
     const isClient =
-      window !== undefined &&
-      window.document !== undefined &&
-      window.document.createElement !== undefined;
+      typeof window !== "undefined" &&
+      typeof window.document !== "undefined" &&
+      typeof window.document.createElement !== "undefined";
 
     if (isClient && !approximate) {
       return _measureWithDOM(text, style);

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -250,14 +250,6 @@ const _measureWithDOM = (
   text: string | string[],
   style?: TextSizeStyleInterface,
 ): { width: number; height: number } => {
-  if (
-    typeof window === "undefined" ||
-    typeof window.document === "undefined" ||
-    typeof window.document.createElement === "undefined"
-  ) {
-    throw new Error("Cannot measure text in a non-browser environment");
-  }
-
   const element = document.createElement("div");
   element.style.position = "absolute";
   element.style.top = "-9999px";
@@ -321,12 +313,21 @@ export interface TextSizeStyleInterface {
 }
 
 export const _approximateTextSizeInternal = {
-  impl: (text: string | string[], style?: TextSizeStyleInterface) => {
+  impl: (
+    text: string | string[],
+    style?: TextSizeStyleInterface,
+    approximate = false,
+  ) => {
     // Attempt to first measure the element in DOM. If there is no DOM, fallback
     // to the less accurate approximation algorithm.
-    try {
+    const isClient =
+      window !== undefined &&
+      window.document !== undefined &&
+      window.document.createElement !== undefined;
+
+    if (isClient && !approximate){
       return _measureWithDOM(text, style);
-    } catch (e) {
+    } else {
       return _approximateFromFont(text, style);
     }
   },
@@ -341,10 +342,12 @@ export const _approximateTextSizeInternal = {
  * @param {number} style.angle Text rotate angle.
  * @param {string} style.letterSpacing Text letterSpacing(space between letters).
  * @param {number} style.lineHeight Line height coefficient.
+ * @param {boolean} approximate If true, approximate text size with approximation algorithm.
  * @returns {number} Approximate text label width and height.
  */
 export const approximateTextSize = (
   text: string | string[],
   style?: TextSizeStyleInterface,
+  approximate?: boolean,
 ): { width: number; height: number } =>
-  _approximateTextSizeInternal.impl(text, style);
+  _approximateTextSizeInternal.impl(text, style, approximate);

--- a/stories/victory-label.stories.js
+++ b/stories/victory-label.stories.js
@@ -415,6 +415,26 @@ export const LineHeight = () => {
           />
         }
       />
+      <VictoryScatter
+        {...defaultScatterProps}
+        labelComponent={
+          <VictoryLabel
+            lineHeight={[2, 1, 3]}
+            text={["测试汉字", "不在正常的 ASCII 范围内", "最后一行"]}
+            backgroundStyle={[{ stroke: "blue", fill: "none" }]}
+          />
+        }
+      />
+      <VictoryScatter
+        {...defaultScatterProps}
+        labelComponent={
+          <VictoryLabel
+            lineHeight={[2, 1, 3]}
+            text={["اختبار اللغات التي تُقرأ من اليمين إلى اليسار", "مثل العربية", "هناك أكثر من ذلك بكثير"]}
+            backgroundStyle={[{ stroke: "blue", fill: "none" }]}
+          />
+        }
+      />
     </div>
   );
 };

--- a/stories/victory-label.stories.js
+++ b/stories/victory-label.stories.js
@@ -430,7 +430,11 @@ export const LineHeight = () => {
         labelComponent={
           <VictoryLabel
             lineHeight={[2, 1, 3]}
-            text={["اختبار اللغات التي تُقرأ من اليمين إلى اليسار", "مثل العربية", "هناك أكثر من ذلك بكثير"]}
+            text={[
+              "اختبار اللغات التي تُقرأ من اليمين إلى اليسار",
+              "مثل العربية",
+              "هناك أكثر من ذلك بكثير",
+            ]}
             backgroundStyle={[{ stroke: "blue", fill: "none" }]}
           />
         }


### PR DESCRIPTION
Fixes #2108

Uses DOM measurements for label width and height. This method proves to be more accurate and 27% more performant than the existing approximation solution as shown below, particularly for CJK and RTL languages.

Some technical limitations include:
- Lack of support for SSR & React Native
  - The `window` element does not exist for either so we continue to fall back to the approximation solution. 
  - It would be very helpful to get a React Native developer to add a similar solution that will work on mobile. 
- Testing is difficult and non-comprehensive
  - Since jsdom doesn't actually render and there is no window width/height, it cannot be measured in tests. 
  - I would love to hear solutions to this problem if any exist. Currently I'm testing that the element is added to the dom.

<img width="1505" alt="Screen Shot 2022-07-06 at 11 04 10 AM" src="https://user-images.githubusercontent.com/4270079/178020032-52bc510c-fa4a-4b64-a6ce-a7b37c32c92f.png">
<img width="1045" alt="Screen Shot 2022-07-06 at 11 03 08 AM" src="https://user-images.githubusercontent.com/4270079/178020075-40baab97-238d-4235-85c1-ef2c230523e9.png">
<img width="985" alt="Screen Shot 2022-07-06 at 11 02 50 AM" src="https://user-images.githubusercontent.com/4270079/178020077-db971d66-cc37-4ade-809b-ba87b95fe21f.png">

