### PR TITLE
TS Migrate: fixed type issues

### DIFF
--- a/packages/victory-axis/src/victory-axis.tsx
+++ b/packages/victory-axis/src/victory-axis.tsx
@@ -176,7 +176,7 @@ class VictoryAxisBase extends React.Component<VictoryAxisProps> {
   static getAxis = Axis.getAxis;
   static getStyles = (props) => getStyles(props);
   static getBaseProps = (props) => getBaseProps(props, fallbackProps);
-  static expectedComponents = [
+  static expectedComponents: Array<keyof VictoryAxisProps> = [
     "axisComponent",
     "axisLabelComponent",
     "groupComponent",
@@ -297,7 +297,7 @@ class VictoryAxisBase extends React.Component<VictoryAxisProps> {
     return !!this.props.animate;
   }
 
-  render() {
+  render(): React.ReactElement {
     const { animationWhitelist } = VictoryAxis;
     const props = Axis.modifyProps(this.props, fallbackProps);
     const userProps = UserProps.getSafeUserProps(this.props);

--- a/packages/victory-box-plot/src/victory-box-plot.tsx
+++ b/packages/victory-box-plot/src/victory-box-plot.tsx
@@ -387,7 +387,7 @@ class VictoryBoxPlotBase extends React.Component<VictoryBoxPlotProps> {
     return hasSummaryStatistics && (this.props.horizontal ? hasY : hasX);
   }
 
-  render() {
+  render(): React.ReactElement {
     const { animationWhitelist, role } = VictoryBoxPlot;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
 

--- a/packages/victory-chart/src/helper-methods.test.tsx
+++ b/packages/victory-chart/src/helper-methods.test.tsx
@@ -4,13 +4,10 @@ import { VictoryAxis } from "victory-axis";
 import { VictoryLine } from "victory-line";
 
 describe("victory-chart/helpers-methods", () => {
-  const getVictoryLine = (props) => React.createElement(VictoryLine, props);
-  const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);
-
   describe("getChildComponents", () => {
     const defaultAxes = {
-      independent: getVictoryAxis({}),
-      dependent: getVictoryAxis({ dependentAxis: true }),
+      independent: <VictoryAxis />,
+      dependent: <VictoryAxis dependentAxis />,
     };
 
     it("returns a pair of default axes when no children are given", () => {
@@ -21,7 +18,7 @@ describe("victory-chart/helpers-methods", () => {
     });
 
     it("adds default axes when none of the children are axis components", () => {
-      const line = getVictoryLine({});
+      const line = <VictoryLine />;
       const children = [line];
       const result = getChildComponents({ children }, defaultAxes);
       expect(result).toHaveLength(3);
@@ -30,7 +27,7 @@ describe("victory-chart/helpers-methods", () => {
     });
 
     it("does not add default axes if axis any axis components exist in children", () => {
-      const axis = getVictoryAxis({});
+      const axis = <VictoryAxis />;
       const children = [axis];
       const result = getChildComponents({ children }, defaultAxes);
       expect(result).toHaveLength(1);

--- a/packages/victory-core/src/victory-util/add-events.tsx
+++ b/packages/victory-core/src/victory-util/add-events.tsx
@@ -63,7 +63,10 @@ export interface EventsMixinClass<TProps> {
   getEventState: typeof Events.getEventState;
   renderData(props: TProps);
   renderContinuousData(props: TProps);
-  animateComponent(props: TProps, defaultAnimationWhitelist);
+  animateComponent(
+    props: TProps,
+    defaultAnimationWhitelist: string[],
+  ): React.ReactElement;
   getComponentProps(
     component: React.ReactElement,
     type: string,
@@ -366,7 +369,10 @@ export function addEvents<
       return React.cloneElement(component, parentProps, children);
     }
 
-    animateComponent(props: TProps, defaultAnimationWhitelist: string[]) {
+    animateComponent(
+      props: TProps,
+      defaultAnimationWhitelist: string[],
+    ): React.ReactElement {
       const animationWhitelist =
         (typeof props.animate === "object" &&
           props.animate?.animationWhitelist) ||

--- a/packages/victory-core/src/victory-util/axis.test.tsx
+++ b/packages/victory-core/src/victory-util/axis.test.tsx
@@ -4,9 +4,6 @@ import { VictoryBar } from "victory-bar";
 import { Axis, Scale } from "victory-core";
 
 describe("helpers/axis", () => {
-  const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);
-  const getVictoryBar = (props) => React.createElement(VictoryBar, props);
-
   describe("isVertical", () => {
     it("returns true when the orientation is vertical", () => {
       const props = { orientation: "left" };
@@ -70,12 +67,11 @@ describe("helpers/axis", () => {
   });
 
   describe("getAxisComponent", () => {
-    const dependentAxis = getVictoryAxis({ dependentAxis: true });
-    const independentAxis = getVictoryAxis({ dependentAxis: false });
-    const bar = getVictoryBar({});
+    const dependentAxis = <VictoryAxis dependentAxis />;
+    const independentAxis = <VictoryAxis dependentAxis={false} />;
+    const bar = <VictoryBar />;
 
     beforeEach(() => {
-      // @ts-expect-error This will error until we convert `victory-axis`
       jest.spyOn(dependentAxis.type, "getAxis");
     });
 
@@ -86,9 +82,7 @@ describe("helpers/axis", () => {
     it("returns the independent axis when called with 'x'", () => {
       const childComponents = [dependentAxis, independentAxis, bar];
       const componentResult = Axis.getAxisComponent(childComponents, "x");
-      // @ts-expect-error This will error until we convert `victory-axis`
       expect(dependentAxis.type.getAxis).toBeCalledWith(dependentAxis.props);
-      // @ts-expect-error This will error until we convert `victory-axis`
       expect(independentAxis.type.getAxis).toBeCalledWith(
         independentAxis.props,
       );

--- a/packages/victory-core/src/victory-util/wrapper.test.tsx
+++ b/packages/victory-core/src/victory-util/wrapper.test.tsx
@@ -4,13 +4,10 @@ import { Wrapper } from "victory-core";
 import { VictoryLine } from "victory-line";
 
 describe("helpers/wrapper", () => {
-  const getVictoryLine = (props) => React.createElement(VictoryLine, props);
-  const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);
-
   describe("getDomain", () => {
-    const victoryLine = getVictoryLine({ domain: [0, 3] });
-    const xAxis = getVictoryAxis({ dependentAxis: false });
-    const yAxis = getVictoryAxis({ dependentAxis: true });
+    const victoryLine = <VictoryLine domain={[0, 3]} />;
+    const xAxis = <VictoryAxis dependentAxis={false} />;
+    const yAxis = <VictoryAxis dependentAxis />;
     const childComponents = [victoryLine, xAxis, yAxis];
 
     it("calculates a domain from props", () => {
@@ -35,7 +32,7 @@ describe("helpers/wrapper", () => {
           { x: "cat", y: 3 },
         ],
       };
-      const childComponents = [getVictoryLine(props)];
+      const childComponents = [<VictoryLine key={0} {...props} />];
       const dataStrings = Wrapper.getStringsFromData(childComponents).x;
       expect(dataStrings).toEqual(["one", "red", "cat"]);
     });
@@ -50,7 +47,7 @@ describe("helpers/wrapper", () => {
         x: 0,
         y: 1,
       };
-      const childComponents = [getVictoryLine(props)];
+      const childComponents = [<VictoryLine key={0} {...props} />];
       const dataStrings = Wrapper.getStringsFromData(childComponents).x;
       expect(dataStrings).toEqual(["one", "red", "cat"]);
     });
@@ -62,7 +59,7 @@ describe("helpers/wrapper", () => {
           { x: "three", y: 3 },
         ],
       };
-      const childComponents = [getVictoryLine(props)];
+      const childComponents = [<VictoryLine key={0} {...props} />];
       expect(Wrapper.getStringsFromData(childComponents).x).toEqual(["three"]);
     });
 
@@ -73,7 +70,7 @@ describe("helpers/wrapper", () => {
           { x: 3, y: 3 },
         ],
       };
-      const childComponents = [getVictoryLine(props)];
+      const childComponents = [<VictoryLine key={0} {...props} />];
       expect(Wrapper.getStringsFromData(childComponents).x).toEqual([]);
     });
 

--- a/packages/victory-errorbar/src/victory-errorbar.tsx
+++ b/packages/victory-errorbar/src/victory-errorbar.tsx
@@ -129,7 +129,7 @@ class VictoryErrorBarBase extends React.Component<VictoryErrorBarProps> {
     return !!this.props.animate;
   }
 
-  render() {
+  render(): React.ReactElement {
     const { animationWhitelist, role } = VictoryErrorBar;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
 

--- a/packages/victory-scatter/src/victory-scatter.test.tsx
+++ b/packages/victory-scatter/src/victory-scatter.test.tsx
@@ -96,6 +96,7 @@ describe("components/victory-scatter", () => {
     it("renders data values with null accessor", () => {
       const data = range(30);
       const { container } = render(
+        // @ts-expect-error "'null' is not assignable to 'x'"
         <VictoryScatter data={data} x={null} y={null} />,
       );
       const points = container.querySelectorAll("path");

--- a/packages/victory-scatter/src/victory-scatter.tsx
+++ b/packages/victory-scatter/src/victory-scatter.tsx
@@ -125,7 +125,7 @@ class VictoryScatterBase extends React.Component<VictoryScatterProps> {
     return !!this.props.animate;
   }
 
-  render() {
+  render(): React.ReactElement {
     const { animationWhitelist, role } = VictoryScatter;
     const props = Helpers.modifyProps(this.props, fallbackProps, role);
 

--- a/packages/victory/src/victory.test.ts
+++ b/packages/victory/src/victory.test.ts
@@ -152,6 +152,145 @@ describe("victory", () => {
   it("ensure it has named exports", () => {
     expect(Area).toBeInstanceOf(Function);
   });
+  it("ensure all components have valid types", () => {
+    /*
+     * See https://github.com/FormidableLabs/victory/issues/2411
+     * It's easy for some of our Components to accidentally get typed as 'any'.
+     * This seems to be due to our use of mixins, especially `addEvents`.
+     *
+     * This test is designed to catch those errors, so that we can be sure
+     * that all of our components are exported with the proper types.
+     */
+
+    let shouldNotBeTypedAsAny: { SHOULD_NOT_BE_TYPED_AS_ANY: true };
+
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryAccessibleGroup;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryAccessibleGroupProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryAnimation;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryAnimationProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryArea;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryAreaProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryAxis;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryAxisProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBar;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBarProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBoxPlot;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBoxPlotProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBrushContainer;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBrushContainerProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBrushLine;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryBrushLineProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryCandlestick;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryCandlestickProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryChart;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryChartProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryClipContainer;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryClipContainerProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryContainer;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryContainerProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryCursorContainer;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryCursorContainerProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryErrorBar;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryErrorBarProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryGroup;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryGroupProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryHistogram;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryHistogramProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryLabel;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryLabelProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryLegend;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryLegendProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryLine;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryLineProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryPie;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryPieProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryPolarAxis;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryPolarAxisProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryPortal;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryPortalProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryScatter;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryScatterProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictorySelectionContainer;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictorySelectionContainerProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictorySharedEvents;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictorySharedEventsProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryStack;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryStackProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryTheme;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryThemeDefinition;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryTooltip;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryTooltipProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryTransition;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryVoronoi;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryVoronoiContainer;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryVoronoiContainerProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryVoronoiProps;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryZoomContainer;
+    // @ts-expect-error This will fail if the component is typed as 'any':
+    shouldNotBeTypedAsAny = VictoryZoomContainerProps;
+  });
   it("ensure everything is exported correctly", () => {
     expect(Object.keys(Victory).sort()).toMatchInlineSnapshot(`
       Array [


### PR DESCRIPTION
# What

4 of our packages were being exported as `any`, like `export declare const VictoryAxis: any;`
This was due to excessively complex issues with the `addEvents` mixin.
This PR fixes that, adds unit tests for all components, and improves various types to work with the fixed type.

Fixes #2411 