### PR TITLE
Typescript: victory-stack props

### DIFF
--- a/.changeset/few-owls-end.md
+++ b/.changeset/few-owls-end.md
@@ -1,0 +1,5 @@
+---
+"victory-stack": patch
+---
+
+TypeScript: Added strongly-typed props to `VictoryStack` (fixes #2449)

--- a/packages/victory-stack/src/victory-stack.tsx
+++ b/packages/victory-stack/src/victory-stack.tsx
@@ -52,7 +52,7 @@ export interface VictoryStackProps
   xOffset?: number;
 }
 
-const VictoryStackBase = (initialProps) => {
+const VictoryStackBase = (initialProps: VictoryStackProps) => {
   // eslint-disable-next-line no-use-before-define
   const { role } = VictoryStack;
   const { setAnimationState, getAnimationProps, getProps } =


### PR DESCRIPTION
# What
- Adds strong types to `victory-stack` props
- Addresses #2449 