### PR TITLE
Add aria-hidden flag to svg for textsize util to fix accessibility issue

### DIFF
--- a/.changeset/many-suns-hang.md
+++ b/.changeset/many-suns-hang.md
@@ -1,0 +1,6 @@
+---
+"victory-core": patch
+"victory": patch
+---
+
+Add aria-hidden flag to svg for textsize util to fix accessibility issue

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -270,6 +270,7 @@ const _getMeasurementContainer = memoize(() => {
   element.setAttribute("width", "300");
   element.setAttribute("height", "300");
   element.setAttribute("viewBox", "0 0 300 300");
+  element.setAttribute("aria-hidden", "true");
 
   const containerElement = document.createElementNS(
     "http://www.w3.org/2000/svg",


### PR DESCRIPTION
The `testsize` util creates a hidden SVG element, but does not set `aria-hidden` to `true`, which causes accessibility issues. This PR simply adds the attribute.