### PR TITLE
Fix inaccurate text size calculations

### DIFF
--- a/.changeset/pretty-moles-laugh.md
+++ b/.changeset/pretty-moles-laugh.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+Fixes #2475: Improve accuracy of text size measurements

--- a/.changeset/pretty-moles-laugh.md
+++ b/.changeset/pretty-moles-laugh.md
@@ -2,4 +2,4 @@
 "victory-core": patch
 ---
 
-Fixes #2475: Improve accuracy of text size measurements
+Improve accuracy of text size measurements (fixes #2475)

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,7 +8,7 @@ const STORIES = path.resolve(ROOT, "stories");
 module.exports = {
   webpackFinal: async (config) => {
     // Read all the victory packages and alias.
-    glob.sync(path.join(PKGS, "victory*/package.json")).forEach((pkgPath) => {
+    glob.sync(path.join(PKGS, "victory*/package.json").replaceAll("\\", "/")).forEach((pkgPath) => {
       const key = path.dirname(path.relative(PKGS, pkgPath));
       config.resolve.alias[key] = path.resolve(path.dirname(pkgPath));
     });

--- a/packages/victory-core/src/victory-util/textsize.test.ts
+++ b/packages/victory-core/src/victory-util/textsize.test.ts
@@ -1,5 +1,8 @@
 import { TextSize } from "victory-core";
 
+const approximate = (text, style?) =>
+  TextSize._approximateTextSizeInternal.impl(text, style, true);
+
 const testString = "ABC";
 
 describe("victory-util/textsize", () => {
@@ -17,11 +20,11 @@ describe("victory-util/textsize", () => {
 
   describe("approximateWidth", () => {
     it("return zero width when no style", () => {
-      expect(TextSize.approximateTextSize(testString).width).toEqual(0);
+      expect(approximate(testString).width).toEqual(0);
     });
     it("return correct width with signed angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           angle: -45,
           fontSize: 14,
         }).width.toFixed(2),
@@ -29,28 +32,28 @@ describe("victory-util/textsize", () => {
     });
     it("return correct width with pixel fontsize", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: "14px",
         }).width.toFixed(2),
       ).toEqual("28.74");
     });
     it("return appropriate width with defined fontSize", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
         }).width.toFixed(2),
       ).toEqual("24.64");
     });
     it("consider font", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 16,
         }).width.toFixed(2),
       ).toEqual("32.85");
     });
     it("consider letterSpacing", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           letterSpacing: "1px",
         }).width.toFixed(2),
@@ -58,7 +61,7 @@ describe("victory-util/textsize", () => {
     });
     it("consider angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           angle: 30,
         }).width.toFixed(2),
@@ -66,7 +69,7 @@ describe("victory-util/textsize", () => {
     });
     it("not consider lineHeight without angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           lineHeight: 2,
         }).width.toFixed(2),
@@ -74,7 +77,7 @@ describe("victory-util/textsize", () => {
     });
     it("consider lineHeight with angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           lineHeight: 2,
           angle: 30,
@@ -83,7 +86,7 @@ describe("victory-util/textsize", () => {
     });
     it("return width of widest string in text", () => {
       expect(
-        TextSize.approximateTextSize("ABC\nDEFGH\nIJK", {
+        approximate("ABC\nDEFGH\nIJK", {
           fontSize: 12,
         }).width.toFixed(2),
       ).toEqual("41.94");
@@ -91,7 +94,7 @@ describe("victory-util/textsize", () => {
 
     it("returns width of widest string in array if array has an empty string", () => {
       expect(
-        TextSize.approximateTextSize(["06-14-20", ""], {
+        approximate(["06-14-20", ""], {
           fontSize: 12,
         }).width.toFixed(2),
       ).toEqual("47.93");
@@ -100,11 +103,11 @@ describe("victory-util/textsize", () => {
 
   describe("approximateHeight", () => {
     it("return zero width when no style", () => {
-      expect(TextSize.approximateTextSize(testString).height).toEqual(0);
+      expect(approximate(testString).height).toEqual(0);
     });
     it("return correct height with signed angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           angle: -45,
           fontSize: 14,
         }).height.toFixed(2),
@@ -112,28 +115,28 @@ describe("victory-util/textsize", () => {
     });
     it("return correct height with pixel fontsize", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: "14px",
         }).height.toFixed(2),
       ).toEqual("16.90");
     });
     it("return appropriate height with expected precision", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
         }).height.toFixed(2),
       ).toEqual("14.49");
     });
     it("consider font", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 16,
         }).height.toFixed(2),
       ).toEqual("19.32");
     });
     it("consider angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           angle: 30,
         }).height.toFixed(2),
@@ -141,7 +144,7 @@ describe("victory-util/textsize", () => {
     });
     it("not consider letterSpacing without angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           letterSpacing: "1px",
         }).height.toFixed(2),
@@ -149,7 +152,7 @@ describe("victory-util/textsize", () => {
     });
     it("consider letterSpacing with angle", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           angle: 30,
           letterSpacing: "1px",
@@ -158,7 +161,7 @@ describe("victory-util/textsize", () => {
     });
     it("consider lineHeight", () => {
       expect(
-        TextSize.approximateTextSize(testString, {
+        approximate(testString, {
           fontSize: 12,
           lineHeight: 2,
         }).height.toFixed(2),
@@ -166,7 +169,7 @@ describe("victory-util/textsize", () => {
     });
     it("consider multiLines text", () => {
       expect(
-        TextSize.approximateTextSize(`ABC\n${"DBCDEFG"}\n123`, {
+        approximate(`ABC\n${"DBCDEFG"}\n123`, {
           fontSize: 12,
         }).height.toFixed(2),
       ).toEqual("43.47");

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -283,7 +283,15 @@ const _getMeasurementContainer = memoize(() => {
   return containerElement;
 });
 
-const _measureDimensionsInternal = (
+const styleToKeyComponent = (style) => {
+  if (!style) {
+    return "null";
+  }
+
+  return `${style.angle}:${style.fontFamily}:${style.fontSize}:${style.letterSpacing}:${style.lineHeight}`;
+};
+
+const _measureDimensionsInternal = memoize((
   text: string | string[],
   style?: TextSizeStyleInterface,
 ) => {
@@ -316,11 +324,14 @@ const _measureDimensionsInternal = (
   containerElement.innerHTML = "";
 
   return { width, height };
-};
+}, (text, style) => {
+  const totalText = Array.isArray(text) ? text.join() : text;
+  const totalStyle = Array.isArray(style) ? style.map(styleToKeyComponent).join() : styleToKeyComponent(style);
+  return `${totalText}::${totalStyle}`;
+});
 
 export interface TextSizeStyleInterface {
   angle?: number;
-  characterConstant?: string;
   fontFamily?: string;
   fontSize?: number | string;
   letterSpacing?: string;

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -290,6 +290,7 @@ const _measureDimensionsInternal = (
   const containerElement = _getMeasurementContainer();
 
   const lines = _splitToLines(text);
+  let heightAcc = 0;
   for (const [i, line] of lines.entries()) {
     const textElement = document.createElementNS(
       "http://www.w3.org/2000/svg",
@@ -303,6 +304,9 @@ const _measureDimensionsInternal = (
     textElement.style.fontFamily = params.fontFamily;
     textElement.style.letterSpacing = params.letterSpacing;
     textElement.textContent = line;
+    textElement.setAttribute("x", "0");
+    textElement.setAttribute("y", `${heightAcc}`);
+    heightAcc += params.lineHeight * params.fontSize;
 
     containerElement.appendChild(textElement);
   }

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -325,7 +325,11 @@ export interface TextSizeStyleInterface {
 
 // Stubbable implementation.
 export const _approximateTextSizeInternal = {
-  impl: (text: string | string[], style?: TextSizeStyleInterface) => {
+  impl: (
+    text: string | string[],
+    style?: TextSizeStyleInterface,
+    __debugForceApproximate = false,
+  ) => {
     // Attempt to first measure the element in DOM. If there is no DOM, fallback
     // to the less accurate approximation algorithm.
     const isClient =
@@ -333,7 +337,7 @@ export const _approximateTextSizeInternal = {
       typeof window.document !== "undefined" &&
       typeof window.document.createElement !== "undefined";
 
-    if (!isClient) {
+    if (!isClient || __debugForceApproximate) {
       return _approximateDimensionsInternal(text, style);
     }
 

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -291,44 +291,46 @@ const styleToKeyComponent = (style) => {
   return `${style.angle}:${style.fontFamily}:${style.fontSize}:${style.letterSpacing}:${style.lineHeight}`;
 };
 
-const _measureDimensionsInternal = memoize((
-  text: string | string[],
-  style?: TextSizeStyleInterface,
-) => {
-  const containerElement = _getMeasurementContainer();
+const _measureDimensionsInternal = memoize(
+  (text: string | string[], style?: TextSizeStyleInterface) => {
+    const containerElement = _getMeasurementContainer();
 
-  const lines = _splitToLines(text);
-  let heightAcc = 0;
-  for (const [i, line] of lines.entries()) {
-    const textElement = document.createElementNS(
-      "http://www.w3.org/2000/svg",
-      "tspan",
-    );
-    const params = _prepareParams(style, i);
-    textElement.style.fontFamily = params.fontFamily;
-    textElement.style.transform = `rotate(${params.angle})`;
-    textElement.style.fontSize = `${params.fontSize}px`;
-    textElement.style.lineHeight = params.lineHeight;
-    textElement.style.fontFamily = params.fontFamily;
-    textElement.style.letterSpacing = params.letterSpacing;
-    textElement.textContent = line;
-    textElement.setAttribute("x", "0");
-    textElement.setAttribute("y", `${heightAcc}`);
-    heightAcc += params.lineHeight * params.fontSize;
+    const lines = _splitToLines(text);
+    let heightAcc = 0;
+    for (const [i, line] of lines.entries()) {
+      const textElement = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "tspan",
+      );
+      const params = _prepareParams(style, i);
+      textElement.style.fontFamily = params.fontFamily;
+      textElement.style.transform = `rotate(${params.angle})`;
+      textElement.style.fontSize = `${params.fontSize}px`;
+      textElement.style.lineHeight = params.lineHeight;
+      textElement.style.fontFamily = params.fontFamily;
+      textElement.style.letterSpacing = params.letterSpacing;
+      textElement.textContent = line;
+      textElement.setAttribute("x", "0");
+      textElement.setAttribute("y", `${heightAcc}`);
+      heightAcc += params.lineHeight * params.fontSize;
 
-    containerElement.appendChild(textElement);
-  }
+      containerElement.appendChild(textElement);
+    }
 
-  const { width, height } = containerElement.getBoundingClientRect();
+    const { width, height } = containerElement.getBoundingClientRect();
 
-  containerElement.innerHTML = "";
+    containerElement.innerHTML = "";
 
-  return { width, height };
-}, (text, style) => {
-  const totalText = Array.isArray(text) ? text.join() : text;
-  const totalStyle = Array.isArray(style) ? style.map(styleToKeyComponent).join() : styleToKeyComponent(style);
-  return `${totalText}::${totalStyle}`;
-});
+    return { width, height };
+  },
+  (text, style) => {
+    const totalText = Array.isArray(text) ? text.join() : text;
+    const totalStyle = Array.isArray(style)
+      ? style.map(styleToKeyComponent).join()
+      : styleToKeyComponent(style);
+    return `${totalText}::${totalStyle}`;
+  },
+);
 
 export interface TextSizeStyleInterface {
   angle?: number;

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -1,6 +1,6 @@
 // http://www.pearsonified.com/2012/01/characters-per-line.php
 /* eslint-disable no-magic-numbers */
-import { assign, defaults } from "lodash";
+import { assign, defaults, memoize } from "lodash";
 
 // Based on measuring specific character widths
 // as in the following example https://bl.ocks.org/tophtucker/62f93a4658387bb61e4510c37e2e97cf
@@ -243,6 +243,77 @@ const _approximateTextHeightInternal = (text: string | string[], style) => {
   }, 0);
 };
 
+const _approximateDimensionsInternal = (
+  text: string | string[],
+  style?: TextSizeStyleInterface,
+) => {
+  const angle = Array.isArray(style)
+    ? style[0] && style[0].angle
+    : style && style.angle;
+  const height = _approximateTextHeightInternal(text, style);
+  const width = _approximateTextWidthInternal(text, style);
+  const widthWithRotate = angle
+    ? _getSizeWithRotate(width, height, angle)
+    : width;
+  const heightWithRotate = angle
+    ? _getSizeWithRotate(height, width, angle)
+    : height;
+  return {
+    width: widthWithRotate,
+    height: heightWithRotate * coefficients.heightOverlapCoef,
+  };
+};
+
+const _getMeasurementContainer = memoize(() => {
+  const element = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  element.setAttribute("xlink", "http://www.w3.org/1999/xlink");
+
+  const containerElement = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "text",
+  );
+  element.appendChild(containerElement);
+
+  element.style.position = "fixed";
+  element.style.top = "-9999px";
+  element.style.left = "-9999px";
+
+  document.body.appendChild(element);
+
+  return containerElement;
+});
+
+const _measureDimensionsInternal = (
+  text: string | string[],
+  style?: TextSizeStyleInterface,
+) => {
+  const containerElement = _getMeasurementContainer();
+
+  const lines = _splitToLines(text);
+  for (const [i, line] of lines.entries()) {
+    const textElement = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "tspan",
+    );
+    const params = _prepareParams(style, i);
+    textElement.style.fontFamily = params.fontFamily;
+    textElement.style.transform = `rotate(${params.angle})`;
+    textElement.style.fontSize = `${params.fontSize}px`;
+    textElement.style.lineHeight = params.lineHeight;
+    textElement.style.fontFamily = params.fontFamily;
+    textElement.style.letterSpacing = params.letterSpacing;
+    textElement.textContent = line;
+
+    containerElement.appendChild(textElement);
+  }
+
+  const { width, height } = containerElement.getBoundingClientRect();
+
+  containerElement.innerHTML = "";
+
+  return { width, height };
+};
+
 export interface TextSizeStyleInterface {
   angle?: number;
   characterConstant?: string;
@@ -255,21 +326,18 @@ export interface TextSizeStyleInterface {
 // Stubbable implementation.
 export const _approximateTextSizeInternal = {
   impl: (text: string | string[], style?: TextSizeStyleInterface) => {
-    const angle = Array.isArray(style)
-      ? style[0] && style[0].angle
-      : style && style.angle;
-    const height = _approximateTextHeightInternal(text, style);
-    const width = _approximateTextWidthInternal(text, style);
-    const widthWithRotate = angle
-      ? _getSizeWithRotate(width, height, angle)
-      : width;
-    const heightWithRotate = angle
-      ? _getSizeWithRotate(height, width, angle)
-      : height;
-    return {
-      width: widthWithRotate,
-      height: heightWithRotate * coefficients.heightOverlapCoef,
-    };
+    // Attempt to first measure the element in DOM. If there is no DOM, fallback
+    // to the less accurate approximation algorithm.
+    const isClient =
+      typeof window !== "undefined" &&
+      typeof window.document !== "undefined" &&
+      typeof window.document.createElement !== "undefined";
+
+    if (!isClient) {
+      return _approximateDimensionsInternal(text, style);
+    }
+
+    return _measureDimensionsInternal(text, style);
   },
 };
 

--- a/packages/victory-vendor/.babelrc.js
+++ b/packages/victory-vendor/.babelrc.js
@@ -48,10 +48,9 @@ module.exports = {
               /^node_modules/,
               "lib-vendor",
             );
-            const relPathToPkg = path.relative(
-              path.dirname(currentFileVendor),
-              vendorPkg,
-            ).replaceAll("\\", "/");
+            const relPathToPkg = path
+              .relative(path.dirname(currentFileVendor), vendorPkg)
+              .replaceAll("\\", "/");
 
             return relPathToPkg;
           }

--- a/stories/victory-label.stories.js
+++ b/stories/victory-label.stories.js
@@ -415,6 +415,30 @@ export const LineHeight = () => {
           />
         }
       />
+      <VictoryScatter
+        {...defaultScatterProps}
+        labelComponent={
+          <VictoryLabel
+            lineHeight={[2, 1, 3]}
+            text={["测试汉字", "不在正常的 ASCII 范围内", "最后一行"]}
+            backgroundStyle={[{ stroke: "blue", fill: "none" }]}
+          />
+        }
+      />
+      <VictoryScatter
+        {...defaultScatterProps}
+        labelComponent={
+          <VictoryLabel
+            lineHeight={[2, 1, 3]}
+            text={[
+              "اختبار اللغات التي تُقرأ من اليمين إلى اليسار",
+              "مثل العربية",
+              "هناك أكثر من ذلك بكثير",
+            ]}
+            backgroundStyle={[{ stroke: "blue", fill: "none" }]}
+          />
+        }
+      />
     </div>
   );
 };


### PR DESCRIPTION
Addresses https://github.com/FormidableLabs/victory/issues/2475

As mentioned in the issue, the tooltip can appear to not have accurate sizing/padding in some cases.
I investigated and found that the tooltip tries to approximate the size that the text content will be, and then uses that to then size the tooltip box around the text. The logic for this size approximation lives [here](https://github.com/FormidableLabs/victory/blob/main/packages/victory-core/src/victory-util/textsize.ts).

The logic for approximating the text size involves reading from a list of hard-coded font metadata, and computing styles and glyph widths to reach a final width and height. (`victory-tooltip` then adds the padding, and uses that for the size of the tooltip).
There's a few issues with this, the primary being that if a font is being used which is not in this list, the measurement could be off by an arbitrary amount. While that's not the case here, it is of course possible for a third party consumer to use their own font-set which is not in this list. 

In this case, I discovered the culprit was the font-family *list*. It's common to list several fallback fonts for an element in css, but the logic here simply uses the first font family it finds in the list which it *has metadata for*. This may not match the font that is actually used during render, as the client may not have that font available. I am assuming that the reason this method doesn't make any attempt to query the browser for available fonts/measurements because this code may be called server-side, where it does not have access to the client it will be rendered on.

To remedy this issue, I've added logic to the tooltip component which measures the true size of the tooltip text using the DOM api, and does an immediate rerender with the accurate sizes. The rerender happens synchronously, before the browser does the next paint, and so the end user never sees the incorrect size.

before: 
<img width="403" alt="image" src="https://user-images.githubusercontent.com/5589147/196566546-d40cc0fc-8a0a-4021-b2cf-a73312d97d00.png">

after: 
<img width="403" alt="image" src="https://user-images.githubusercontent.com/5589147/196566668-9e8ecec0-c2f9-458c-a06d-c6331e003ec2.png">
