### PR TITLE
Chore(build): do not build JS sourcemaps

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-  inputSourceMap: true,
   presets: ["@babel/preset-react", "@babel/preset-typescript"],
   plugins: [
     "lodash",

--- a/.changeset/wet-zebras-happen.md
+++ b/.changeset/wet-zebras-happen.md
@@ -1,0 +1,34 @@
+---
+"victory": patch
+"victory-area": patch
+"victory-axis": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-brush-container": patch
+"victory-brush-line": patch
+"victory-candlestick": patch
+"victory-canvas": patch
+"victory-chart": patch
+"victory-core": patch
+"victory-create-container": patch
+"victory-cursor-container": patch
+"victory-errorbar": patch
+"victory-group": patch
+"victory-histogram": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-native": patch
+"victory-pie": patch
+"victory-polar-axis": patch
+"victory-scatter": patch
+"victory-selection-container": patch
+"victory-shared-events": patch
+"victory-stack": patch
+"victory-tooltip": patch
+"victory-vendor": patch
+"victory-voronoi": patch
+"victory-voronoi-container": patch
+"victory-zoom-container": patch
+---
+
+Do not generate *.js.map sourcemaps (fixes #2346)

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -31,9 +31,9 @@ module.exports = {
     // Build.
     // - Libraries
     "build:lib:esm":
-      "cross-env BABEL_ENV=es babel src --out-dir es --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js --source-maps",
+      "cross-env BABEL_ENV=es babel src --out-dir es --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js",
     "build:lib:cjs":
-      "cross-env BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js --source-maps",
+      "cross-env BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.build.js --extensions .tsx,.ts,.jsx,.js",
     // - UMD distributions
     // TODO(2375): Add / verify caching
     // https://github.com/FormidableLabs/victory/issues/2375

--- a/packages/victory-area/package.json
+++ b/packages/victory-area/package.json
@@ -72,7 +72,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -91,7 +93,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -117,6 +121,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -138,6 +144,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-axis/package.json
+++ b/packages/victory-axis/package.json
@@ -71,7 +71,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -89,7 +91,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -114,6 +118,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -134,6 +140,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -72,7 +72,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -91,7 +93,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -117,6 +121,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -138,6 +144,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-box-plot/package.json
+++ b/packages/victory-box-plot/package.json
@@ -72,7 +72,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -91,7 +93,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -117,6 +121,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -138,6 +144,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -71,7 +71,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -89,7 +91,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -114,6 +118,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -134,6 +140,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -68,7 +68,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -86,7 +88,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -111,6 +115,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -131,6 +137,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-candlestick/package.json
+++ b/packages/victory-candlestick/package.json
@@ -70,7 +70,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -88,7 +90,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -113,6 +117,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -133,6 +139,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-canvas/package.json
+++ b/packages/victory-canvas/package.json
@@ -68,7 +68,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -87,7 +89,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -113,6 +117,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -134,6 +140,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-chart/package.json
+++ b/packages/victory-chart/package.json
@@ -75,7 +75,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -96,7 +98,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -124,6 +128,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -147,6 +153,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -74,7 +74,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -92,7 +94,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -117,6 +121,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -137,6 +143,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-create-container/package.json
+++ b/packages/victory-create-container/package.json
@@ -71,7 +71,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -94,7 +96,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -124,6 +128,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -149,6 +155,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-cursor-container/package.json
+++ b/packages/victory-cursor-container/package.json
@@ -67,7 +67,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -85,7 +87,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -110,6 +114,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -130,6 +136,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-errorbar/package.json
+++ b/packages/victory-errorbar/package.json
@@ -70,7 +70,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -88,7 +90,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -113,6 +117,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -133,6 +139,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -73,7 +73,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -92,7 +94,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -118,6 +122,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -139,6 +145,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -70,7 +70,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -90,7 +92,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -117,6 +121,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -139,6 +145,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-legend/package.json
+++ b/packages/victory-legend/package.json
@@ -67,7 +67,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -85,7 +87,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -110,6 +114,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -130,6 +136,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -72,7 +72,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -91,7 +93,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -117,6 +121,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -138,6 +144,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-pie/package.json
+++ b/packages/victory-pie/package.json
@@ -71,7 +71,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -90,7 +92,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -116,6 +120,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -137,6 +143,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-polar-axis/package.json
+++ b/packages/victory-polar-axis/package.json
@@ -67,7 +67,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -85,7 +87,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -110,6 +114,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -130,6 +136,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-scatter/package.json
+++ b/packages/victory-scatter/package.json
@@ -70,7 +70,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -88,7 +90,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -113,6 +117,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -133,6 +139,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-selection-container/package.json
+++ b/packages/victory-selection-container/package.json
@@ -70,7 +70,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -88,7 +90,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -113,6 +117,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -133,6 +139,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-shared-events/package.json
+++ b/packages/victory-shared-events/package.json
@@ -69,7 +69,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -87,7 +89,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -112,6 +116,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -132,6 +138,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -74,7 +74,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -93,7 +95,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -119,6 +123,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -140,6 +146,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-tooltip/package.json
+++ b/packages/victory-tooltip/package.json
@@ -67,7 +67,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -85,7 +87,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -110,6 +114,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -130,6 +136,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -70,7 +70,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -89,7 +91,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -115,6 +119,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -136,6 +142,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-voronoi/package.json
+++ b/packages/victory-voronoi/package.json
@@ -68,7 +68,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -86,7 +88,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -111,6 +115,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -131,6 +137,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory-zoom-container/package.json
+++ b/packages/victory-zoom-container/package.json
@@ -67,7 +67,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -85,7 +87,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -110,6 +114,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -130,6 +136,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -95,7 +95,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "es/**/*.js",
@@ -139,7 +141,9 @@
       "files": [
         "src/**",
         "!src/**/*.test.*",
-        "../../.babelrc.build.js"
+        "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js"
       ],
       "output": [
         "lib/**/*.js",
@@ -190,6 +194,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js",
         "../../config/webpack.config.dev.js"
       ],
@@ -236,6 +242,8 @@
         "src/**",
         "!src/**/*.test.*",
         "../../.babelrc.build.js",
+        "../../.babelrc.js",
+        "../../package-scripts.js",
         "../../config/webpack.config.js"
       ],
       "output": [

--- a/scripts/sync-pkgs-wireit-helpers.js
+++ b/scripts/sync-pkgs-wireit-helpers.js
@@ -65,7 +65,9 @@ function generateWireitConfig(pkg, rootPkg) {
         "files": [
           "src/**",
           "!src/**/*.test.*",
-          "../../.babelrc.build.js"
+          "../../.babelrc.build.js",
+          "../../.babelrc.js",
+          "../../package-scripts.js",
         ],
         "output": [
           "es/**/*.js",
@@ -81,7 +83,9 @@ function generateWireitConfig(pkg, rootPkg) {
         "files": [
           "src/**",
           "!src/**/*.test.*",
-          "../../.babelrc.build.js"
+          "../../.babelrc.build.js",
+          "../../.babelrc.js",
+          "../../package-scripts.js",
         ],
         "output": [
           "lib/**/*.js",
@@ -104,6 +108,8 @@ function generateWireitConfig(pkg, rootPkg) {
           "src/**",
           "!src/**/*.test.*",
           "../../.babelrc.build.js",
+          "../../.babelrc.js",
+          "../../package-scripts.js",
           "../../config/webpack.config.js",
           "../../config/webpack.config.dev.js",
         ],
@@ -126,6 +132,8 @@ function generateWireitConfig(pkg, rootPkg) {
           "src/**",
           "!src/**/*.test.*",
           "../../.babelrc.build.js",
+          "../../.babelrc.js",
+          "../../package-scripts.js",
           "../../config/webpack.config.js",
         ],
         "output": [


### PR DESCRIPTION
# What
We introduced source-map generation to improve Victory development (#2307).  
However, we intentionally did not publish these maps to NPM due to excessive file size (several MB).

This PR disables source-maps from the `.js` builds.  This prevents the `//# sourceMappingURL=index.d.ts.map` comments from being generated and published.  

This PR does NOT disable `.d.ts.map` generation.  This allows the developer workflow to stay awesome, since all of our core packages have been converted to TS.  (these map files are still not published to NPM)

This will address #2346 