### PR TITLE
Fix path issues when building on windows os

### DIFF
--- a/config/webpack/demo/webpack.config.dev.js
+++ b/config/webpack/demo/webpack.config.dev.js
@@ -6,8 +6,9 @@ const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
 
 const ROOT = path.resolve(__dirname, "../../.."); // eslint-disable-line no-undef
 const PKGS = path.join(ROOT, "packages")
+const VICTORY_GLOB = path.join(PKGS, "victory*/package.json").replaceAll('\\', '/');
 // Read all the victory packages and alias.
-const VICTORY_ALIASES = glob.sync(path.join(PKGS, "victory*/package.json"))
+const VICTORY_ALIASES = glob.sync(VICTORY_GLOB)
   .reduce((memo, pkgPath) => {
     const key = path.dirname(path.relative(PKGS, pkgPath));
     memo[key] = path.resolve(path.dirname(pkgPath));

--- a/packages/victory-vendor/.babelrc.js
+++ b/packages/victory-vendor/.babelrc.js
@@ -51,7 +51,7 @@ module.exports = {
             const relPathToPkg = path.relative(
               path.dirname(currentFileVendor),
               vendorPkg,
-            );
+            ).replaceAll("\\", "/");
 
             return relPathToPkg;
           }


### PR DESCRIPTION
Some of the tools used in the build process (particularly in the webpack dev server flow) fall apart when using windows-style paths, with backslashes (\\) instead of forward slashes (/).
This PR normalizes paths in the places where it affects the build, allowing `pnpm start` to fully function on windows machines, while not affecting builds on *nix systems.