### PR TITLE
Vercel for Staging Previews

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,16 +49,6 @@ jobs:
       - name: Build Docs
         run: yarn build
 
-      # deploy to staging if the branch is not main
-      - name: Deploy Docs (staging)
-        if: github.ref != 'refs/heads/main'
-        run: yarn deploy:stage
-        env:
-          FORMIDEPLOY_GIT_SHA: ${{ github.event.pull_request.head.sha }}
-          GITHUB_DEPLOYMENT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-
       # deploy to production only if the branch is main
       - name: Deploy docs (production)
         if: github.ref == 'refs/heads/main'

--- a/docs/static-config-helpers/constants.js
+++ b/docs/static-config-helpers/constants.js
@@ -7,6 +7,6 @@ const stage =
   process.env.REACT_STATIC_STAGING === "true"
     ? "staging"
     : process.env.REACT_STATIC_ENV;
-const landerBasePath = "open-source/victory";
+const landerBasePath = process.env.VERCEL_ENV === "preview" ? "." : "open-source/victory";
 
 module.exports = { stage, landerBasePath };


### PR DESCRIPTION
This PR drops Surge for preview deploys in favor of Vercel, and sets up build config to work for staging previews + "production stitching" into formidable.com. [Example staging preview here](https://victory-pbo02en91-formidable-labs.vercel.app/).