### PR TITLE
add missing size prop to symbol type in victory-legend

### DIFF
--- a/.changeset/warm-rocks-rest.md
+++ b/.changeset/warm-rocks-rest.md
@@ -1,0 +1,5 @@
+---
+"victory-legend": patch
+---
+
+Add missing size property to TS definitions

--- a/packages/victory-legend/src/index.d.ts
+++ b/packages/victory-legend/src/index.d.ts
@@ -32,6 +32,7 @@ export interface VictoryLegendProps
     symbol?: {
       fill?: string;
       type?: string;
+      size?: number;
     };
   }>;
   dataComponent?: React.ReactElement;

--- a/packages/victory-legend/src/index.d.ts
+++ b/packages/victory-legend/src/index.d.ts
@@ -31,8 +31,8 @@ export interface VictoryLegendProps
     };
     symbol?: {
       fill?: string;
-      type?: string;
       size?: number;
+      type?: string;
     };
   }>;
   dataComponent?: React.ReactElement;


### PR DESCRIPTION
Add missing 'size' property for the symbol in victory-legend 

https://github.com/FormidableLabs/victory/issues/2496