### PR TITLE
TS: Fixed the exported types for all containers

### DIFF
--- a/.changeset/swift-singers-reply.md
+++ b/.changeset/swift-singers-reply.md
@@ -1,0 +1,9 @@
+---
+"victory-brush-container": patch
+"victory-cursor-container": patch
+"victory-selection-container": patch
+"victory-voronoi-container": patch
+"victory-zoom-container": patch
+---
+
+Improved the exported types (fixes #2451)

--- a/packages/victory-brush-container/src/victory-brush-container.tsx
+++ b/packages/victory-brush-container/src/victory-brush-container.tsx
@@ -236,3 +236,4 @@ export const brushContainerMixin = <TBase extends Constructor>(base: TBase) =>
   };
 
 export const VictoryBrushContainer = brushContainerMixin(VictoryContainer);
+export type VictoryBrushContainer = typeof VictoryBrushContainer;

--- a/packages/victory-cursor-container/src/victory-cursor-container.tsx
+++ b/packages/victory-cursor-container/src/victory-cursor-container.tsx
@@ -234,3 +234,4 @@ export function cursorContainerMixin<
 }
 
 export const VictoryCursorContainer = cursorContainerMixin(VictoryContainer);
+export type VictoryCursorContainer = typeof VictoryCursorContainer;

--- a/packages/victory-selection-container/src/victory-selection-container.js
+++ b/packages/victory-selection-container/src/victory-selection-container.js
@@ -96,3 +96,6 @@ export const selectionContainerMixin = (base) =>
   };
 
 export default selectionContainerMixin(VictoryContainer);
+// @ts-expect-error IMPORTANT: when converting this file to TypeScript, you must export the type as well:
+// export const VictorySelectionContainer = selectionContainerMixin(VictoryContainer);
+// export type VictorySelectionContainer = typeof VictorySelectionContainer;

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.js
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.js
@@ -244,3 +244,6 @@ export const voronoiContainerMixin = (base) =>
   };
 
 export default voronoiContainerMixin(VictoryContainer);
+// @ts-expect-error IMPORTANT: when converting this file to TypeScript, you must export the type as well:
+// export const VictoryVoronoiContainer = voronoiContainerMixin(VictoryContainer);
+// export type VictoryVoronoiContainer = typeof VictoryVoronoiContainer;

--- a/packages/victory-zoom-container/src/victory-zoom-container.js
+++ b/packages/victory-zoom-container/src/victory-zoom-container.js
@@ -234,3 +234,6 @@ export const zoomContainerMixin = (base) =>
   };
 
 export default zoomContainerMixin(VictoryContainer);
+// @ts-expect-error IMPORTANT: when converting this file to TypeScript, you must export the type as well:
+// export const VictoryZoomContainer = zoomContainerMixin(VictoryContainer);
+// export type VictoryZoomContainer = typeof VictoryZoomContainer;


### PR DESCRIPTION
# What

Before TS conversion, we were falsely exporting a `class Victory___Container`, which serves as both a value and a type.
After TS conversion, we are now exporting just a value, `const Victory___Container = mixin(...)`, which no longer serves as a type.
This broke our `victory-native` types, since we were using it as a type.  However, this went unchecked, because we don't type-check our `.d.ts` files.

With this PR, I am now exporting both the value and the type. 
I have also left some comments in some JS files where this problem will occur once converting to TS.

Addresses #2451