### PR TITLE
Correctly type props in Victory Primitives

### DIFF
--- a/.changeset/clean-needles-grow.md
+++ b/.changeset/clean-needles-grow.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+Correctly type props in Victory Primitives

--- a/packages/victory-core/src/victory-primitives/circle.tsx
+++ b/packages/victory-core/src/victory-primitives/circle.tsx
@@ -1,16 +1,26 @@
-import React from "react";
+import React, { forwardRef } from "react";
+import { evaluateProp } from "../victory-util/helpers";
 import { VictoryPrimitiveShapeProps } from "./types";
 
-export const Circle = (props: VictoryPrimitiveShapeProps) => {
-  // eslint-disable-next-line react/prop-types
-  const { desc, ...rest } = props;
-  return desc ? (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <circle vectorEffect="non-scaling-stroke" {...rest}>
-      <desc>{desc}</desc>
-    </circle>
-  ) : (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <circle vectorEffect="non-scaling-stroke" {...rest} />
-  );
-};
+export const Circle = forwardRef<SVGCircleElement, VictoryPrimitiveShapeProps>(
+  (props, ref) => {
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars --
+     * origin conflicts with the SVG element's origin attribute
+     */
+    const { desc, id, tabIndex, origin, ...rest } = props;
+
+    const svgProps: React.SVGProps<SVGCircleElement> = {
+      vectorEffect: "non-scaling-stroke",
+      id: evaluateProp(id, props)?.toString(),
+      tabIndex: evaluateProp(tabIndex, props),
+      ...rest,
+    };
+    return desc ? (
+      <circle {...svgProps} ref={ref}>
+        <desc>{desc}</desc>
+      </circle>
+    ) : (
+      <circle {...svgProps} ref={ref} />
+    );
+  },
+);

--- a/packages/victory-core/src/victory-primitives/clip-path.tsx
+++ b/packages/victory-core/src/victory-primitives/clip-path.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";
 
 export interface ClipPathProps extends VictoryCommonPrimitiveProps {
@@ -9,17 +8,6 @@ export interface ClipPathProps extends VictoryCommonPrimitiveProps {
 
 export const ClipPath = (props: ClipPathProps) => (
   <defs>
-    {
-      // @ts-expect-error FIXME: "id cannot be a number"
-      <clipPath id={props.clipId}>{props.children}</clipPath>
-    }
+    {<clipPath id={props.clipId?.toString()}>{props.children}</clipPath>}
   </defs>
 );
-
-ClipPath.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]),
-  clipId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-};

--- a/packages/victory-core/src/victory-primitives/line.tsx
+++ b/packages/victory-core/src/victory-primitives/line.tsx
@@ -1,16 +1,27 @@
-import React from "react";
+import React, { forwardRef } from "react";
+import { evaluateProp } from "../victory-util/helpers";
 import { VictoryPrimitiveShapeProps } from "./types";
 
-export const Line = (props: VictoryPrimitiveShapeProps) => {
-  // eslint-disable-next-line react/prop-types
-  const { desc, ...rest } = props;
-  return desc ? (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <line vectorEffect="non-scaling-stroke" {...rest}>
-      <desc>{desc}</desc>
-    </line>
-  ) : (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <line vectorEffect="non-scaling-stroke" {...rest} />
-  );
-};
+export const Line = forwardRef<SVGLineElement, VictoryPrimitiveShapeProps>(
+  (props, ref) => {
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars --
+     * origin conflicts with the SVG element's origin attribute
+     */
+    const { desc, id, tabIndex, origin, ...rest } = props;
+
+    const svgProps: React.SVGProps<SVGLineElement> = {
+      vectorEffect: "non-scaling-stroke",
+      id: evaluateProp(id, props)?.toString(),
+      tabIndex: evaluateProp(tabIndex, props),
+      ...rest,
+    };
+
+    return desc ? (
+      <line {...svgProps} ref={ref}>
+        <desc>{desc}</desc>
+      </line>
+    ) : (
+      <line {...svgProps} ref={ref} />
+    );
+  },
+);

--- a/packages/victory-core/src/victory-primitives/path.tsx
+++ b/packages/victory-core/src/victory-primitives/path.tsx
@@ -1,20 +1,26 @@
 import React, { forwardRef } from "react";
+import { evaluateProp } from "../victory-util/helpers";
 import { VictoryPrimitiveShapeProps } from "./types";
 
-// eslint-disable-next-line prefer-arrow-callback
-export const Path = forwardRef(function Path(
-  props: VictoryPrimitiveShapeProps,
-  ref,
-) {
-  // eslint-disable-next-line react/prop-types
-  const { desc, ...rest } = props;
-  return desc ? (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <path {...rest} ref={ref}>
-      <desc>{desc}</desc>
-    </path>
-  ) : (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <path {...rest} ref={ref} />
-  );
-});
+export const Path = forwardRef<SVGPathElement, VictoryPrimitiveShapeProps>(
+  (props, ref) => {
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars --
+     * origin conflicts with the SVG element's origin attribute
+     */
+    const { desc, id, tabIndex, origin, ...rest } = props;
+
+    const svgProps: React.SVGProps<SVGPathElement> = {
+      id: evaluateProp(id, props)?.toString(),
+      tabIndex: evaluateProp(tabIndex, props),
+      ...rest,
+    };
+
+    return desc ? (
+      <path {...svgProps} ref={ref}>
+        <desc>{desc}</desc>
+      </path>
+    ) : (
+      <path {...svgProps} ref={ref} />
+    );
+  },
+);

--- a/packages/victory-core/src/victory-primitives/rect.tsx
+++ b/packages/victory-core/src/victory-primitives/rect.tsx
@@ -1,16 +1,27 @@
-import React from "react";
+import React, { forwardRef } from "react";
+import { evaluateProp } from "../victory-util/helpers";
 import { VictoryPrimitiveShapeProps } from "./types";
 
-export const Rect = (props: VictoryPrimitiveShapeProps) => {
-  // eslint-disable-next-line react/prop-types
-  const { desc, ...rest } = props;
-  return desc ? (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <rect vectorEffect="non-scaling-stroke" {...rest}>
-      <desc>{desc}</desc>
-    </rect>
-  ) : (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <rect vectorEffect="non-scaling-stroke" {...rest} />
-  );
-};
+export const Rect = forwardRef<SVGRectElement, VictoryPrimitiveShapeProps>(
+  (props, ref) => {
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars --
+     * origin conflicts with the SVG element's origin attribute
+     */
+    const { desc, id, tabIndex, origin, ...rest } = props;
+
+    const svgProps: React.SVGProps<SVGRectElement> = {
+      vectorEffect: "non-scaling-stroke",
+      id: evaluateProp(id, props)?.toString(),
+      tabIndex: evaluateProp(tabIndex, props),
+      ...rest,
+    };
+
+    return desc ? (
+      <rect {...svgProps} ref={ref}>
+        <desc>{desc}</desc>
+      </rect>
+    ) : (
+      <rect {...svgProps} ref={ref} />
+    );
+  },
+);

--- a/packages/victory-core/src/victory-primitives/text.tsx
+++ b/packages/victory-core/src/victory-primitives/text.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
+import { evaluateProp } from "../victory-util/helpers";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";
 
 export interface TextProps extends VictoryCommonPrimitiveProps {
@@ -9,19 +9,22 @@ export interface TextProps extends VictoryCommonPrimitiveProps {
 }
 
 export const Text = (props: TextProps) => {
-  const { children, title, desc, ...rest } = props;
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars --
+   * origin conflicts with the SVG element's origin attribute
+   */
+  const { children, desc, id, origin, tabIndex, title, ...rest } = props;
+
+  const svgProps: React.SVGProps<SVGTextElement> = {
+    id: evaluateProp(id, props)?.toString(),
+    tabIndex: evaluateProp(tabIndex, props),
+    ...rest,
+  };
+
   return (
-    // @ts-expect-error FIXME: "id cannot be a number"
-    <text {...rest}>
+    <text {...svgProps}>
       {title && <title>{title}</title>}
       {desc && <desc>{desc}</desc>}
       {children}
     </text>
   );
-};
-
-Text.propTypes = {
-  children: PropTypes.node,
-  desc: PropTypes.string,
-  title: PropTypes.string,
 };

--- a/packages/victory-core/src/victory-primitives/tspan.tsx
+++ b/packages/victory-core/src/victory-primitives/tspan.tsx
@@ -1,7 +1,18 @@
 import React from "react";
+import { evaluateProp } from "../victory-util/helpers";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";
 
-export const TSpan = (props: VictoryCommonPrimitiveProps) => (
-  // @ts-expect-error FIXME: "id cannot be a number"
-  <tspan {...props} />
-);
+export const TSpan = (props: VictoryCommonPrimitiveProps) => {
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars --
+   * origin conflicts with the SVG element's origin attribute
+   */
+  const { desc, id, tabIndex, origin, ...rest } = props;
+
+  const svgProps: React.SVGProps<SVGTSpanElement> = {
+    id: evaluateProp(id, props)?.toString(),
+    tabIndex: evaluateProp(tabIndex, props),
+    ...rest,
+  };
+
+  return <tspan {...svgProps} />;
+};

--- a/packages/victory-core/src/victory-util/user-props.ts
+++ b/packages/victory-core/src/victory-util/user-props.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { evaluateProp } from "./helpers";
 
 /*
   USER_PROPS_SAFELIST is to contain any string deemed safe for user props.
@@ -55,19 +56,6 @@ const testIfSafeProp = (key: string): key is SafeAttribute => {
 };
 
 /**
- * Gets the value from props if a function value is provided
- * @param {any} value: maybe function value
- * @param {Object} props: props object
- * @returns {any} newValue
- */
-const getValue = (value, props) => {
-  if (typeof value === "function") {
-    return value(props);
-  }
-  return value;
-};
-
-/**
  * getSafeUserProps - function that takes in a props object and removes any
  * key-value entries that do not match filter strings in the USER_PROPS_SAFELIST
  * object.
@@ -83,7 +71,7 @@ export const getSafeUserProps = <T>(
     Object.entries(propsToFilter)
       .filter(([key]) => testIfSafeProp(key))
       .map(([key, value]) => {
-        return [key, getValue(value, props)];
+        return [key, evaluateProp(value, props)];
       }),
   );
 };


### PR DESCRIPTION
Fix the props passed to Victory Primitives by coercing the user supplied value functions into scaler values when neccessary and removing any conflicting props. 

This also solves a problem where Babel produces invalid tree shaking annotations for libraries like Rollup. (see #2692)

### Before

The following Typescript code

```
// @ts-expect-error FIXME: "id cannot be a number"
<circle vectorEffect="non-scaling-stroke" {...rest}>
  <desc>{desc}</desc>
</circle>
```

Produces the following JS output in Babel

```
/*#__PURE__*/
// @ts-expect-error FIXME: "id cannot be a number"
React.createElement("circle", _extends({
  vectorEffect: "non-scaling-stroke"
}, rest), /*#__PURE__*/React.createElement("desc", null, desc))
```

*BUG*: The problem with the above output is the TS comment between `/*#__PURE__*/` and the call to `React.createElement`. The `PURE` annotation needs to directly precede the function call.

### After

The following Typescript code no longer requires the TS comment because we have fixed the underlying TS error

```
<circle {...svgProps}>
  <desc>{desc}</desc>
</circle>
```

Produces the following JS output in Babel

```
/*#__PURE__*/ React.createElement("circle", _extends({}, svgProps, {
  ref: ref
})
```

Note in the above, we have also corrected Ref forwarding for the `Rect` primitive so it aligns with other primitives in Victory.