### PR TITLE
fix Date equality in axis

### DIFF
--- a/packages/victory-axis/src/helper-methods.tsx
+++ b/packages/victory-axis/src/helper-methods.tsx
@@ -257,6 +257,13 @@ const getStandaloneOffset = (props, calculatedValues) => {
   };
 };
 
+const isEqual = (a, b) => {
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  return a === b;
+}
+
 // eslint-disable-next-line complexity
 const getOffset = (props, calculatedValues) => {
   const { scale, origin, orientation, orientations, domain, padding } =
@@ -285,15 +292,14 @@ const getOffset = (props, calculatedValues) => {
   };
   const originPosition = {
     x:
-      origin.x === domain.x[0] || origin.x === domain.x[1]
+      isEqual(origin.x, domain.x[0]) || isEqual(origin.x, domain.x[1])
         ? 0
         : scale.x(origin.x),
     y:
-      origin.y === domain.y[0] || origin.y === domain.y[1]
+      isEqual(origin.y, domain.y[0]) || isEqual(origin.y, domain.y[1])
         ? 0
         : scale.y(origin.y),
   };
-
   const x = originPosition.x
     ? Math.abs(originOffset.x - originPosition.x)
     : orientationOffset.x;

--- a/packages/victory-axis/src/helper-methods.tsx
+++ b/packages/victory-axis/src/helper-methods.tsx
@@ -343,11 +343,11 @@ const getHorizontalOffset = (props, calculatedValues) => {
   };
   const originPosition = {
     x:
-      origin.x === domain.x[0] || origin.x === domain.x[1]
+      isEqual(origin.x, domain.x[0]) || isEqual(origin.x, domain.x[1])
         ? 0
         : scale.x(origin.x),
     y:
-      origin.y === domain.y[0] || origin.y === domain.y[1]
+      isEqual(origin.y, domain.y[0]) || isEqual(origin.y, domain.y[1])
         ? 0
         : scale.y(origin.y),
   };


### PR DESCRIPTION
fixes https://github.com/FormidableLabs/victory/issues/2251

Dates can't be compared with ===


```
new Date().getTime()
1693254943567
new Date(1693254943567) === new Date(1693254943567)
false
new Date(1693254943567).getTime() === new Date(1693254943567).getTime()
true
```