### PR TITLE
Chore: added `react`  as a peer dependency to `react-native`

### DIFF
--- a/.changeset/strange-mangos-leave.md
+++ b/.changeset/strange-mangos-leave.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Added `react` as a `peerDependency` (fixes #2478)

--- a/packages/victory-native/package.json
+++ b/packages/victory-native/package.json
@@ -61,6 +61,9 @@
     "react-native-gesture-handler": "^1.10.3",
     "react-native-svg": "^12.4.3"
   },
+  "peerDependencies": {
+    "react": ">=16.6.0"
+  },
   "scripts": {
     "build": "wireit",
     "build:lib": "wireit",


### PR DESCRIPTION
# What

- Adds `react` as a peerDependency for `react-native`
- Addresses #2478 
