### PR TITLE
chore(typescript): improved `textAnchor` props for `victory-label`

### DIFF
--- a/packages/victory-core/src/types/callbacks.ts
+++ b/packages/victory-core/src/types/callbacks.ts
@@ -51,3 +51,5 @@ export type PaddingOrCallback = number | BlockProps | VictoryPaddingCallback;
 export type OrientationOrCallback =
   | OrientationTypes
   | VictoryOrientationCallback;
+
+export type ValueOrCallback<TValue> = TValue | ((args: CallbackArgs) => TValue);

--- a/packages/victory-core/src/victory-label/victory-label.tsx
+++ b/packages/victory-core/src/victory-label/victory-label.tsx
@@ -17,6 +17,7 @@ import {
   NumberOrCallback,
   StringOrCallback,
   StringOrNumberOrCallback,
+  ValueOrCallback,
 } from "../types/callbacks";
 import {
   PaddingProps,
@@ -55,11 +56,11 @@ export interface VictoryLabelProps {
   tabIndex?: NumberOrCallback;
   text?: string[] | StringOrNumberOrCallback;
   textComponent?: React.ReactElement;
-  textAnchor?: TextAnchorType | { (): TextAnchorType };
+  textAnchor?: ValueOrCallback<TextAnchorType>;
   title?: string;
-  transform?: string | object | (() => string | object);
+  transform?: ValueOrCallback<string | object>;
   tspanComponent?: React.ReactElement;
-  verticalAnchor?: VerticalAnchorType | { (): VerticalAnchorType };
+  verticalAnchor?: ValueOrCallback<VerticalAnchorType>;
   x?: number;
   y?: number;
   dx?: StringOrNumberOrCallback;


### PR DESCRIPTION
# What

This improves the callback signature for the `textAnchor` prop.
Fixes #2361 
