### PR TITLE
Update PropTypes to support single axis scale values

### DIFF
--- a/packages/victory-core/src/victory-util/common-props.tsx
+++ b/packages/victory-core/src/victory-util/common-props.tsx
@@ -228,11 +228,12 @@ const baseProps: React.WeakValidationMap<VictoryCommonProps> = {
       y: CustomPropTypes.domain.isRequired,
     }),
   ]),
+  // @ts-expect-error TODO: synchronize the type with this PropTypes
   scale: PropTypes.oneOfType([
     CustomPropTypes.scale,
-    PropTypes.shape({
-      x: CustomPropTypes.scale.isRequired,
-      y: CustomPropTypes.scale.isRequired,
+    PropTypes.exact({
+      x: CustomPropTypes.scale,
+      y: CustomPropTypes.scale,
     }),
   ]),
   // @ts-expect-error TODO: synchronize the type with this PropTypes
@@ -292,7 +293,10 @@ const primitiveProps: React.WeakValidationMap<VictoryCommonPrimitiveProps> = {
   role: PropTypes.string,
   scale: PropTypes.oneOfType([
     CustomPropTypes.scale,
-    PropTypes.shape({ x: CustomPropTypes.scale, y: CustomPropTypes.scale }),
+    PropTypes.exact({
+      x: CustomPropTypes.scale,
+      y: CustomPropTypes.scale,
+    }),
   ]),
   shapeRendering: PropTypes.string,
   style: PropTypes.object,

--- a/packages/victory-core/src/victory-util/common-props.tsx
+++ b/packages/victory-core/src/victory-util/common-props.tsx
@@ -270,13 +270,7 @@ export interface VictoryCommonPrimitiveProps {
   origin?: OriginType;
   polar?: boolean;
   role?: string;
-  scale?:
-    | ScalePropType
-    | D3Scale
-    | {
-        x?: ScalePropType | D3Scale;
-        y?: ScalePropType | D3Scale;
-      };
+  scale?: any;
   shapeRendering?: string;
   style?: any;
   tabIndex?: NumberOrCallback;
@@ -297,7 +291,6 @@ const primitiveProps: React.WeakValidationMap<VictoryCommonPrimitiveProps> = {
   origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
   polar: PropTypes.bool,
   role: PropTypes.string,
-  // @ts-expect-error TODO: synchronize the type with this PropType
   scale: PropTypes.oneOfType([
     CustomPropTypes.scale,
     PropTypes.exact({

--- a/packages/victory-core/src/victory-util/common-props.tsx
+++ b/packages/victory-core/src/victory-util/common-props.tsx
@@ -270,7 +270,13 @@ export interface VictoryCommonPrimitiveProps {
   origin?: OriginType;
   polar?: boolean;
   role?: string;
-  scale?: any;
+  scale?:
+    | ScalePropType
+    | D3Scale
+    | {
+        x?: ScalePropType | D3Scale;
+        y?: ScalePropType | D3Scale;
+      };
   shapeRendering?: string;
   style?: any;
   tabIndex?: NumberOrCallback;
@@ -291,6 +297,7 @@ const primitiveProps: React.WeakValidationMap<VictoryCommonPrimitiveProps> = {
   origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
   polar: PropTypes.bool,
   role: PropTypes.string,
+  // @ts-expect-error TODO: synchronize the type with this PropType
   scale: PropTypes.oneOfType([
     CustomPropTypes.scale,
     PropTypes.exact({


### PR DESCRIPTION
Related issue #2489 

Users would get PropType errors on `scale` props when single axis values were provided (e.g. `scale={{ x: 'log' }}`) even though documentation and demos both have examples of single axis scale props and the components functioned normally. 

PropTypes for `scale` have been updated to no longer require both axises. `PropTypes.shape` was replaced with `PropTypes.exact` in order to catch invalid properties (e.g. `{ z: 'log' }`)

### Caveat
TypeScript error is suppressed on updated prop types. The error appears when `isRequired` is removed from either axis properties. A verbose workaround could be to list each possible combination of axis properties to keep `isRequired` like so:
```
scale: PropTypes.oneOfType([
  CustomPropTypes.scale,
  PropTypes.exact({
    x: CustomPropTypes.scale.isRequired,
    y: CustomPropTypes.scale.isRequired,
  }),
  PropTypes.exact({
    x: CustomPropTypes.scale.isRequired,
  }),
  PropTypes.exact({
    y: CustomPropTypes.scale.isRequired,
  }),
])
```