### PR TITLE
chore: Added "check" script for individual packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,24 @@ To develop against `victory-native`, please see the package [README](./packages/
 
 ### Tips and tricks
 
+#### Scripts can be run from the _root_ AND from inside any _package_ folder
+
+For example, when working on a single package like `victory-core`, you can run `pnpm run check --watch` from the `packages/victory-core` directory, and it will only check the core.  Example:  
+
+```sh
+$ cd packages/victory-core
+$ pnpm run check --watch
+```
+
+This is especially helpful when you're making changes to any package that is _depended upon_, like `victory-core` or `victory-vendor`, and don't want to run every single script during development.
+
+
+#### My IDE shows outdated TypeScript errors
+
+It seems like VS Code and WebStorm both struggle to update their internal cache, whenever the **built types** change.  For example, when making changes to `victory-core`, the TypeScript changes won't be picked up by your IDE automatically.
+
+Instead of restarting your IDE completely, try restarting the TypeScript Service.
+
 #### My computer grinds to a halt!
 
 The initial build/check, or one where something that is part of a lot of cache keys changes, can really slow down your computer, especially if you've got an older model. To allow you to do other work on your computer at the same time, consider using the `WIREIT_PARALLEL=<NUM_PROCESS>` environment variable like:

--- a/packages/victory-area/package.json
+++ b/packages/victory-area/package.json
@@ -42,6 +42,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -150,6 +151,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -204,6 +213,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -219,19 +241,6 @@
         "../victory-chart:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-axis/package.json
+++ b/packages/victory-axis/package.json
@@ -41,6 +41,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -145,6 +146,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -198,6 +207,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -212,19 +234,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -42,6 +42,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -150,6 +151,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -204,6 +213,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -219,19 +241,6 @@
         "../victory-chart:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-box-plot/package.json
+++ b/packages/victory-box-plot/package.json
@@ -42,6 +42,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -150,6 +151,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -204,6 +213,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -219,19 +241,6 @@
         "../victory-chart:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -41,6 +41,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -145,6 +146,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -197,6 +206,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -210,19 +232,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -38,6 +38,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -142,6 +143,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -194,6 +203,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -207,19 +229,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-candlestick/package.json
+++ b/packages/victory-candlestick/package.json
@@ -40,6 +40,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -144,6 +145,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -197,6 +206,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -211,19 +233,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-canvas/package.json
+++ b/packages/victory-canvas/package.json
@@ -38,6 +38,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -146,6 +147,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -200,6 +209,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -214,19 +236,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-chart/package.json
+++ b/packages/victory-chart/package.json
@@ -45,6 +45,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -161,6 +162,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -220,6 +229,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -237,19 +259,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -44,6 +44,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -148,6 +149,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -202,6 +211,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -218,19 +240,6 @@
         "../victory-line:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-create-container/package.json
+++ b/packages/victory-create-container/package.json
@@ -41,6 +41,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -165,6 +166,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -227,6 +236,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -245,19 +267,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-cursor-container/package.json
+++ b/packages/victory-cursor-container/package.json
@@ -37,6 +37,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -141,6 +142,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -193,6 +202,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -206,19 +228,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-errorbar/package.json
+++ b/packages/victory-errorbar/package.json
@@ -40,6 +40,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -144,6 +145,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -196,6 +205,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -209,19 +231,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -42,6 +42,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -150,6 +151,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -205,6 +214,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -220,19 +242,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -40,6 +40,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -152,6 +153,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -207,6 +216,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -222,19 +244,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-legend/package.json
+++ b/packages/victory-legend/package.json
@@ -37,6 +37,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -141,6 +142,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -193,6 +202,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -206,19 +228,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -42,6 +42,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -150,6 +151,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -204,6 +213,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -219,19 +241,6 @@
         "../victory-chart:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-native/package.json
+++ b/packages/victory-native/package.json
@@ -69,6 +69,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -107,6 +108,14 @@
       "command": "echo \"No build required\"",
       "files": [],
       "output": []
+    },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
     },
     "types:check": {
       "command": "echo \"No types to check here\"",

--- a/packages/victory-pie/package.json
+++ b/packages/victory-pie/package.json
@@ -41,6 +41,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -149,6 +150,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -202,6 +211,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -216,19 +238,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-polar-axis/package.json
+++ b/packages/victory-polar-axis/package.json
@@ -37,6 +37,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -141,6 +142,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -193,6 +202,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -206,19 +228,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-scatter/package.json
+++ b/packages/victory-scatter/package.json
@@ -40,6 +40,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -144,6 +145,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -196,6 +205,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -209,19 +231,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-selection-container/package.json
+++ b/packages/victory-selection-container/package.json
@@ -40,6 +40,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -144,6 +145,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -197,6 +206,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -211,19 +233,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-shared-events/package.json
+++ b/packages/victory-shared-events/package.json
@@ -39,6 +39,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -143,6 +144,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -195,6 +204,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -208,19 +230,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -42,6 +42,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -150,6 +151,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -205,6 +214,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -220,19 +242,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-tooltip/package.json
+++ b/packages/victory-tooltip/package.json
@@ -37,6 +37,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -141,6 +142,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -193,6 +202,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -206,19 +228,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-vendor/package.json
+++ b/packages/victory-vendor/package.json
@@ -57,6 +57,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -105,6 +106,14 @@
     "build:dist:min": {
       "dependencies": [
         "build"
+      ]
+    },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
       ]
     },
     "types:check": {

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -40,6 +40,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -148,6 +149,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -202,6 +211,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -216,19 +238,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-voronoi/package.json
+++ b/packages/victory-voronoi/package.json
@@ -38,6 +38,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -142,6 +143,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -193,6 +202,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -205,19 +227,6 @@
         "../victory-core:types:create",
         "../victory-vendor:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory-zoom-container/package.json
+++ b/packages/victory-zoom-container/package.json
@@ -37,6 +37,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -141,6 +142,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -193,6 +202,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -206,19 +228,6 @@
         "../victory-vendor:types:create",
         "../victory-voronoi:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -65,6 +65,7 @@
     "build:dist": "wireit",
     "build:dist:dev": "wireit",
     "build:dist:min": "wireit",
+    "check": "wireit",
     "types:check": "wireit",
     "types:create": "wireit",
     "format": "wireit",
@@ -273,6 +274,14 @@
         "pnpm-lock.yaml"
       ]
     },
+    "check": {
+      "dependencies": [
+        "types:check",
+        "jest",
+        "format",
+        "lint"
+      ]
+    },
     "types:check": {
       "command": "nps types:pkg:check",
       "files": [
@@ -376,6 +385,19 @@
         "pnpm-lock.yaml"
       ]
     },
+    "format:fix": {
+      "command": "pnpm run format || nps format:pkg:fix",
+      "files": [
+        "src/**",
+        "*.json",
+        "../../.prettierignore",
+        "../../.prettierrc.json"
+      ],
+      "output": [],
+      "packageLocks": [
+        "pnpm-lock.yaml"
+      ]
+    },
     "lint": {
       "command": "nps lint:pkg",
       "files": [
@@ -414,19 +436,6 @@
         "../victory-zoom-container:types:create",
         "../victory-vendor:types:create"
       ],
-      "packageLocks": [
-        "pnpm-lock.yaml"
-      ]
-    },
-    "format:fix": {
-      "command": "pnpm run format || nps format:pkg:fix",
-      "files": [
-        "src/**",
-        "*.json",
-        "../../.prettierignore",
-        "../../.prettierrc.json"
-      ],
-      "output": [],
       "packageLocks": [
         "pnpm-lock.yaml"
       ]

--- a/scripts/sync-pkgs-wireit-helpers.js
+++ b/scripts/sync-pkgs-wireit-helpers.js
@@ -35,6 +35,7 @@ function generateWireitConfig(pkg, rootPkg) {
       "build:dist": "wireit",
       "build:dist:dev": "wireit",
       "build:dist:min": "wireit",
+      "check": "wireit",
       "types:check": "wireit",
       "types:create": "wireit",
       "format": "wireit",
@@ -135,6 +136,14 @@ function generateWireitConfig(pkg, rootPkg) {
         ],
         "packageLocks": ["pnpm-lock.yaml"]
       },
+      "check": {
+        "dependencies": [
+          "types:check",
+          "jest",
+          "format",
+          "lint",
+        ]
+      },
       "types:check": {
         "command": "nps types:pkg:check",
         "files": [
@@ -169,12 +178,12 @@ function generateWireitConfig(pkg, rootPkg) {
         ],
         "packageLocks": ["pnpm-lock.yaml"]
       },
-      // lint/format + fix
+
       // For the "fix" task, we first run the normal check that may fail so that
-      // we get caching for packages without changed files.
-      ...["", ":fix"].reduce((acc, key) => {
-        acc[`format${key}`] = {
-          "command": key === "" ? "nps format:pkg" : "pnpm run format || nps format:pkg:fix",
+      // we get caching for packages without changed files:
+      ...["format", "format:fix"].reduce((wireit, key) => {
+        wireit[key] = {
+          "command": key === "format" ? "nps format:pkg" : "pnpm run format || nps format:pkg:fix",
           "files": [
             "src/**",
             "*.json",
@@ -184,9 +193,12 @@ function generateWireitConfig(pkg, rootPkg) {
           "output": [],
           "packageLocks": ["pnpm-lock.yaml"]
         };
-
-        acc[`lint${key}`] = {
-          "command": key === "" ? "nps lint:pkg" : "pnpm run lint || nps lint:pkg:fix",
+        return wireit;
+      }, {}),
+      // Same as above
+      ...["lint", "lint:fix"].reduce((wireit, key) => {
+        wireit[key] = {
+          "command": key === "lint" ? "nps lint:pkg" : "pnpm run lint || nps lint:pkg:fix",
           "files": [
             "src/**",
             "../../.eslintignore",
@@ -199,8 +211,9 @@ function generateWireitConfig(pkg, rootPkg) {
           "packageLocks": ["pnpm-lock.yaml"]
         };
 
-        return acc;
+        return wireit;
       }, {}),
+
       "jest": {
         "command": "nps jest:pkg",
         "files": [


### PR DESCRIPTION
I love how our current "root" scripts are the same as our "package" scripts.  
This PR just adds the `check` script, so that I can do:
```
cd packages/victory-axis
pnpm run check
```
and also with the `--watch` option, which is a great workflow when working in a specific package.