### PR TITLE
Fix victory-group animation

### DIFF
--- a/.changeset/seven-brooms-destroy.md
+++ b/.changeset/seven-brooms-destroy.md
@@ -1,0 +1,5 @@
+---
+"victory-group": patch
+---
+
+Fix victory-group animation

--- a/packages/victory-group/src/victory-group.tsx
+++ b/packages/victory-group/src/victory-group.tsx
@@ -67,8 +67,11 @@ const VictoryGroupBase: React.FC<VictoryGroupProps> = (initialProps) => {
   const role = VictoryGroup?.role;
   const { getAnimationProps, setAnimationState, getProps } =
     Hooks.useAnimationState();
-  initialProps = { ...defaultProps, ...initialProps };
-  const props = getProps(initialProps);
+  const propsWithDefaults = React.useMemo(
+    () => ({ ...defaultProps, ...initialProps }),
+    [initialProps],
+  );
+  const props = getProps(propsWithDefaults);
 
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, role);
   const {
@@ -132,8 +135,8 @@ const VictoryGroupBase: React.FC<VictoryGroupProps> = (initialProps) => {
   ]);
 
   const userProps = React.useMemo(
-    () => UserProps.getSafeUserProps(initialProps),
-    [initialProps],
+    () => UserProps.getSafeUserProps(propsWithDefaults),
+    [propsWithDefaults],
   );
 
   const container = React.useMemo(() => {
@@ -160,16 +163,16 @@ const VictoryGroupBase: React.FC<VictoryGroupProps> = (initialProps) => {
     return Wrapper.getAllEvents(props);
   }, [props]);
 
-  const previousProps = Hooks.usePreviousProps(initialProps);
+  const previousProps = Hooks.usePreviousProps(propsWithDefaults);
 
   React.useEffect(() => {
     // This is called before dismount to keep state in sync
     return () => {
-      if (initialProps.animate) {
+      if (propsWithDefaults.animate) {
         setAnimationState(previousProps, props);
       }
     };
-  }, [setAnimationState, previousProps, initialProps, props]);
+  }, [setAnimationState, previousProps, propsWithDefaults, props]);
 
   if (!isEmpty(events)) {
     return (


### PR DESCRIPTION
## Problem
Users are seeing a **maximum update depth exceeded** error when using the VictoryGroup component, specifically when trying to animate it #2708.

I was able to reproduce this in Storybook by rendering the following component:
```tsx
const Example = () => {
  const [data, setData] = useState([]);

  useEffect(() => {
    setTimeout(() => {
      setData([
        { x: 1, y: 2 },
        { x: 2, y: 3 },
        { x: 3, y: 5 },
        { x: 4, y: 4 },
        { x: 5, y: 7 },
      ]);
    }, 2000);
  }, []);

  return (
    <VictoryChart>
      <VictoryGroup data={data} animate={{ duration: 1000 }}>
        <VictoryBar />
        <VictoryBar />
      </VictoryGroup>
    </VictoryChart>
  );
};
```

When the component unmounts (tested in video by switching tab), the error appears.

https://github.com/FormidableLabs/victory/assets/9557798/f3e6b7e7-03c2-4ad9-a249-81cc5b428d35

## Solution
The `initialProps` were being reassigned in the body of the component:

<img width="529" alt="Screenshot 2024-01-16 at 12 18 20" src="https://github.com/FormidableLabs/victory/assets/9557798/237fd190-a38d-45aa-865e-28bc18fbdb4c">

For some reason, this meant that the linter couldn't detect that `initialProps` is the dependency of a `useMemo`, which was revealed when the new object was assigned to a const:

<img width="1066" alt="Screenshot 2024-01-16 at 12 18 59" src="https://github.com/FormidableLabs/victory/assets/9557798/9eebdee5-66da-44d9-9a0b-7eb78844852f">

To solve this dependency issue, I have wrapped the merging of defaultProps and initialProps in a `useMemo`.
<img width="478" alt="Screenshot 2024-01-16 at 12 17 51" src="https://github.com/FormidableLabs/victory/assets/9557798/224fdaa4-bc61-49af-bfea-1d89d3bc40a8">

Working example:

https://github.com/FormidableLabs/victory/assets/9557798/8ea09df2-c771-4d4c-a489-6b8dc4f0ef2f
