### PR TITLE
Docs: fix typos and grammatical errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Note that Chromatic internally runs `npm run build-storybook` around which we ha
 
 We use [changesets](https://github.com/changesets/changesets) to create package versions and publish them.
 
-### Using changsets
+### Using changesets
 
 Our official release path is to use automation to perform the actual publishing of our packages. The steps are to:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Projects using Victory should also depend on [React][]. Victory works with React
 
 ## Victory Native
 
-Victory Native shares most of its code with Victory, and has a nearly identical API! To learn more, check out the [Victory Native package REAMDE](./packages/victory-native/README.md).
+Victory Native shares most of its code with Victory, and has a nearly identical API! To learn more, check out the [Victory Native package README](./packages/victory-native/README.md).
 
 ## Contributing
 Please see the [Contributing guide](CONTRIBUTING.md).

--- a/docs/src/content/common-props/common-props.md
+++ b/docs/src/content/common-props/common-props.md
@@ -15,7 +15,7 @@ scope:
 
 Not every component uses all of these props. These are all common to things like `VictoryBar`, `VictoryScatter`, but other components like `VictoryStack` use only some of them.
 
-The props explanations given here are general. Each component docs page should be considered as the the source of truth for a component's props, and any caveats will be listed there.
+The props explanations given here are general. Each component docs page should be considered as the source of truth for a component's props, and any caveats will be listed there.
 
 ## animate
 
@@ -292,7 +292,7 @@ ReactDOM.render(<CustomStyledBarChart/>, mountNode);
 
 `type: array[low, high] || { x: [low, high], y: [low, high] }`
 
-The `domain` prop describes the range of data the component will include. This prop can be given as a array of the minimum and maximum expected values of the data or as an object that specifies separate arrays for x and y. If this prop is not provided, a domain will be calculated from data, or other available information.
+The `domain` prop describes the range of data the component will include. This prop can be given as an array of the minimum and maximum expected values of the data or as an object that specifies separate arrays for x and y. If this prop is not provided, a domain will be calculated from data, or other available information.
 
 _note:_ The `x` value supplied to the `domain` prop refers to the _independent_ variable, and the `y` value refers to the _dependent_ variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to the y axis.
 
@@ -350,7 +350,7 @@ Identifying properties include:
 
 - `childName`: the name of the component the event should be attached to. When events are specified in `VictorySharedEvents` or on a component that renders several Victory components as children (_i.e._ `VictoryChart`, `VictoryGroup`, `VictoryStack`), it is necessary to specify which child events should apply to. The given `childName` should match the `name` prop of a child component. This identifier can be given as a string, an array of strings, or as "all".
 
-- `target`: the type of element the event should be attached to. Valid targets for most Victory components will be `"parent"`, `"data"`, and `"labels"`. Events with the "parent" target will be attached to to the top level svg. Events with `"data"` and `"labels"` targets will be attached to `dataComponent` and `labelComponent` elements respectively. Some components, like `VictoryAxis` use non-standard targets like `"grid"`. Refer to individual API docs for additional caveats.
+- `target`: the type of element the event should be attached to. Valid targets for most Victory components will be `"parent"`, `"data"`, and `"labels"`. Events with the "parent" target will be attached to the top level svg. Events with `"data"` and `"labels"` targets will be attached to `dataComponent` and `labelComponent` elements respectively. Some components, like `VictoryAxis` use non-standard targets like `"grid"`. Refer to individual API docs for additional caveats.
 
 - `eventKey`: the specific element to be targeted. Events may be attached to specific elements by `eventKey`. By default, `eventKey` corresponds to the index in the `data` array (or `tickValues` array) corresponding to a rendered element. This value may be given as a single string or number, an array of strings or numbers, or as "all". It is not typically necessary to specify an individual `eventKey` for attaching events. When no `eventKey` is given, events will be attached to all elements that match a given `childName` and `target`. Some components like `VictoryArea` and `VictoryLine` render only a single element for an entire series of data. For these, the `eventKey` should be "all".
 
@@ -880,7 +880,7 @@ _default:_ `sortOrder="ascending"`
 
 `type: boolean`
 
-The `standalone` props specifies whether the component should be rendered in a independent `<svg>` element or in a `<g>` tag. This prop defaults to true, and renders an `svg`, however, wrapper components like `VictoryChart`, `VictoryStack`, and `VictoryGroup` force children to use `standalone={false}`.
+The `standalone` props specifies whether the component should be rendered in an independent `<svg>` element or in a `<g>` tag. This prop defaults to true, and renders an `svg`, however, wrapper components like `VictoryChart`, `VictoryStack`, and `VictoryGroup` force children to use `standalone={false}`.
 
 _default:_ `standalone={true}`
 
@@ -923,7 +923,7 @@ _note_ The `style` prop used by `VictoryAxis` has a different format than the st
 
 _note_ When a component is rendered as a child of another Victory component, or within a custom `<svg>` element with `standalone={false}` parent styles will be applied to the enclosing `<g>` tag. Many styles that can be applied to a parent `<svg>` will not be expressed when applied to a `<g>`.
 
-_note_ custom `angle` and `verticalAnchor` properties maybe included in labels styles.
+_note_ custom `angle` and `verticalAnchor` properties may be included in labels styles.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-area.md
+++ b/docs/src/content/docs/victory-area.md
@@ -439,7 +439,7 @@ _default:_ `standalone={true}`
 
 `VictoryArea` uses the standard `style` prop. [Read about it here](/docs/common-props#style)
 
-*note:* Since `VictoryArea` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of individual `datum`. Instead, try using [gradient fills](/docs/faq/#how-can-i-use-gradient-fills-in-victory) for styling continuous data.
+*note:* Since `VictoryArea` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of an individual `datum`. Instead, try using [gradient fills](/docs/faq/#how-can-i-use-gradient-fills-in-victory) for styling continuous data.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-axis.md
+++ b/docs/src/content/docs/victory-axis.md
@@ -72,7 +72,7 @@ axisLabelComponent={<VictoryLabel dy={20}/>}
 
 ## axisValue
 
-The `axisValue` prop may be used to position the dependent axis. Ths prop is useful when dependent axes should line up with values on the independent axis.
+The `axisValue` prop may be used to position the dependent axis. This prop is useful when dependent axes should line up with values on the independent axis.
 
 ```playground
  <VictoryChart>

--- a/docs/src/content/docs/victory-boxplot.md
+++ b/docs/src/content/docs/victory-boxplot.md
@@ -113,7 +113,7 @@ data={[
 ```
 
 - As an array of data objects with pre-calculated summary statistics(`min`, `median`, `max`, `q1`, `q3`)
-  When given in this format, `VictoryBoxPlot` _will not_ preform statistical analysis. Pre-calculating summary statistics for large datasets will improve performance.
+  When given in this format, `VictoryBoxPlot` _will not_ perform statistical analysis. Pre-calculating summary statistics for large datasets will improve performance.
 
 ```jsx
 data={[

--- a/docs/src/content/docs/victory-brush-container.md
+++ b/docs/src/content/docs/victory-brush-container.md
@@ -119,7 +119,7 @@ _default:_ `brushComponent={<rect/>}`
 
 `type: "x" || "y"`
 
-When the `brushDimension` prop is set, brushing will only be specific to the to the given dimension
+When the `brushDimension` prop is set, brushing will only be specific to the given dimension
 (either "x" or "y"), and the entire domain of the other dimension will be highlighted. When this prop
 is not specified, highlighting will occur along both dimensions.
 
@@ -206,7 +206,7 @@ _default:_ `handleWidth={8}`
 
 `type: function`
 
-The optional `onBrushCleared` prop accepts an function to be called when tha active brush area is cleared. The function accepts the parameters of `domain` (the updated domain), and `props` (the props used by `VictoryBrushContainer`).
+The optional `onBrushCleared` prop accepts a function to be called when the active brush area is cleared. The function accepts the parameters of `domain` (the updated domain), and `props` (the props used by `VictoryBrushContainer`).
 
 _example:_ `onBrushCleared={(domain, props) => handleBrushCleared(domain, props)}`
 
@@ -214,7 +214,7 @@ _example:_ `onBrushCleared={(domain, props) => handleBrushCleared(domain, props)
 
 `type: function`
 
-The optional `onBrushDomainChange` prop accepts an function to be called on each update to the highlighted domain. The function accepts the parameters of `domain` (the updated domain), and `props` (the props used by `VictoryBrushContainer`).
+The optional `onBrushDomainChange` prop accepts a function to be called on each update to the highlighted domain. The function accepts the parameters of `domain` (the updated domain), and `props` (the props used by `VictoryBrushContainer`).
 
 _example:_ `onBrushDomainChange={(domain, props) => handleDomainChange(domain, props)}`
 
@@ -222,7 +222,7 @@ _example:_ `onBrushDomainChange={(domain, props) => handleDomainChange(domain, p
 
 `type: function`
 
-The optional `onBrushDomainChangeEnd` prop accepts an function to be called only on mouse up events. The function accepts the parameters of `domain` (the updated domain), and `props` (the props used by `VictoryBrushContainer`).
+The optional `onBrushDomainChangeEnd` prop accepts a function to be called only on mouse up events. The function accepts the parameters of `domain` (the updated domain), and `props` (the props used by `VictoryBrushContainer`).
 
 _example:_ `onBrushDomainChangeEnd={(domain, props) => handleDomainChangeEnd(domain, props)}`
 

--- a/docs/src/content/docs/victory-brush-line.md
+++ b/docs/src/content/docs/victory-brush-line.md
@@ -79,7 +79,7 @@ The `brushAreaWidth` prop is used to specify the width of the interactive brush 
 
 `type: element`
 
-The `brushComponent` prop specifies the component to be rendered for active brush.
+The `brushComponent` prop specifies the component to be rendered for the active brush.
 This component will be supplied with the following props: x, y, width, height, and style.
 When this prop is not specified, a [`Box`][] component will be rendered.
 

--- a/docs/src/content/docs/victory-candlestick.md
+++ b/docs/src/content/docs/victory-candlestick.md
@@ -543,15 +543,15 @@ Use `open` data accessor prop to define the open value of a candle.
 
 _examples:_ `open="opening_value"`
 
-**function:** use a function to translate each element in a data array into a open value
+**function:** use a function to translate each element in a data array into an open value
 
 _examples:_ `open={() => 10}`
 
-**array index:** specify which index of an array should be used as a open value when data is given as an array of arrays
+**array index:** specify which index of an array should be used as an open value when data is given as an array of arrays
 
 _examples:_ `open={1}`
 
-**path string or path array:** specify which property in an array of nested data objects should be used as a open value
+**path string or path array:** specify which property in an array of nested data objects should be used as an open value
 
 _examples:_ `open="bonds.open"`, `open={["bonds", "open"]}`
 

--- a/docs/src/content/docs/victory-chart.md
+++ b/docs/src/content/docs/victory-chart.md
@@ -49,7 +49,7 @@ animate={{
 
 `type: element`
 
-The `backgroundComponent` prop takes a component instance which will be responsible for rendering a background if the `VictoryChart`'s `style` component includes `background` styles. The new element created from the passed `backgroundComponent` will be provided with the following properties calculated by `VictoryChart`: `height`, `polar`, `scale`, `style`, `x`, `y`, `width`. All of these props on `Background` should take prececence over what `VictoryChart` is trying to set.
+The `backgroundComponent` prop takes a component instance which will be responsible for rendering a background if the `VictoryChart`'s `style` component includes `background` styles. The new element created from the passed `backgroundComponent` will be provided with the following properties calculated by `VictoryChart`: `height`, `polar`, `scale`, `style`, `x`, `y`, `width`. All of these props on `Background` should take precedence over what `VictoryChart` is trying to set.
 
 _default:_ `<Background/>`
 

--- a/docs/src/content/docs/victory-clip-container.md
+++ b/docs/src/content/docs/victory-clip-container.md
@@ -91,7 +91,7 @@ _default:_ `<g/>`
 
 `type: { x: number, y: number }`
 
-Victory components will pass an `origin` prop is to define the center point in svg coordinates for polar charts. **This prop should not be set manually.**
+Victory components will pass an `origin` prop to define the center point in svg coordinates for polar charts. **This prop should not be set manually.**
 
 ## polar
 

--- a/docs/src/content/docs/victory-errorbar.md
+++ b/docs/src/content/docs/victory-errorbar.md
@@ -147,7 +147,7 @@ _examples:_ `errorX={() => 10}`
 
 _examples:_ `errorX={1}`
 
-**path string or path array:** specify which property in an array of nested data objects should be used as a errorX value
+**path string or path array:** specify which property in an array of nested data objects should be used as an errorX value
 
 _examples:_ `errorX="measurement.uncertainty"`, `errorX={["measurement", "uncertainty"]}`
 
@@ -161,15 +161,15 @@ Use `errorY` data accessor prop to define the y error bar.
 
 _examples:_ `errorY="uncertainty"`
 
-**function:** use a function to translate each element in a data array into a errorY value
+**function:** use a function to translate each element in a data array into an errorY value
 
 _examples:_ `errorY={() => 10}`
 
-**array index:** specify which index of an array should be used as a errorY value when data is given as an array of arrays
+**array index:** specify which index of an array should be used as an errorY value when data is given as an array of arrays
 
 _examples:_ `errorY={1}`
 
-**path string or path array:** specify which property in an array of nested data objects should be used as a errorY value
+**path string or path array:** specify which property in an array of nested data objects should be used as an errorY value
 
 _examples:_ `errorY="measurement.uncertainty"`, `errorY={["measurement", "uncertainty"]}`
 

--- a/docs/src/content/docs/victory-group.md
+++ b/docs/src/content/docs/victory-group.md
@@ -310,7 +310,7 @@ name = "series-1";
 
 `type: number`
 
-The `offset` prop determines the number of pixels each element in a group should be offset from its original position the on the independent axis. In the case of groups of bars, this number should be equal to the width of the bar plus the desired spacing between bars.
+The `offset` prop determines the number of pixels each element in a group should be offset from its original position on the independent axis. In the case of groups of bars, this number should be equal to the width of the bar plus the desired spacing between bars.
 
 ```playground
 <VictoryGroup

--- a/docs/src/content/docs/victory-group.md
+++ b/docs/src/content/docs/victory-group.md
@@ -310,7 +310,7 @@ name = "series-1";
 
 `type: number`
 
-The `offset` prop determines the number of pixels each element in a group should be offset from its original position of the on the independent axis. In the case of groups of bars, this number should be equal to the width of the bar plus the desired spacing between bars.
+The `offset` prop determines the number of pixels each element in a group should be offset from its original position the on the independent axis. In the case of groups of bars, this number should be equal to the width of the bar plus the desired spacing between bars.
 
 ```playground
 <VictoryGroup

--- a/docs/src/content/docs/victory-histogram.md
+++ b/docs/src/content/docs/victory-histogram.md
@@ -174,7 +174,7 @@ The `cornerRadius` prop specifies a radius to apply to each bar. If this prop is
 
 `type: array[object]`
 
-`VictoryHistogram` uses the standard `data` prop, except for it only expects each object within the array to have `x` properties. The `x` data accessor prop can be used to defined a custom data format. [Read about it here](/docs/common-props#data)
+`VictoryHistogram` uses the standard `data` prop, except for it only expects each object within the array to have `x` properties. The `x` data accessor prop can be used to define a custom data format. [Read about it here](/docs/common-props#data)
 
 Because each bar represents a bin rather than a particular data point (like with `VictoryScatter` for example), when accessing `datum` via a prop that passes `datum` such as `style`, datum will have properties `x`, `x0`, `x1`, `y`, and `binnedData`. `x` is the midpoint between the bin, `x0` is the beginning of the bin, `x1` is the end of the bin, `y` is the aggregate amount of data points within that bin, and `binnedData` is an array of the original data points that were grouped into this bin.
 

--- a/docs/src/content/docs/victory-label.md
+++ b/docs/src/content/docs/victory-label.md
@@ -244,7 +244,7 @@ _default:_ `false`
 
 `type: "parallel" || "perpendicular" || "vertical"`
 
-The `labelPlacement` prop is used to specify the placement of labels relative to the data point they represent. This prop may be given as "vertical", "parallel" or "perpendicular". This props is particularly useful in polar charts, where it may be desireable to position a label either parallel or perpendicular to its corresponding angle. When this prop is not set, perpendicular label placement will be used for polar charts, and vertical label placement will be used for cartesian charts.
+The `labelPlacement` prop is used to specify the placement of labels relative to the data point they represent. This prop may be given as "vertical", "parallel" or "perpendicular". This props is particularly useful in polar charts, where it may be desirable to position a label either parallel or perpendicular to its corresponding angle. When this prop is not set, perpendicular label placement will be used for polar charts, and vertical label placement will be used for cartesian charts.
 
 ## lineHeight
 

--- a/docs/src/content/docs/victory-legend.md
+++ b/docs/src/content/docs/victory-legend.md
@@ -429,7 +429,7 @@ _default:_ `<VictoryLabel/>`
 
 `type: "top" || "bottom" || "left" || "right"`
 
-The `titleOrientation` prop specifies where the a title should be rendered in relation to the rest of the legend. Possible values for this prop are "top", "bottom", "left", and "right".
+The `titleOrientation` prop specifies where the title should be rendered in relation to the rest of the legend. Possible values for this prop are "top", "bottom", "left", and "right".
 
 _default (provided by default theme):_ `titleOrientation="top"`
 

--- a/docs/src/content/docs/victory-line.md
+++ b/docs/src/content/docs/victory-line.md
@@ -467,7 +467,7 @@ _default:_ `standalone={true}`
 
 `VictoryLine` uses the standard `style` prop. [Read about it here](/docs/common-props#style)
 
-*note:* Since `VictoryLine` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of individual `datum`. Instead, try using [gradient fills](/docs/faq/#how-can-i-use-gradient-fills-in-victory) for styling continuous data.
+*note:* Since `VictoryLine` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of an individual `datum`. Instead, try using [gradient fills](/docs/faq/#how-can-i-use-gradient-fills-in-victory) for styling continuous data.
 
 _default (provided by default theme):_ See [grayscale theme][] for more detail
 

--- a/docs/src/content/docs/victory-polar-axis.md
+++ b/docs/src/content/docs/victory-polar-axis.md
@@ -88,7 +88,7 @@ axisLabelComponent={<VictoryLabel dy={20}/>}
 
 `type: number`
 
-The `axisValue` prop may be used instead of `axisAngle` to position the dependent axis. Ths prop is useful when dependent axes should line up with values on the independent axis.
+The `axisValue` prop may be used instead of `axisAngle` to position the dependent axis. This prop is useful when dependent axes should line up with values on the independent axis.
 
 ```playground
  <VictoryChart polar

--- a/docs/src/content/docs/victory-primitives.md
+++ b/docs/src/content/docs/victory-primitives.md
@@ -413,7 +413,7 @@ _note_ `Box` also exported as `Border`
 - `shapeRendering` _string_ the shape rendering attribute to apply to the rendered path
 - `slice` _object_ an object specifying the startAngle, endAngle, padAngle, and data of the slice
 - `sliceEndAngle` _number or function_ the end angle the slice. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
-- `sliceStartAngle` _number or function_ the start angle the slice. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
+- `sliceStartAngle` _number or function_ the start angle of the slice. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
 - `style` _object_ the styles to apply to the rendered element
 - `tabIndex` _number or function_ number will be applied to the rendered path. When this prop is given as a function it will be called with the rest of the props supplied to `Slice`.
 - `transform` _string_ a transform that will be supplied to elements this component renders

--- a/docs/src/content/docs/victory-selection-container.md
+++ b/docs/src/content/docs/victory-selection-container.md
@@ -11,7 +11,7 @@ scope: null
 `VictorySelectionContainer` is used to enable selecting data points within a highlighted region.
 Clicking and dragging will select an x-y region, and add the `active` prop to any elements
 corresponding to data points within the region. Create a select-box control by tying the set of
-selected data points to other elements, such as filtered table.
+selected data points to other elements, such as a filtered table.
 
 `VictorySelectionContainer` is similar to `VictoryBrushContainer`. `VictoryBrushContainer` may be
 used to identify the domain of a selected region, whereas `VictorySelectionContainer` may be used to

--- a/docs/src/content/docs/victory-tooltip.md
+++ b/docs/src/content/docs/victory-tooltip.md
@@ -88,7 +88,7 @@ The `constrainToVisibleArea` prop determines whether to coerce tooltips so that 
 
 `type: number || function`
 
-The `cornerRadius` prop determines corner radius of the flyout container. This prop may be given as a positive number or a function of datum.
+The `cornerRadius` prop determines the corner radius of the flyout container. This prop may be given as a positive number or a function of datum.
 
 ```playground
 <VictoryBar
@@ -127,7 +127,7 @@ The `dy` prop defines a vertical shift from the `y` coordinate.
 
 `type: object`
 
-The `events` prop attaches arbitrary event handlers to the label component. This prop should be given as an object of event names and corresponding event handlers. When events are provided via Victory's event system, event handlers will be called with the event, the props of the component is attached to, and an eventKey.
+The `events` prop attaches arbitrary event handlers to the label component. This prop should be given as an object of event names and corresponding event handlers. When events are provided via Victory's event system, event handlers will be called with the event, the props of the component it is attached to, and an eventKey.
 
 _examples:_ `events={{onClick: (evt) => alert("x: " + evt.clientX)}}`
 

--- a/docs/src/content/docs/victory-voronoi-container.md
+++ b/docs/src/content/docs/victory-voronoi-container.md
@@ -66,7 +66,7 @@ When the `disable` prop is set to `true`, `VictoryVoronoiContainer` events will 
 
 When a `labels` prop is provided to `VictoryVoronoiContainer` it will render a label component
 rather than activating labels on the child components it renders. This is useful for creating multi-
-point tooltips. This prop should be given as a function which will be called once for each active point. The `labels` function will be called with the the props that correspond to the active label.
+point tooltips. This prop should be given as a function which will be called once for each active point. The `labels` function will be called with the props that correspond to the active label.
 
 _example:_ `labels={({ datum }) => "y: " + datum.y}`
 
@@ -165,7 +165,7 @@ _example:_ `radius={25}`
 
 `type: array[string]`
 
-The `voronoiBlacklist` prop is used to specify a list of components to ignore when calculating a shared voronoi diagram. Components with a `name` prop matching an element in the `voronoiBlacklist` array will be ignored by `VictoryVoronoiContainer`. Ignored components will never be flagged as active, and will not contribute date to shared tooltips or labels.
+The `voronoiBlacklist` prop is used to specify a list of components to ignore when calculating a shared voronoi diagram. Components with a `name` prop matching an element in the `voronoiBlacklist` array will be ignored by `VictoryVoronoiContainer`. Ignored components will never be flagged as active, and will not contribute data to shared tooltips or labels.
 
 _example:_ `voronoiBlacklist={["redPoints"]}`
 
@@ -199,7 +199,7 @@ _example:_ `voronoiBlacklist={["redPoints"]}`
 When the `voronoiDimension` prop is set, voronoi selection will only take the given dimension into account.
 For example, when `dimension` is set to "x", all data points matching a particular x mouse position
 will be activated regardless of y value. When this prop is not given, voronoi selection is
-determined by both x any y values.
+determined by both x and y values.
 
 _example:_ `voronoiDimension="x"`
 

--- a/docs/src/content/docs/victory-zoom-container.md
+++ b/docs/src/content/docs/victory-zoom-container.md
@@ -64,7 +64,7 @@ When the `disable` prop is set to `true`, `VictoryZoomContainer` events will not
 
 `type: number || boolean`
 
-The `downsample` prop limits the number of points that will be displayed. This prop may be given as a boolean or a number corresponding to maximum number of points. When given as a boolean, the maximum number of points that will be plotted is 150.
+The `downsample` prop limits the number of points that will be displayed. This prop may be given as a boolean or a number corresponding to the maximum number of points. When given as a boolean, the maximum number of points that will be plotted is 150.
 
 ## minimumZoom
 
@@ -83,7 +83,7 @@ _example:_ `minimumZoom={{x: 1, y: 0.01}}`
 
 `type: function`
 
-The optional `onZoomDomainChange` prop accepts an function to be called on each update to the visible domain. The function accepts the parameters `domain` (the updated domain) and `props` (the props used by `VictoryZoomContainer`).
+The optional `onZoomDomainChange` prop accepts a function to be called on each update to the visible domain. The function accepts the parameters `domain` (the updated domain) and `props` (the props used by `VictoryZoomContainer`).
 
 _example:_ `onZoomDomainChange={(domain, props) => handleDomainChange(domain, props)}`
 

--- a/docs/src/content/faq/faq.md
+++ b/docs/src/content/faq/faq.md
@@ -103,7 +103,7 @@ Create a gradient def as usual and then reference it by id in your style object.
 
 ### How can I add arbitrary labels to my charts?
 
-Use `VictoryLabel` to as a child of `VictoryChart` to add arbitrary labels. Labels can be positioned with the `x` and `y` props, or with `datum` when used within `VictoryChart` or `VictoryGroup`.
+Use `VictoryLabel` as a child of `VictoryChart` to add arbitrary labels. Labels can be positioned with the `x` and `y` props, or with `datum` when used within `VictoryChart` or `VictoryGroup`.
 
 ```playground
 <VictoryChart domain={[0, 10]}>
@@ -119,7 +119,7 @@ Use `VictoryLabel` to as a child of `VictoryChart` to add arbitrary labels. Labe
 
 ### How can I annotate my charts with lines and markers?
 
-Victory doesn't have specific components for annotations. Instead, use standard component such as `VictoryLine` and `VictoryScatter` to add lines and markers to your chart.
+Victory doesn't have specific components for annotations. Instead, use standard components such as `VictoryLine` and `VictoryScatter` to add lines and markers to your chart.
 
 ```playground
 <VictoryChart domain={[0, 10]}>
@@ -306,7 +306,7 @@ To solve this, you will need to manually set sensible defaults on the `domain` o
 
 ### How can I add tooltips to a line?
 
-`VictoryLine` only renders a single element to represent an entire dataset, so replacing its `labelComponent` with `VictoryTooltip` wont work as expected, since there will be only a single event trigger. Voronoi tooltips can be used to add tooltips and other interactions components without unique event triggers, or with event triggers that are too small, or too close together to be useful. Use `VictoryVoronoiContainer` to associate mouse position with the nearest data points. [Read more about Voronoi Tooltips](/guides/tooltips#tooltips-with-victoryvoronoicontainer) and [`VictoryVoronoiContainer`](/docs/victory-voronoi-container).
+`VictoryLine` only renders a single element to represent an entire dataset, so replacing its `labelComponent` with `VictoryTooltip` won't work as expected, since there will be only a single event trigger. Voronoi tooltips can be used to add tooltips and other interactions to components without unique event triggers, or with event triggers that are too small, or too close together to be useful. Use `VictoryVoronoiContainer` to associate mouse position with the nearest data points. [Read more about Voronoi Tooltips](/guides/tooltips#tooltips-with-victoryvoronoicontainer) and [`VictoryVoronoiContainer`](/docs/victory-voronoi-container).
 
 
 ### How can I add my own events when I'm using VictoryTooltip?

--- a/docs/src/content/guides/events.md
+++ b/docs/src/content/guides/events.md
@@ -264,7 +264,7 @@ _Note_ External mutations are applied to the same state object that is used to c
 
 ## Simple Events
 
-For simple events, it may be desireable to bypass Victory's event system. To do so, specify `events` props directly on primitive components rather than using the `events` prop on Victory components. The simple `events` prop should be given as an object whose properties are event names like `onClick`, and whose values are event handlers. Events specified this way will only be called with the standard event objects.
+For simple events, it may be desirable to bypass Victory's event system. To do so, specify `events` props directly on primitive components rather than using the `events` prop on Victory components. The simple `events` prop should be given as an object whose properties are event names like `onClick`, and whose values are event handlers. Events specified this way will only be called with the standard event objects.
 
 ```playground
   <VictoryBar

--- a/docs/src/content/guides/tooltips.md
+++ b/docs/src/content/guides/tooltips.md
@@ -384,7 +384,7 @@ ReactDOM.render(<App/>, mountNode);
 ```
 
 ## Victory Native
-In Victory Native tooltips are much more reliable when using `VictoryVoronoiContainer`. Using `VictoryVoronoiContainer` registers all touch events on the container itself, which mitigates interference with other chart element, which can be a problem on some platforms. Showing the closest data point with `VictoryVoronoiContainer` also increases the tap targets for the tooltip, which can otherwise be quite small. Set `VictoryVoronoiContainer` as the `containerComponent` prop on the outermost Victory component.
+In Victory Native tooltips are much more reliable when using `VictoryVoronoiContainer`. Using `VictoryVoronoiContainer` registers all touch events on the container itself, which mitigates interference with other chart elements, which can be a problem on some platforms. Showing the closest data point with `VictoryVoronoiContainer` also increases the tap targets for the tooltip, which can otherwise be quite small. Set `VictoryVoronoiContainer` as the `containerComponent` prop on the outermost Victory component.
 
 ```jsx
 <VictoryChart containerComponent={<VictoryVoronoiContainer />} >

--- a/docs/src/content/guides/zoom-large-data.md
+++ b/docs/src/content/guides/zoom-large-data.md
@@ -131,7 +131,7 @@ when the chart is zoomed out we still render all of the data points!
 
 ## Render a small sample of points
 
-There are a number of possible methods to reducing the number of visible data points rendered.
+There are a number of possible methods to reduce the number of visible data points rendered.
 We'll use the simplest method: selecting only every `k`th point, and discarding all others.
 `k` is determined simply:
 if there are 5,000 points and we only want to show 100, then `k` is 50.
@@ -238,7 +238,7 @@ ReactDOM.render(<CustomChart data={allData} maxPoints={120} />, mountNode);
 
 ## Extending this Demo
 
-This guide serves a start, but you might have some questions:
+This guide serves as a start, but you might have some questions:
 
 * _How big should `maxPoints` be?_ For most situations between 50 and 150 is ideal.
 * _What if I want to render millions of data points?_ This concept can be extended to millions of points, but you'll need the help of a library to handle the sampling. Try [Crossfilter][].

--- a/docs/src/content/introduction/native.md
+++ b/docs/src/content/introduction/native.md
@@ -12,7 +12,7 @@ In this guide, we’ll show you how to get started with Victory Native and the R
 
 #### 1. Adding Victory Native to your React Native app
 
-Visit the [the guide on getting started](https://reactnative.dev/docs/getting-started) with React Native if you’re just getting started with React Native.
+Visit [the guide on getting started](https://reactnative.dev/docs/getting-started) with React Native if you’re just getting started with React Native.
 
 Victory Native is compatible with React Native 0.50 or higher.
 
@@ -44,9 +44,9 @@ $ react-native install react-native-svg
 
 #### 3. Using Victory Native in your React Native app
 
-Victory Native behaves and functions the same way for React Native as it does for the web. Just import components from `victory-native` to get started. To learn move about how to use Victory visit the [Getting Started Guide][].
+Victory Native behaves and functions the same way for React Native as it does for the web. Just import components from `victory-native` to get started. To learn more about how to use Victory visit the [Getting Started Guide][].
 
-The example below shows a how Victory Native easily integrates within your React Native app.
+The example below shows how Victory Native easily integrates within your React Native app.
 
 ```jsx
 import React from "react";

--- a/docs/src/content/introduction/new.md
+++ b/docs/src/content/introduction/new.md
@@ -11,11 +11,11 @@ scope:
 
 # New Features
 
-Victory is actively developed. You can read about some of our newest feature here. For more information on improvements and bug fixes, check out our [changelog](https://github.com/FormidableLabs/victory/blob/main/CHANGELOG.md).
+Victory is actively developed. You can read about some of our newest features here. For more information on improvements and bug fixes, check out our [changelog](https://github.com/FormidableLabs/victory/blob/main/CHANGELOG.md).
 
 ## Accessibility Features
 
-With improved chart and chart component accessibilty in mind, we've added a [`VictoryAccessibleGroup`](/docs/victory-accessible-group) for use with the [`groupComponent`](/docs/common-props#groupcomponent) prop. This component will wrap its children in a `g` tag with a user provided `aria-label` and optional description via the `desc` prop. Other available props can be found in the [docs](/docs/victory-accessible-group).
+With improved chart and chart component accessibility in mind, we've added a [`VictoryAccessibleGroup`](/docs/victory-accessible-group) for use with the [`groupComponent`](/docs/common-props#groupcomponent) prop. This component will wrap its children in a `g` tag with a user provided `aria-label` and optional description via the `desc` prop. Other available props can be found in the [docs](/docs/victory-accessible-group).
 
 We've also added `ariaLabel` and `tabIndex` props to all our primitives. Documentation on these can be found in under [`VictoryPrimitives`](/docs/victory-primitives#victory-primitives).
 


### PR DESCRIPTION
I used the [Grammarly extension for VS Code](https://marketplace.visualstudio.com/items?itemName=znck.grammarly&ssr=false#overview) to find issues.