### PR TITLE
Remove Google Ad Cookie

### DIFF
--- a/docs/src/google-tag-manager.js
+++ b/docs/src/google-tag-manager.js
@@ -7,6 +7,6 @@ export const initGoogleTagManager = () => {
   if (typeof document === "undefined") {
     return {};
   } else {
-    return TagManager.initialize({ gtmId: "GTM-MD32945" });
+    return TagManager.initialize({ gtmId: "GTM-MD32945", allow_google_signals: false });
   }
 };


### PR DESCRIPTION
Following work on dot-com, we don't want `_gcl_au` cookie to get set. 

https://support.google.com/analytics/answer/9050852?hl=en

identified here: 
<img width="484" alt="Screenshot 2023-05-24 at 3 04 00 PM" src="https://github.com/FormidableLabs/victory/assets/10720454/9234bdfc-0c52-4a91-9203-e600bb2223ce">
