### PR TITLE
use different GitHub token for Version Packages

### DIFF
--- a/.changeset/breezy-berries-fix.md
+++ b/.changeset/breezy-berries-fix.md
@@ -1,0 +1,5 @@
+---
+"victory-zoom-container": patch
+---
+
+Test for Changesets GitHub Actions workflow fix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.VERSION_PACKAGES_TOKEN }}
 
       - name: Use Node.js
         uses: actions/setup-node@v2
@@ -54,5 +55,5 @@ jobs:
           version: pnpm run version
           publish: pnpm run publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.VERSION_PACKAGES_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,7 @@ jobs:
           version: pnpm run version
           publish: pnpm run publish
         env:
-          GITHUB_TOKEN: ${{ secrets.VERSION_PACKAGES_TOKEN }}
+          # Note: we are using a different GITHUB_TOKEN due to the issues in this thread:
+          # https://github.com/changesets/action/issues/187
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
To help resolve #2434 - I believe this [thread](https://github.com/changesets/action/issues/187) and [solution](https://github.com/changesets/action/issues/187#issuecomment-1228413850) outline a potential temporary fix.

A token was generated (details to be provided in Slack) and this has been setup in the `release.yml` workflow.

Hopefully this works and correctly runs the workflows as the `victory-ci` user without us needing to close and re-open the PR!

We will need to test this properly after a merge to review if the "Version Packages" PR that is opened runs the CI tests/suite as expected. If it does, we do not need to revert this change. If it does not, then this change has not been worthwhile in fixing this bug