### PR TITLE
Added changelog.js file that prevents dependency updates from being l…

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
-  "changelog": ["@svitejs/changesets-changelog-github-compact", { "repo": "FormidableLabs/victory" }],
+  "changelog": ["../scripts/changelog.js", { "repo": "FormidableLabs/victory" }],
   "access": "public",
   "baseBranch": "main",
   "fixed": [["victory*"]]

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,13 +1,13 @@
-import { getReleaseLine } from '@svitejs/changesets-changelog-github-compact';
+import { getReleaseLine } from "@svitejs/changesets-changelog-github-compact";
 
 const changelogFunctions = {
   // Dependencies are updated on every changeset for every package, so
   // remove them to reduce noise.
-  getDependencyReleaseLine: () => '',
-  getReleaseLine
+  getDependencyReleaseLine: () => "",
+  getReleaseLine,
 };
 
 export default {
   ...changelogFunctions,
-  default: changelogFunctions
+  default: changelogFunctions,
 };

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -7,7 +7,7 @@ const changelogFunctions = {
   getReleaseLine
 };
 
-module.exports = {
+export default {
   ...changelogFunctions,
   default: changelogFunctions
 };

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,0 +1,16 @@
+const { config } = require('dotenv');
+const { getReleaseLine } = require('@svitejs/changesets-changelog-github-compact');
+
+config();
+
+const changelogFunctions = {
+  // Dependencies are updated on every changeset for every package, so
+  // remove them to reduce noise.
+  getDependencyReleaseLine: () => '',
+  getReleaseLine
+};
+
+module.exports = {
+  ...changelogFunctions,
+  default: changelogFunctions
+};

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,7 +1,4 @@
-const { config } = require('dotenv');
-const { getReleaseLine } = require('@svitejs/changesets-changelog-github-compact');
-
-config();
+import { getReleaseLine } from '@svitejs/changesets-changelog-github-compact';
 
 const changelogFunctions = {
   // Dependencies are updated on every changeset for every package, so

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,13 +1,13 @@
-import { getReleaseLine } from "@svitejs/changesets-changelog-github-compact";
+const {
+  default: changelogFunctions,
+} = require("@svitejs/changesets-changelog-github-compact");
 
-const changelogFunctions = {
-  // Dependencies are updated on every changeset for every package, so
-  // remove them to reduce noise.
-  getDependencyReleaseLine: () => "",
-  getReleaseLine,
+const customFunctions = {
+  ...changelogFunctions,
+  getDependencyReleaseLine: async () => "",
 };
 
-export default {
-  ...changelogFunctions,
-  default: changelogFunctions,
+module.exports = {
+  ...customFunctions,
+  default: customFunctions,
 };


### PR DESCRIPTION
Fixes #2429

- Created a new file, `scripts/changelog.js`, that ignores dependency changes when logging changelog files.
- Modified .changelog/config.js to point to that file.