### PR TITLE
provenance repository.url field update

### DIFF
--- a/.changeset/calm-cobras-wonder.md
+++ b/.changeset/calm-cobras-wonder.md
@@ -1,0 +1,34 @@
+---
+"victory": patch
+"victory-area": patch
+"victory-axis": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-brush-container": patch
+"victory-brush-line": patch
+"victory-candlestick": patch
+"victory-canvas": patch
+"victory-chart": patch
+"victory-core": patch
+"victory-create-container": patch
+"victory-cursor-container": patch
+"victory-errorbar": patch
+"victory-group": patch
+"victory-histogram": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-native": patch
+"victory-pie": patch
+"victory-polar-axis": patch
+"victory-scatter": patch
+"victory-selection-container": patch
+"victory-shared-events": patch
+"victory-stack": patch
+"victory-tooltip": patch
+"victory-vendor": patch
+"victory-voronoi": patch
+"victory-voronoi-container": patch
+"victory-zoom-container": patch
+---
+
+Setup NPM Provenance

--- a/packages/victory-area/package.json
+++ b/packages/victory-area/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-axis/package.json
+++ b/packages/victory-axis/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-bar/package.json
+++ b/packages/victory-bar/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-box-plot/package.json
+++ b/packages/victory-box-plot/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-brush-container/package.json
+++ b/packages/victory-brush-container/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-brush-line/package.json
+++ b/packages/victory-brush-line/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-candlestick/package.json
+++ b/packages/victory-candlestick/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-canvas/package.json
+++ b/packages/victory-canvas/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-chart/package.json
+++ b/packages/victory-chart/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-core/package.json
+++ b/packages/victory-core/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-create-container/package.json
+++ b/packages/victory-create-container/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-cursor-container/package.json
+++ b/packages/victory-cursor-container/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-errorbar/package.json
+++ b/packages/victory-errorbar/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-group/package.json
+++ b/packages/victory-group/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-histogram/package.json
+++ b/packages/victory-histogram/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-legend/package.json
+++ b/packages/victory-legend/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-line/package.json
+++ b/packages/victory-line/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-native/package.json
+++ b/packages/victory-native/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "source": "src/index.js",

--- a/packages/victory-pie/package.json
+++ b/packages/victory-pie/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-polar-axis/package.json
+++ b/packages/victory-polar-axis/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-scatter/package.json
+++ b/packages/victory-scatter/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-selection-container/package.json
+++ b/packages/victory-selection-container/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-shared-events/package.json
+++ b/packages/victory-shared-events/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-stack/package.json
+++ b/packages/victory-stack/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-tooltip/package.json
+++ b/packages/victory-tooltip/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-vendor/package.json
+++ b/packages/victory-vendor/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "author": "Formidable",

--- a/packages/victory-voronoi-container/package.json
+++ b/packages/victory-voronoi-container/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-voronoi/package.json
+++ b/packages/victory-voronoi/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory-zoom-container/package.json
+++ b/packages/victory-zoom-container/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "sideEffects": false,

--- a/packages/victory/package.json
+++ b/packages/victory/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/formidablelabs/victory.git"
+    "url": "https://github.com/FormidableLabs/victory"
   },
   "homepage": "https://formidable.com/open-source/victory",
   "source": "src/index.js",


### PR DESCRIPTION
Updating the `repository.url` field in each package to avoid Provenance returning this error:

```
🦋  error an error occurred while publishing victory-brush-line: E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/victory-brush-line - Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/formidablelabs/victory.git", expected to match "git+https://github.com/FormidableLabs/victory" from provenance 
```