### PR TITLE
VictoryLine's animate type overrides VictoryCommonProps

### DIFF
--- a/packages/victory-line/src/victory-line.tsx
+++ b/packages/victory-line/src/victory-line.tsx
@@ -150,5 +150,4 @@ export interface VictoryLineProps
   interpolation?: InterpolationPropType | Function;
   samples?: number;
   style?: VictoryStyleInterface;
-  animate?: boolean;
 }


### PR DESCRIPTION
This fixes a TypeScript error where `VictoryLine`'s `animate` type inadvertently overrides `VictoryCommonProps`. According to the  `VictoryLine` docs, the `animate` prop should accept `boolean | AnimatePropTypeInterface`.

Closes: https://github.com/FormidableLabs/victory/issues/2463