### PR TITLE
chore(build): Run checks even for doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '**'
   pull_request:
     branches:
       - main
-    paths:
-      - '**'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 # Runs build and test on:
-#   every push to main that has a change in a file
-#   every pull request with main branch as the base that has a change in a file
+#   every push to main
+#   every pull request with main branch as the base
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,19 @@
 name: CI
 
 # Runs build and test on:
-#   every push to main that has a change in a file not in the docs folder
-#   every pull request with main branch as the base that has a change in a file not in the docs folder
+#   every push to main that has a change in a file
+#   every pull request with main branch as the base that has a change in a file
 on:
   push:
     branches:
       - main
     paths:
       - '**'
-      - '!docs/**'
   pull_request:
     branches:
       - main
     paths:
       - '**'
-      - '!docs/**'
 
 jobs:
   test:


### PR DESCRIPTION
Currently we skip CI checks for doc-only changes.
However, since these checks are "Required", it blocks doc-only PRs from merging.

This PR will run CI checks for any changes, even if doc-only.