### PR TITLE
Chore: added explicit `any` types to exported methods

### DIFF
--- a/packages/victory-canvas/src/index.d.ts
+++ b/packages/victory-canvas/src/index.d.ts
@@ -66,8 +66,8 @@ export class CanvasGroup extends React.Component<CanvasGroupProps, any> {}
 
 export interface CanvasContextValue {
   canvasRef: React.RefObject<HTMLCanvasElement>;
-  clear(ctx): void;
-  clip(ctx): void;
+  clear(ctx: CanvasRenderingContext2D): void;
+  clip(ctx: CanvasRenderingContext2D): void;
 }
 
 export const useCanvasContext: () => CanvasContextValue;

--- a/packages/victory-create-container/src/index.d.ts
+++ b/packages/victory-create-container/src/index.d.ts
@@ -11,9 +11,9 @@ export function createContainer<V, W>(
   c2: ContainerType,
 ): React.ComponentType<V & W>;
 
-export function combineContainerMixins(mixins, Container): any;
+export function combineContainerMixins(mixins: any, Container: any): any;
 
 export const makeCreateContainerFunction: (
-  mixinMap,
-  Container,
-) => (behaviorA, behaviorB) => any;
+  mixinMap: any,
+  Container: any,
+) => (behaviorA: any, behaviorB: any) => any;

--- a/packages/victory-selection-container/src/index.d.ts
+++ b/packages/victory-selection-container/src/index.d.ts
@@ -29,13 +29,13 @@ export class VictorySelectionContainer extends React.Component<
 > {}
 
 export const SelectionHelpers: {
-  getDimension(props): any;
-  getDatasets(props): any;
-  filterDatasets(props, datasets, bounds): any;
-  getSelectedData(props, dataset): any;
-  onMouseDown(evt, targetProps): any;
-  onMouseMove(evt, targetProps): any;
-  onMouseUp(evt, targetProps): any;
+  getDimension(props: any): any;
+  getDatasets(props: any): any;
+  filterDatasets(props: any, datasets: any, bounds: any): any;
+  getSelectedData(props: any, dataset: any): any;
+  onMouseDown(evt: any, targetProps: any): any;
+  onMouseMove(evt: any, targetProps: any): any;
+  onMouseUp(evt: any, targetProps: any): any;
 };
 
 export const selectionContainerMixin: (base: Function) => Function;

--- a/packages/victory-voronoi-container/src/index.d.ts
+++ b/packages/victory-voronoi-container/src/index.d.ts
@@ -22,18 +22,23 @@ export class VictoryVoronoiContainer extends React.Component<
 > {}
 
 export const VoronoiHelpers: {
-  withinBounds(props, point): any;
-  getDatasets(props): any;
-  findPoints(datasets, point): any;
-  withinRadius(point, mousePosition, radius): any;
-  getVoronoiPoints(props, mousePosition): any;
-  getActiveMutations(props, point): any;
-  getInactiveMutations(props, point): any;
-  getParentMutation(activePoints, mousePosition, parentSVG, vIndex): any;
-  onActivated(props, points): any;
-  onDeactivated(props, points): any;
-  onMouseLeave(evt, targetProps): any;
-  onMouseMove(evt, targetProps): any;
+  withinBounds(props: any, point: any): any;
+  getDatasets(props: any): any;
+  findPoints(datasets: any, point: any): any;
+  withinRadius(point: any, mousePosition: any, radius: any): any;
+  getVoronoiPoints(props: any, mousePosition: any): any;
+  getActiveMutations(props: any, point: any): any;
+  getInactiveMutations(props: any, point: any): any;
+  getParentMutation(
+    activePoints: any,
+    mousePosition: any,
+    parentSVG: any,
+    vIndex: any,
+  ): any;
+  onActivated(props: any, points: any): any;
+  onDeactivated(props: any, points: any): any;
+  onMouseLeave(evt: any, targetProps: any): any;
+  onMouseMove(evt: any, targetProps: any): any;
 };
 
 export const voronoiContainerMixin: (base: Function) => Function;

--- a/packages/victory-zoom-container/src/index.d.ts
+++ b/packages/victory-zoom-container/src/index.d.ts
@@ -24,24 +24,24 @@ export class VictoryZoomContainer extends React.Component<
 > {}
 
 export const RawZoomHelpers: {
-  checkDomainEquality(a, b): any;
-  scale(currentDomain, evt, props, axis): any;
-  getScaledDomain(currentDomain, factor, percent): any;
-  getMinimumDomain(point, props, axis): any;
+  checkDomainEquality(a: any, b: any): any;
+  scale(currentDomain: any, evt: any, props: any, axis: any): any;
+  getScaledDomain(currentDomain: any, factor: any, percent: any): any;
+  getMinimumDomain(point: any, props: any, axis: any): any;
   zoommingOut(evt): any;
   getScaleFactor(evt): any;
-  getScalePercent(evt, props, axis): any;
-  getPosition(evt, props, originalDomain): any;
-  pan(currentDomain, originalDomain, delta): any;
-  getDomainScale(domain, scale, axis): any;
+  getScalePercent(evt: any, props: any, axis: any): any;
+  getPosition(evt: any, props: any, originalDomain: any): any;
+  pan(currentDomain: any, originalDomain: any, delta: any): any;
+  getDomainScale(domain: any, scale: any, axis: any): any;
   handleAnimation(ctx): any;
-  getLastDomain(targetProps, originalDomain): any;
+  getLastDomain(targetProps: any, originalDomain: any): any;
   getDomain(props): any;
-  onMouseDown(evt, targetProps): any;
-  onMouseUp(evt, targetProps): any;
-  onMouseLeave(evt, targetProps): any;
-  onMouseMove(evt, targetProps, eventKey, ctx): any;
-  onWheel(evt, targetProps, eventKey, ctx): any;
+  onMouseDown(evt: any, targetProps: any): any;
+  onMouseUp(evt: any, targetProps: any): any;
+  onMouseLeave(evt: any, targetProps: any): any;
+  onMouseMove(evt: any, targetProps: any, eventKey: any, ctx: any): any;
+  onWheel(evt: any, targetProps: any, eventKey: any, ctx: any): any;
 };
 
 export const ZoomHelpers: Pick<


### PR DESCRIPTION
# The Problem

In https://github.com/FormidableLabs/victory/commit/5a4fc5be26f3b04e3d335625e72df5482d1150b8 I added several missing types to our `index.d.ts` files.  I added these with implicit `any` parameters.

Since these `.d.ts` files get **copied**, not **compiled**, they don't automatically get explicit `:any` types.
This caused #2358 for consumers who have "no implicit any" configurations.

# The Fix
This PR adds explicit `:any` types to all these parameters.

I considered adding "good" types for these methods. But since all these types will eventually be made obsolete once we convert these packages to TypeScript, it makes more sense to just add `:any` here for now, and allow the TS migration to handle improved types.

