### PR TITLE
Use parallel builds in workflow for improved CI times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,8 @@ on:
       - main
 
 jobs:
-  test:
-    name: Check Code
+  build:
     runs-on: ubuntu-latest
-    env:
-      DISPLAY: :99.0
     strategy:
       matrix:
         node-version: [16.x, 18.x]
@@ -34,5 +31,56 @@ jobs:
       - name: Build libraries and distributions ${{ matrix.node-version }}
         run: pnpm build
 
-      - name: Check Code ${{ matrix.node-version }}
-        run: pnpm check:ci
+  format:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: 18.x
+
+      - name: Format
+        run: pnpm format
+
+  lint:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: 18.x
+
+      - name: Lint
+        run: pnpm lint
+
+  types:
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Types Check ${{ matrix.node-version }}
+        run: pnpm types:check
+
+  test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Test ${{ matrix.node-version }}
+        run: pnpm jest

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "changeset": "changeset",
     "start": "concurrently --raw \"pnpm:build:lib:esm --watch\" \"webpack serve --config ./config/webpack/demo/webpack.config.dev.js --static demo/js --entry ./demo/js/app\"",
     "start:ts": "concurrently --raw \"pnpm:build:typescript --watch\" \"webpack serve --config ./config/webpack/demo/webpack.config.dev.js --static demo/ts --entry ./demo/ts/app\"",
+    "check": "wireit",
     "check:debug": "cross-env WIREIT_PARALLEL=1 pnpm check",
     "clean:build": "rimraf coverage \"packages/*/{dist,es,lib}\"",
     "clean:cache": "wireit",
@@ -171,6 +172,14 @@
         "clean:cache:wireit",
         "clean:cache:lint",
         "clean:cache:modules"
+      ]
+    },
+    "check": {
+      "dependencies": [
+        "format",
+        "lint",
+        "jest",
+        "types:check"
       ]
     },
     "build": {

--- a/package.json
+++ b/package.json
@@ -128,8 +128,6 @@
     "changeset": "changeset",
     "start": "concurrently --raw \"pnpm:build:lib:esm --watch\" \"webpack serve --config ./config/webpack/demo/webpack.config.dev.js --static demo/js --entry ./demo/js/app\"",
     "start:ts": "concurrently --raw \"pnpm:build:typescript --watch\" \"webpack serve --config ./config/webpack/demo/webpack.config.dev.js --static demo/ts --entry ./demo/ts/app\"",
-    "check": "wireit",
-    "check:ci": "wireit",
     "check:debug": "cross-env WIREIT_PARALLEL=1 pnpm check",
     "clean:build": "rimraf coverage \"packages/*/{dist,es,lib}\"",
     "clean:cache": "wireit",
@@ -173,19 +171,6 @@
         "clean:cache:wireit",
         "clean:cache:lint",
         "clean:cache:modules"
-      ]
-    },
-    "check": {
-      "dependencies": [
-        "format",
-        "lint",
-        "jest",
-        "types:check"
-      ]
-    },
-    "check:ci": {
-      "dependencies": [
-        "check"
       ]
     },
     "build": {


### PR DESCRIPTION
Improves the CI run time by running the 4 CI checks in parallel and only running specific Node versions for checks where that matters.

![image](https://github.com/FormidableLabs/victory/assets/1521394/b69f1299-8d0a-46e9-89ab-58dba9a96870)

