### PR TITLE
Improve lineheight calc in measureDimensions

### DIFF
--- a/.changeset/short-countries-serve.md
+++ b/.changeset/short-countries-serve.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+Fix text size regression when using line-height

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -315,17 +315,22 @@ const _measureDimensionsInternal = memoize(
       textElement.setAttribute("x", "0");
       textElement.setAttribute("y", `${heightAcc}`);
       containerElement.appendChild(textElement);
-      
-      heightAcc += params.lineHeight * textElement.getBoundingClientRect().height;
-    } 
+
+      heightAcc +=
+        params.lineHeight * textElement.getBoundingClientRect().height;
+    }
 
     const { width } = containerElement.getBoundingClientRect();
 
     containerElement.innerHTML = "";
 
     return {
-      width: style?.angle ? _getSizeWithRotate(width, heightAcc, style?.angle) : width,
-      height: style?.angle ? _getSizeWithRotate(heightAcc, width, style?.angle) : heightAcc,
+      width: style?.angle
+        ? _getSizeWithRotate(width, heightAcc, style?.angle)
+        : width,
+      height: style?.angle
+        ? _getSizeWithRotate(heightAcc, width, style?.angle)
+        : heightAcc,
     };
   },
   (text, style) => {

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -267,6 +267,9 @@ const _approximateDimensionsInternal = (
 const _getMeasurementContainer = memoize(() => {
   const element = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   element.setAttribute("xlink", "http://www.w3.org/1999/xlink");
+  element.setAttribute("width", "300");
+  element.setAttribute("height", "300");
+  element.setAttribute("viewBox", "0 0 300 300");
 
   const containerElement = document.createElementNS(
     "http://www.w3.org/2000/svg",
@@ -304,7 +307,6 @@ const _measureDimensionsInternal = memoize(
       );
       const params = _prepareParams(style, i);
       textElement.style.fontFamily = params.fontFamily;
-      textElement.style.transform = `rotate(${params.angle})`;
       textElement.style.fontSize = `${params.fontSize}px`;
       textElement.style.lineHeight = params.lineHeight;
       textElement.style.fontFamily = params.fontFamily;
@@ -312,16 +314,19 @@ const _measureDimensionsInternal = memoize(
       textElement.textContent = line;
       textElement.setAttribute("x", "0");
       textElement.setAttribute("y", `${heightAcc}`);
-      heightAcc += params.lineHeight * params.fontSize;
-
       containerElement.appendChild(textElement);
-    }
+      
+      heightAcc += params.lineHeight * textElement.getBoundingClientRect().height;
+    } 
 
-    const { width, height } = containerElement.getBoundingClientRect();
+    const { width } = containerElement.getBoundingClientRect();
 
     containerElement.innerHTML = "";
 
-    return { width, height };
+    return {
+      width: style?.angle ? _getSizeWithRotate(width, heightAcc, style?.angle) : width,
+      height: style?.angle ? _getSizeWithRotate(heightAcc, width, style?.angle) : heightAcc,
+    };
   },
   (text, style) => {
     const totalText = Array.isArray(text) ? text.join() : text;

--- a/stories/victory-legend.stories.js
+++ b/stories/victory-legend.stories.js
@@ -78,7 +78,7 @@ export const LineHeight = () => {
           orientation="vertical"
           rowGutter={0}
           style={{
-            labels: { lineHeight: 0.275 }
+            labels: { lineHeight: 0.275 },
           }}
           data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
         />
@@ -88,7 +88,7 @@ export const LineHeight = () => {
           orientation="vertical"
           rowGutter={0}
           style={{
-            labels: { lineHeight: 0.75 }
+            labels: { lineHeight: 0.75 },
           }}
           data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
         />

--- a/stories/victory-legend.stories.js
+++ b/stories/victory-legend.stories.js
@@ -70,6 +70,33 @@ export const DefaultRendering = () => {
   );
 };
 
+export const LineHeight = () => {
+  return (
+    <div style={containerStyle}>
+      <Wrapper>
+        <VictoryLegend
+          orientation="vertical"
+          rowGutter={0}
+          style={{
+            labels: { lineHeight: 0.275 }
+          }}
+          data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
+        />
+      </Wrapper>
+      <Wrapper>
+        <VictoryLegend
+          orientation="vertical"
+          rowGutter={0}
+          style={{
+            labels: { lineHeight: 0.75 }
+          }}
+          data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
+        />
+      </Wrapper>
+    </div>
+  );
+};
+
 export const Title = () => {
   return (
     <div style={containerStyle}>


### PR DESCRIPTION
fix for https://github.com/FormidableLabs/victory/issues/2613

I made a change a while back to improve the text size calculations, which were inadequate when using certain fonts or character sets, such as arabic or chinese.
It was recently discovered that this change also regressed calculations involving line-height. It turns out, setting line-height on an svg text element does not appear to have any effect. This PR fixes that regression by manually computing line-height per-line using the rendered text height multiplied by the desired line-height.