### PR TITLE
Infra/Bug: Fix format tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
       ]
     },
     "format:root:fix": {
-      "command": "nps format:root:fix",
+      "command": "pnpm run format:root || nps format:root:fix",
       "files": [
         ".eslintrc.js",
         "*.js",

--- a/packages/victory-area/package.json
+++ b/packages/victory-area/package.json
@@ -224,7 +224,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-axis/package.json
+++ b/packages/victory-axis/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -224,7 +224,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-box-plot/package.json
+++ b/packages/victory-box-plot/package.json
@@ -223,7 +223,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -212,7 +212,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -212,7 +212,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-candlestick/package.json
+++ b/packages/victory-candlestick/package.json
@@ -216,7 +216,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-canvas/package.json
+++ b/packages/victory-canvas/package.json
@@ -219,7 +219,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-chart/package.json
+++ b/packages/victory-chart/package.json
@@ -242,7 +242,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -223,7 +223,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-create-container/package.json
+++ b/packages/victory-create-container/package.json
@@ -250,7 +250,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-cursor-container/package.json
+++ b/packages/victory-cursor-container/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-errorbar/package.json
+++ b/packages/victory-errorbar/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -225,7 +225,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -227,7 +227,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-legend/package.json
+++ b/packages/victory-legend/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -224,7 +224,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-pie/package.json
+++ b/packages/victory-pie/package.json
@@ -221,7 +221,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-polar-axis/package.json
+++ b/packages/victory-polar-axis/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-scatter/package.json
+++ b/packages/victory-scatter/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-selection-container/package.json
+++ b/packages/victory-selection-container/package.json
@@ -216,7 +216,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-shared-events/package.json
+++ b/packages/victory-shared-events/package.json
@@ -213,7 +213,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -225,7 +225,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-tooltip/package.json
+++ b/packages/victory-tooltip/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -221,7 +221,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-voronoi/package.json
+++ b/packages/victory-voronoi/package.json
@@ -210,7 +210,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory-zoom-container/package.json
+++ b/packages/victory-zoom-container/package.json
@@ -211,7 +211,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -419,7 +419,7 @@
       ]
     },
     "format:fix": {
-      "command": "pnpm run lint || nps format:pkg:fix",
+      "command": "pnpm run format || nps format:pkg:fix",
       "files": [
         "src/**",
         "*.json",

--- a/scripts/sync-pkgs-wireit-helpers.js
+++ b/scripts/sync-pkgs-wireit-helpers.js
@@ -174,7 +174,7 @@ function generateWireitConfig(pkg, rootPkg) {
       // we get caching for packages without changed files.
       ...["", ":fix"].reduce((acc, key) => {
         acc[`format${key}`] = {
-          "command": key === "" ? "nps format:pkg" : "pnpm run lint || nps format:pkg:fix",
+          "command": key === "" ? "nps format:pkg" : "pnpm run format || nps format:pkg:fix",
           "files": [
             "src/**",
             "*.json",


### PR DESCRIPTION
This is the cause of the CI failures in https://github.com/FormidableLabs/victory/pull/2379

- Pkg format incorrectly checked if _lint_ succeeded first.
- Root pkg fix needed conditional check.