### PR TITLE
Fix the label background position when using dy fns

### DIFF
--- a/.changeset/moody-mayflies-attack.md
+++ b/.changeset/moody-mayflies-attack.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+Fix the label background position when using dy fns

--- a/packages/victory-core/src/victory-label/victory-label.tsx
+++ b/packages/victory-core/src/victory-label/victory-label.tsx
@@ -508,7 +508,7 @@ const getCalculatedProps = <T extends VictoryLabelProps>(props: T) => {
     verticalAnchor,
     dx,
     dy,
-    originalDy: props.dy,
+    originalDy: Helpers.evaluateProp(props.dy, props),
     transform,
     x,
     y,

--- a/stories/victory-label.stories.js
+++ b/stories/victory-label.stories.js
@@ -581,6 +581,30 @@ export const BackgroundStyles = () => {
           />
         }
       />
+      <VictoryScatter
+        {...defaultScatterProps}
+        labelComponent={
+          <VictoryLabel
+            dy={({ datum }) => (datum.y > 0 ? -5 : 8)}
+            verticalAnchor="end"
+            backgroundPadding={{ top: 5, right: 5, bottom: 5, left: 5 }}
+            backgroundStyle={{ fill: "plum", stroke: "#000000" }}
+            text={["Victory is awesome.", "background styles", "work with dy functions"]}
+          />
+        }
+      />
+      <VictoryScatter
+        {...defaultScatterProps}
+        labelComponent={
+          <VictoryLabel
+            dx={({ datum }) => (datum.y > 0 ? -5 : 8)}
+            verticalAnchor="end"
+            backgroundPadding={{ top: 5, right: 5, bottom: 5, left: 5 }}
+            backgroundStyle={{ fill: "thistle", stroke: "#000000" }}
+            text={["Victory is awesome.", "background styles", "work with dx functions"]}
+          />
+        }
+      />
     </div>
   );
 };

--- a/stories/victory-label.stories.js
+++ b/stories/victory-label.stories.js
@@ -589,7 +589,11 @@ export const BackgroundStyles = () => {
             verticalAnchor="end"
             backgroundPadding={{ top: 5, right: 5, bottom: 5, left: 5 }}
             backgroundStyle={{ fill: "plum", stroke: "#000000" }}
-            text={["Victory is awesome.", "background styles", "work with dy functions"]}
+            text={[
+              "Victory is awesome.",
+              "background styles",
+              "work with dy functions",
+            ]}
           />
         }
       />
@@ -601,7 +605,11 @@ export const BackgroundStyles = () => {
             verticalAnchor="end"
             backgroundPadding={{ top: 5, right: 5, bottom: 5, left: 5 }}
             backgroundStyle={{ fill: "thistle", stroke: "#000000" }}
-            text={["Victory is awesome.", "background styles", "work with dx functions"]}
+            text={[
+              "Victory is awesome.",
+              "background styles",
+              "work with dx functions",
+            ]}
           />
         }
       />


### PR DESCRIPTION
When using a user provided function for the `label` `dy` property, the component was not correctly calculating the new `y` offset based on the original position.

Added a new storybook use case so Chromatic can track this as well

### Before

![before](https://github.com/FormidableLabs/victory/assets/1521394/c8be1b2b-cb42-4ca3-9444-baa6b90cec32)

### After

![after](https://github.com/FormidableLabs/victory/assets/1521394/5c76cb76-02a6-4a89-9249-328c9059c9ca)

Fixes #2715 