### PR TITLE
Add missing defaultProps to VictorySharedEvents

### DIFF
--- a/.changeset/tough-spoons-float.md
+++ b/.changeset/tough-spoons-float.md
@@ -1,0 +1,5 @@
+---
+"victory-shared-events": patch
+---
+
+Fix VictorySharedEvents defaultProps

--- a/packages/victory-shared-events/src/victory-shared-events.tsx
+++ b/packages/victory-shared-events/src/victory-shared-events.tsx
@@ -44,6 +44,9 @@ export class VictorySharedEvents extends React.Component<VictorySharedEventsProp
   static displayName = "VictorySharedEvents";
   static role = "shared-event-wrapper";
   static contextType = TimerContext;
+  static defaultProps = {
+    groupComponent: <g />,
+  };
 
   getScopedEvents;
   getEventState;


### PR DESCRIPTION
- Add missing defaultProps to VictorySharedEvents
- Regression caused by accidentally removing the defaultProps when migrating to TypeScript here https://github.com/FormidableLabs/victory/pull/2733/files#diff-069d2eda6414197c2671c7db2f0f632a42face6d114cbd71273a4dde2252a900L81-L83

Fixes #2751 