### PR TITLE
TypeScript: fixed broken import

### DIFF
--- a/.changeset/spicy-books-search.md
+++ b/.changeset/spicy-books-search.md
@@ -1,0 +1,5 @@
+---
+"victory-cursor-container": patch
+---
+
+Fixed broken import (fixes #2426)

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,18 @@ module.exports = {
     "consistent-return": "off", // we're migrating to TS and this is more properly handled there.
     "react/sort-comp": "off",
     "import/no-unresolved": ["error", { ignore: ["victory*"] }],
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["victory*/src", "victory*/src/**"],
+            message:
+              "Be sure to import directly from Victory packages, not from /src folders!",
+          },
+        ],
+      },
+    ],
     "max-statements": "off",
     complexity: ["error", { max: 16 }],
     "no-magic-numbers": [

--- a/packages/victory-cursor-container/src/cursor-helpers.tsx
+++ b/packages/victory-cursor-container/src/cursor-helpers.tsx
@@ -1,6 +1,5 @@
-import { Selection } from "victory-core";
+import { Selection, SVGCoordinateType } from "victory-core";
 import { throttle, isFunction, mapValues } from "lodash";
-import { SVGCoordinateType } from "victory-core/src";
 
 const ON_MOUSE_MOVE_THROTTLE_MS = 16;
 

--- a/packages/victory-line/src/v37/victory-line.stories.tsx
+++ b/packages/victory-line/src/v37/victory-line.stories.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable no-magic-numbers */
 import * as React from "react";
 import { VictoryLine } from "./victory-line";
-import VictoryChart from "victory-chart/lib/v37/victory-chart";
+import VictoryChart from "victory-chart/es/v37/victory-chart";
 import { getData } from "../../../../stories/data";
 
 export default {

--- a/stories/victory-tooltip.stories.js
+++ b/stories/victory-tooltip.stories.js
@@ -3,7 +3,7 @@
 import React from "react";
 import { VictoryBar } from "victory-bar";
 import { VictoryTooltip, Flyout } from "victory-tooltip";
-import { VictoryLabel } from "victory-core/src";
+import { VictoryLabel } from "victory-core";
 import { getData, getMixedData } from "./data";
 import styled from "styled-components";
 


### PR DESCRIPTION
# What
An import statement incorrectly referenced `victory-core/src`, which caused all source code to try to be compiled.

# TODO
- [ ] Find a way to prevent this from regressions