### PR TITLE
fix: fix using React.ComponentProps with VictoryLine component

### DIFF
--- a/.changeset/neat-trains-doubt.md
+++ b/.changeset/neat-trains-doubt.md
@@ -1,0 +1,5 @@
+---
+"victory-line": minor
+---
+
+Fix using React.ComponentProps with VictoryLine component

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Formidable",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/formidablelabs/victory/issue"
+    "url": "https://github.com/formidablelabs/victory/issues"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Formidable",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/formidablelabs/victory/issues"
+    "url": "https://github.com/formidablelabs/victory/issue"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "devDependencies": {

--- a/packages/victory-line/src/victory-line.tsx
+++ b/packages/victory-line/src/victory-line.tsx
@@ -45,9 +45,6 @@ const options = {
 interface VictoryLineBase extends EventsMixinClass<VictoryLineProps> {}
 
 class VictoryLineBase extends React.Component<VictoryLineProps> {
-  constructor(props) {
-    super(props);
-  }
 
   static animationWhitelist = [
     "data",


### PR DESCRIPTION
Looking at file `myApp/node_modules/victory-line/lib/victory-line.d.ts` file the built type file ended up with a constructor that takes props as type of any:
```
declare class VictoryLineBase extends React.Component<VictoryLineProps> {
    constructor(props: any); // Breaks typing
    static animationWhitelist: string[];
```

When trying to parse the components props one ended up with `any` type for `VictoryLineProps`. However inferring types for other components like `VictoryScatter` worked fine because it didn't have constructor defined in code.

```
import {
  VictoryLine,
  VictoryScatter,
} from "victory-native";

type VictoryScatterProps = React.ComponentProps<typeof VictoryScatter>; // Correct typing
type VictoryLineProps = React.ComponentProps<typeof VictoryLine>; // any type
```

So in this PR just removing the constructor to avoid it getting any type. Doesn't look like the constructor is needed or used for anything anyway.