### PR TITLE
chore: Removed Template Literal Types to increase TS compatibility

### DIFF
--- a/packages/victory-core/src/victory-util/events.ts
+++ b/packages/victory-core/src/victory-util/events.ts
@@ -20,7 +20,8 @@ export interface ComponentEvent {
   eventKey?: ComponentEventKey | ComponentEventKey[];
   eventHandlers: ComponentEventHandlers;
 }
-export type ComponentEventName = `on${Capitalize<string>}`;
+// Normally we'd use Template Literal Types, but we're avoiding it to maximize TS compatibility with TS < 4.1
+export type ComponentEventName = string; // `on${Capitalize<string>}`;
 export interface ComponentEventHandlers {
   [k: ComponentEventName]: ComponentEventHandler;
 }

--- a/packages/victory-core/src/victory-util/user-props.ts
+++ b/packages/victory-core/src/victory-util/user-props.ts
@@ -11,7 +11,8 @@ const USER_PROPS_SAFELIST = {
   exactMatch: [] as string[],
 };
 
-type SafeAttribute = `data-${string}` | `aria-${string}`;
+// Normally we'd use Template Literal Types, but we're avoiding it to maximize TS compatibility with TS < 4.1
+type SafeAttribute = string; // `data-${string}` | `aria-${string}`;
 
 /**
  * doesPropStartWith: Function that takes a prop's key and runs it against all


### PR DESCRIPTION
# What
Replaced Template Literal Types since they're a newer TS feature (starting in 4.1).
Replaced with simply `string` types.

These types were nice to have, but weren't extremely useful, so we decided to loosen up the types.

Fixes #2409 