### PR TITLE
Document `animationWhitelist` in the animations guide

### DIFF
--- a/docs/src/content/guides/animations.md
+++ b/docs/src/content/guides/animations.md
@@ -8,7 +8,7 @@ scope:
 ---
 # Animations
 
-VictoryAnimation is able to animate changes in props using [d3-interpolate][]. Victory components define their animations via the `animate` prop. `duration`, `delay`, `easing` and `onEnd` functions may all be specified via the `animate` prop.
+VictoryAnimation is able to animate changes in props using [d3-interpolate][]. Victory components define their animations via the `animate` prop. `duration`, `delay`, `easing` and `onEnd` functions may all be specified via the `animate` prop. An `animationWhitelist` may also be specified on the `animate` prop. When given, only props specified in the whitelist will animate.
 
 ```playground_norender
 class App extends React.Component {


### PR DESCRIPTION
The animations guide doesn't mention the `animationWhitelist` (although it is documented in common props); adding this in here as well makes sense (I found it digging through the code after not finding it in the guide, only found it in common props after).