### PR TITLE
Ensure CI creates a chromatic baseline against main

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,12 @@
 name: Chromatic
 
 # Runs chromatic on:
-#   every pull request where there are changes in stories/ or packages/ and the PR is not in draft mode
+# - every push to main (to create a chromatic baseline)
+# - every pull request where there are changes in stories/ or packages/ and the PR is not in draft mode
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Chromatic requires a build to be run on main for proper ancestor control

https://www.chromatic.com/docs/branching-and-baselines/#what-if-i-skip-running-chromatic-on-a-base-branch