### PR TITLE
Fix (TypeScript): give `datum` an `any` type

### DIFF
--- a/.changeset/quiet-dogs-serve.md
+++ b/.changeset/quiet-dogs-serve.md
@@ -1,0 +1,34 @@
+---
+"victory-core": patch
+"victory": patch
+"victory-area": patch
+"victory-axis": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-brush-container": patch
+"victory-brush-line": patch
+"victory-candlestick": patch
+"victory-canvas": patch
+"victory-chart": patch
+"victory-create-container": patch
+"victory-cursor-container": patch
+"victory-errorbar": patch
+"victory-group": patch
+"victory-histogram": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-native": patch
+"victory-pie": patch
+"victory-polar-axis": patch
+"victory-scatter": patch
+"victory-selection-container": patch
+"victory-shared-events": patch
+"victory-stack": patch
+"victory-tooltip": patch
+"victory-vendor": patch
+"victory-voronoi": patch
+"victory-voronoi-container": patch
+"victory-zoom-container": patch
+---
+
+Allow data accessors to accept any data types (fixes #2360)

--- a/packages/victory-core/src/types/callbacks.ts
+++ b/packages/victory-core/src/types/callbacks.ts
@@ -51,5 +51,3 @@ export type PaddingOrCallback = number | BlockProps | VictoryPaddingCallback;
 export type OrientationOrCallback =
   | OrientationTypes
   | VictoryOrientationCallback;
-
-export type ValueOrCallback<TValue> = TValue | ((args: CallbackArgs) => TValue);

--- a/packages/victory-core/src/types/prop-types.ts
+++ b/packages/victory-core/src/types/prop-types.ts
@@ -16,7 +16,7 @@ export type DatumValue = number | string | Date | null | undefined;
 export type Datum = any;
 export type ForAxes<T> = T | { x?: T; y?: T };
 export type ID = number | string;
-export type ValueOrAccessor<ValueType = unknown, PropsType = object> =
+export type ValueOrAccessor<ValueType, PropsType> =
   | ValueType
   | ((props: PropsType) => ValueType);
 export type Tuple<T> = [T, T];
@@ -137,7 +137,8 @@ export type CategoryPropType =
     };
 
 export type DataGetterPropType = ValueOrAccessor<
-  string | string[] | number | number[]
+  string | string[] | number | number[],
+  any // The arg will be the `datum`, which can have any type
 >;
 
 export type InterpolationPropType =

--- a/packages/victory-core/src/types/prop-types.ts
+++ b/packages/victory-core/src/types/prop-types.ts
@@ -9,14 +9,14 @@ import {
   AnimationEasing,
   AnimationStyle,
 } from "../victory-animation/victory-animation";
-import { StringOrNumberOrCallback } from "./callbacks";
+import { CallbackArgs, StringOrNumberOrCallback } from "./callbacks";
 
 export type AxisType = "x" | "y";
 export type DatumValue = number | string | Date | null | undefined;
 export type Datum = any;
 export type ForAxes<T> = T | { x?: T; y?: T };
 export type ID = number | string;
-export type ValueOrAccessor<ValueType, PropsType> =
+export type ValueOrAccessor<ValueType, PropsType = CallbackArgs> =
   | ValueType
   | ((props: PropsType) => ValueType);
 export type Tuple<T> = [T, T];

--- a/packages/victory-core/src/victory-label/victory-label.tsx
+++ b/packages/victory-core/src/victory-label/victory-label.tsx
@@ -14,11 +14,12 @@ import * as Style from "../victory-util/style";
 import * as TextSize from "../victory-util/textsize";
 import * as UserProps from "../victory-util/user-props";
 import {
+  CallbackArgs,
   NumberOrCallback,
   StringOrCallback,
   StringOrNumberOrCallback,
-  ValueOrCallback,
 } from "../types/callbacks";
+import { ValueOrAccessor } from "../types/prop-types";
 import {
   PaddingProps,
   VerticalAnchorType,
@@ -56,11 +57,11 @@ export interface VictoryLabelProps {
   tabIndex?: NumberOrCallback;
   text?: string[] | StringOrNumberOrCallback;
   textComponent?: React.ReactElement;
-  textAnchor?: ValueOrCallback<TextAnchorType>;
+  textAnchor?: ValueOrAccessor<TextAnchorType, CallbackArgs>;
   title?: string;
-  transform?: ValueOrCallback<string | object>;
+  transform?: ValueOrAccessor<string | object, CallbackArgs>;
   tspanComponent?: React.ReactElement;
-  verticalAnchor?: ValueOrCallback<VerticalAnchorType>;
+  verticalAnchor?: ValueOrAccessor<VerticalAnchorType, CallbackArgs>;
   x?: number;
   y?: number;
   dx?: StringOrNumberOrCallback;

--- a/packages/victory-core/src/victory-label/victory-label.tsx
+++ b/packages/victory-core/src/victory-label/victory-label.tsx
@@ -14,7 +14,6 @@ import * as Style from "../victory-util/style";
 import * as TextSize from "../victory-util/textsize";
 import * as UserProps from "../victory-util/user-props";
 import {
-  CallbackArgs,
   NumberOrCallback,
   StringOrCallback,
   StringOrNumberOrCallback,
@@ -57,11 +56,11 @@ export interface VictoryLabelProps {
   tabIndex?: NumberOrCallback;
   text?: string[] | StringOrNumberOrCallback;
   textComponent?: React.ReactElement;
-  textAnchor?: ValueOrAccessor<TextAnchorType, CallbackArgs>;
+  textAnchor?: ValueOrAccessor<TextAnchorType>;
   title?: string;
-  transform?: ValueOrAccessor<string | object, CallbackArgs>;
+  transform?: ValueOrAccessor<string | object>;
   tspanComponent?: React.ReactElement;
-  verticalAnchor?: ValueOrAccessor<VerticalAnchorType, CallbackArgs>;
+  verticalAnchor?: ValueOrAccessor<VerticalAnchorType>;
   x?: number;
   y?: number;
   dx?: StringOrNumberOrCallback;

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-use-before-define */
 import React from "react";
 import { defaults, isFunction, property, pick, assign, keys } from "lodash";
-import { CallbackArgs, ValueOrCallback } from "../types/callbacks";
+import { CallbackArgs } from "../types/callbacks";
+import { ValueOrAccessor } from "../types/prop-types";
 
 // Private Functions
 
@@ -128,7 +129,7 @@ export function getStyles(style, defaultStyles) {
 }
 
 export function evaluateProp<TValue>(
-  prop: ValueOrCallback<TValue>,
+  prop: ValueOrAccessor<TValue, CallbackArgs>,
   props: CallbackArgs,
 ): TValue {
   return isFunction(prop) ? prop(props) : prop;

--- a/packages/victory-cursor-container/src/victory-cursor-container.tsx
+++ b/packages/victory-cursor-container/src/victory-cursor-container.tsx
@@ -8,7 +8,7 @@ import {
   VictoryContainerProps,
   CoordinatesPropType,
   VictoryLabelProps,
-  ValueOrCallback,
+  ValueOrAccessor,
 } from "victory-core";
 import { defaults, assign, isObject } from "lodash";
 import { CursorHelpers } from "./cursor-helpers";
@@ -18,7 +18,7 @@ export type CursorCoordinatesPropType = CoordinatesPropType | number;
 export interface VictoryCursorContainerProps extends VictoryContainerProps {
   cursorComponent?: React.ReactElement;
   cursorDimension?: "x" | "y";
-  cursorLabel?: ValueOrCallback<VictoryLabelProps["text"]>;
+  cursorLabel?: ValueOrAccessor<VictoryLabelProps["text"]>;
   cursorLabelComponent?: React.ReactElement;
   cursorLabelOffset?: CursorCoordinatesPropType;
   defaultCursorValue?: CursorCoordinatesPropType;


### PR DESCRIPTION
# What

The common props `x`, `y`, `y0`, and `sortKey` allow for "accessor" functions, like:
```
<VictoryLine
  data={data}
  x = {(datum) => datum.xValue}
  y = {(datum) => datum.yValue}
/>
```
Currently, we have the `datum` arg typed as `object`, which doesn't allow for any property access nor strong types (see #2360).

This PR allows for the type to be `any`.  This seems like the best approach, since we currently don't know the shape of Datum, nor do we support generics with any of our components.
This will allow the above code to function properly, as well as support manually-added types (like `(datum: MyData) => datum.xValue`).