### PR TITLE
Fix label measurement after SSR hydration mismatch

### DIFF
--- a/.changeset/tender-insects-rest.md
+++ b/.changeset/tender-insects-rest.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+Fix label measurements after SSR hydration mismatch

--- a/.changeset/tender-insects-rest.md
+++ b/.changeset/tender-insects-rest.md
@@ -2,4 +2,4 @@
 "victory-core": patch
 ---
 
-Fix label measurements after SSR hydration mismatch
+Fix text label measurements after SSR hydration mismatch

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -296,7 +296,11 @@ const styleToKeyComponent = (style) => {
 
 const _measureDimensionsInternal = memoize(
   (text: string | string[], style?: TextSizeStyleInterface) => {
-    const containerElement = _getMeasurementContainer();
+    let containerElement = _getMeasurementContainer();
+    if (!containerElement.isConnected) {
+      _getMeasurementContainer.cache.clear?.();
+      containerElement = _getMeasurementContainer();
+    }
 
     const lines = _splitToLines(text);
     let heightAcc = 0;


### PR DESCRIPTION
Fixes #2625

When React removes the measurement container SVG element from the DOM, label measurements result in `{ width: 0, height: 0 }`. This change verifies that the measurement container is still connected. If not, then a new measurement container is created.