### PR TITLE
Bug: Fix victory devDeps references.

### DIFF
--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "victory-chart": "*",
-    "victory-bar": "."
+    "victory-bar": "*"
   },
   "scripts": {
     "###            THESE SCRIPTS ARE GENERATED           ###": "true",

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "victory-chart": "*",
-    "victory-line": "."
+    "victory-line": "*"
   },
   "scripts": {
     "###            THESE SCRIPTS ARE GENERATED           ###": "true",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,7 +270,7 @@ importers:
     specifiers:
       lodash: ^4.17.19
       prop-types: ^15.8.1
-      victory-bar: .
+      victory-bar: '*'
       victory-chart: '*'
       victory-core: ^36.5.3
       victory-vendor: ^36.5.1
@@ -480,7 +480,7 @@ importers:
       prop-types: ^15.8.1
       victory-chart: '*'
       victory-core: ^36.5.3
-      victory-line: .
+      victory-line: '*'
       victory-vendor: ^36.5.1
     dependencies:
       lodash: 4.17.21


### PR DESCRIPTION
Changesets can't handle references like:

```js
"devDependencies": {
  "victory-line": "."
}
```

so we're switching to:

```js
"devDependencies": {
  "victory-line": "*"
}
```

See, e.g. https://github.com/FormidableLabs/victory/runs/7617438496?check_suite_focus=true

```
> pnpm changeset version && pnpm install

🦋  error TypeError: Invalid comparator: .
🦋  error     at Comparator.parse (/home/runner/work/victory/victory/node_modules/.pnpm/semver@5.7.1/node_modules/semver/semver.js:754:11)
🦋  error     at new Comparator (/home/runner/work/victory/victory/node_modules/.pnpm/semver@5.7.1/node_modules/semver/semver.js:737:8)
🦋  error     at Range.<anonymous> (/home/runner/work/victory/victory/node_modules/.pnpm/semver@5.7.1/node_modules/semver/semver.js:925:12)
🦋  error     at Array.map (<anonymous>)
🦋  error     at Range.parseRange (/home/runner/work/victory/victory/node_modules/.pnpm/semver@5.7.1/node_modules/semver/semver.js:924:13)
🦋  error     at Range.<anonymous> (/home/runner/work/victory/victory/node_modules/.pnpm/semver@5.7.1/node_modules/semver/semver.js:867:17)
🦋  error     at Array.map (<anonymous>)
🦋  error     at new Range (/home/runner/work/victory/victory/node_modules/.pnpm/semver@5.7.1/node_modules/semver/semver.js:866:40)
🦋  error     at versionPackage (/home/runner/work/victory/victory/node_modules/.pnpm/@changesets+apply-release-plan@6.0.3/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js:171:9)
🦋  error     at /home/runner/work/victory/victory/node_modules/.pnpm/@changesets+apply-release-plan@6.0.3/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js:308:12
 ELIFECYCLE  Command failed with exit code 1.
Error: The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1
    at m._setResult (/home/runner/work/_actions/changesets/action/v1/dist/index.js:102:7258)
    at m.CheckComplete (/home/runner/work/_actions/changesets/action/v1/dist/index.js:102:6686)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/changesets/action/v1/dist/index.js:102:5723)
    at ChildProcess.emit (events.js:[31](https://github.com/FormidableLabs/victory/runs/7617438496?check_suite_focus=true#step:10:32)4:20)
    at maybeClose (internal/child_process.js:1022:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
```