### PR TITLE
Add links to React Native XL documentation in React Native sections

### DIFF
--- a/docs/src/content/introduction/index.md
+++ b/docs/src/content/introduction/index.md
@@ -13,7 +13,7 @@ Victory is an opinionated, but fully overridable, ecosystem of composable React 
 
 Check out the documentation for [Victory Native XL](https://formidable.com/open-source/victory-native/) - the rewrite of Victory Native that favors flexibility, ease of use, and performance.
 
-For the original Victory Native (versions ≤36), see [Getting Started with Victory Native](/docs/native).
+For the legacy versions of Victory Native, see [Getting Started with Victory Native](/docs/native).
 
 ## Tutorial
 

--- a/docs/src/content/introduction/index.md
+++ b/docs/src/content/introduction/index.md
@@ -11,7 +11,9 @@ Victory is an opinionated, but fully overridable, ecosystem of composable React 
 
 #### Getting Started with Victory Native?
 
-[Check out the native version of this getting started tutorial][]
+Check out the documentation for [Victory Native XL](https://formidable.com/open-source/victory-native/) - the rewrite of Victory Native that favors flexibility, ease of use, and performance.
+
+For the original Victory Native (versions ≤36), see [Getting Started with Victory Native](/docs/native).
 
 ## Tutorial
 
@@ -432,4 +434,3 @@ For more information about Victory and its components, check out the docs - see 
 [our guides]: /guides
 [Gallery]: /gallery
 [FAQs]: /docs/faq
-[Check out the native version of this getting started tutorial]: /docs/native

--- a/docs/src/content/introduction/native.md
+++ b/docs/src/content/introduction/native.md
@@ -8,6 +8,8 @@ scope: null
 
 # Getting Started with Victory Native
 
+> These docs are for version ≤36 of Victory Native. If you're looking for docs on versions ≥40, please [see here](https://formidable.com/open-source/victory-native/).
+
 In this guide, we’ll show you how to get started with Victory Native and the React Native SVG dependency running in your React Native app for iOS and Android.
 
 #### 1. Adding Victory Native to your React Native app

--- a/docs/src/content/introduction/native.md
+++ b/docs/src/content/introduction/native.md
@@ -8,7 +8,8 @@ scope: null
 
 # Getting Started with Victory Native
 
-> These docs are for version ≤36 of Victory Native. If you're looking for docs on versions ≥40, please [see here](https://formidable.com/open-source/victory-native/).
+> These docs are for the legacy versions of Victory Native. If you're looking for Victory Native XL docs, please [see here]
+(https://formidable.com/open-source/victory-native/).
 
 In this guide, we’ll show you how to get started with Victory Native and the React Native SVG dependency running in your React Native app for iOS and Android.
 

--- a/docs/src/styles/global.js
+++ b/docs/src/styles/global.js
@@ -251,6 +251,16 @@ const GlobalStyle = createGlobalStyle`
   button {
     cursor: pointer;
   }
+
+  blockquote {
+    border-left: 0.3rem solid ${({ theme }) => theme.color.red};
+    background: ${({ theme }) => theme.color.nearWhite};
+    padding: 2rem;
+
+    p {
+      margin: 0;
+    }
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
- Add links to React Native XL documentation in React Native sections
  - https://victory-git-chore-victory-native-xl-links-formidable-labs.vercel.app/docs#getting-started-with-victory-native
  - https://victory-git-chore-victory-native-xl-links-formidable-labs.vercel.app/docs/native
- Also added some styles for the markdown blockquote elements to differentiate them from regular paragraph text
  <img width="1122" alt="Screenshot 2024-01-04 at 13 40 05" src="https://github.com/FormidableLabs/victory/assets/9557798/47c1b127-bfa0-42d6-807f-33ee48c04484">

#2693 