### PR TITLE
Migrate instances of lodash.assign to object.assign

### DIFF
--- a/.changeset/brave-cycles-matter.md
+++ b/.changeset/brave-cycles-matter.md
@@ -1,0 +1,34 @@
+---
+"victory-area": patch
+"victory-axis": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-brush-container": patch
+"victory-brush-line": patch
+"victory-candlestick": patch
+"victory-canvas": patch
+"victory-chart": patch
+"victory-core": patch
+"victory-cursor-container": patch
+"victory-errorbar": patch
+"victory-group": patch
+"victory-histogram": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-native": patch
+"victory-pie": patch
+"victory-polar-axis": patch
+"victory-scatter": patch
+"victory-selection-container": patch
+"victory-shared-events": patch
+"victory-stack": patch
+"victory-tooltip": patch
+"victory-voronoi": patch
+"victory-voronoi-container": patch
+"victory": patch
+"victory-create-container": patch
+"victory-vendor": patch
+"victory-zoom-container": patch
+---
+
+Replace instances of lodash.assign with Object.assign

--- a/demo/js/components/events-demo.js
+++ b/demo/js/components/events-demo.js
@@ -6,7 +6,6 @@ import { VictoryArea } from "victory-area";
 import { VictoryBar } from "victory-bar";
 import { VictoryLine } from "victory-line";
 import { VictoryTheme, VictoryLabel } from "victory-core";
-import { merge } from "lodash";
 
 class App extends React.Component {
   render() {
@@ -104,7 +103,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "lime" }),
+                            style: Object.assign({}, props.style, { stroke: "lime" }),
                           };
                         },
                       },
@@ -113,7 +112,7 @@ class App extends React.Component {
                         target: "labels",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "green" }),
+                            style: Object.assign({}, props.style, { fill: "green" }),
                             text: "waddup",
                           };
                         },

--- a/demo/js/components/external-events-demo.js
+++ b/demo/js/components/external-events-demo.js
@@ -8,7 +8,7 @@ import { VictoryBar } from "victory-bar";
 import { VictoryLine } from "victory-line";
 import { VictoryZoomContainer } from "victory-zoom-container";
 import { VictoryVoronoiContainer } from "victory-voronoi-container";
-import { range, assign } from "lodash";
+import { range } from "lodash";
 
 class App extends React.Component {
   constructor() {
@@ -52,8 +52,8 @@ class App extends React.Component {
           mutation: (props) => {
             const fill = props.style && props.style.fill;
             return fill === "blue"
-              ? { style: assign({}, props.style, { fill: "red" }) }
-              : { style: assign({}, props.style, { fill: "blue" }) };
+              ? { style: Object.assign({}, props.style, { fill: "red" }) }
+              : { style: Object.assign({}, props.style, { fill: "blue" }) };
           },
           callback,
         },

--- a/demo/js/components/immutable-demo.js
+++ b/demo/js/components/immutable-demo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers, react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { assign, merge, keys, random, range, round } from "lodash";
+import { keys, random, range, round } from "lodash";
 import { fromJS } from "immutable";
 import { VictoryClipContainer, VictoryLabel, VictoryTheme } from "victory-core";
 
@@ -36,7 +36,7 @@ class Wrapper extends React.Component {
   renderChildren(props) {
     const children = React.Children.toArray(props.children);
     return children.map((child) => {
-      return React.cloneElement(child, assign({}, child.props, props));
+      return React.cloneElement(child, Object.assign({}, child.props, props));
     });
   }
 
@@ -214,7 +214,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "gold" }),
+                            style: Object.assign({}, props.style, { fill: "gold" }),
                           };
                         },
                       },
@@ -223,7 +223,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "orange" }),
+                            style: Object.assign({}, props.style, { fill: "orange" }),
                           };
                         },
                       },
@@ -232,7 +232,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "red" }),
+                            style: Object.assign({}, props.style, { fill: "red" }),
                           };
                         },
                       },
@@ -344,7 +344,7 @@ class App extends React.Component {
 
           <svg height={500} width={500}>
             <VictoryCandlestick
-              style={merge({}, chartStyle, { data: { width: 10 } })}
+              style={Object.assign({}, chartStyle, { data: { width: 10 } })}
               data={fromJS([
                 {
                   x: new Date(2016, 6, 1),
@@ -414,7 +414,7 @@ class App extends React.Component {
                         {
                           mutation: (props) => {
                             return {
-                              style: merge({}, props.style.labels, {
+                              style: Object.assign({}, props.style.labels, {
                                 fill: "orange",
                               }),
                             };
@@ -432,7 +432,7 @@ class App extends React.Component {
                         {
                           mutation: (props) => {
                             return {
-                              style: merge({}, props.style, { fill: "blue" }),
+                              style: Object.assign({}, props.style, { fill: "blue" }),
                             };
                           },
                         },
@@ -468,7 +468,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "lime" }),
+                            style: Object.assign({}, props.style, { stroke: "lime" }),
                           };
                         },
                       },
@@ -477,7 +477,7 @@ class App extends React.Component {
                         target: "labels",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "green" }),
+                            style: Object.assign({}, props.style, { fill: "green" }),
                             text: "waddup",
                           };
                         },
@@ -572,7 +572,7 @@ class App extends React.Component {
           </VictoryChart>
 
           <VictoryVoronoi
-            style={merge({}, chartStyle, {
+            style={Object.assign({}, chartStyle, {
               data: {
                 fill: "gray",
                 opacity: 0.1,
@@ -631,7 +631,7 @@ class App extends React.Component {
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "gold" }),
+                          style: Object.assign({}, props.style, { fill: "gold" }),
                         };
                       },
                     },
@@ -640,7 +640,7 @@ class App extends React.Component {
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },
@@ -649,7 +649,7 @@ class App extends React.Component {
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "red" }),
+                          style: Object.assign({}, props.style, { fill: "red" }),
                         };
                       },
                     },

--- a/demo/js/components/victory-area-demo.js
+++ b/demo/js/components/victory-area-demo.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import React from "react";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
@@ -278,7 +278,7 @@ export default class App extends React.Component {
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },

--- a/demo/js/components/victory-axis-demo.js
+++ b/demo/js/components/victory-axis-demo.js
@@ -6,7 +6,7 @@ import {
   VictoryContainer,
   VictoryTheme,
 } from "victory-core";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import XYTheme from "../theme/victory-axis-differential-styling-theme";
 
 export default class App extends React.Component {
@@ -122,7 +122,7 @@ export default class App extends React.Component {
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "orange" }),
+                            style: Object.assign({}, props.style, { stroke: "orange" }),
                           };
                         },
                       },

--- a/demo/js/components/victory-bar-demo.js
+++ b/demo/js/components/victory-bar-demo.js
@@ -12,7 +12,7 @@ import {
   VictoryTheme,
   VictoryLabel,
 } from "victory-core";
-import { assign, random, range, merge } from "lodash";
+import { random, range } from "lodash";
 
 class Wrapper extends React.Component {
   static propTypes = {
@@ -25,7 +25,7 @@ class Wrapper extends React.Component {
   renderChildren(props) {
     const children = React.Children.toArray(props.children);
     return children.map((child) => {
-      return React.cloneElement(child, assign({}, child.props, props));
+      return React.cloneElement(child, Object.assign({}, child.props, props));
     });
   }
 
@@ -262,7 +262,7 @@ export default class App extends React.Component {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },
@@ -399,7 +399,7 @@ export default class App extends React.Component {
                         {
                           mutation: (props) => {
                             return {
-                              style: merge({}, props.style, { fill: "orange" }),
+                              style: Object.assign({}, props.style, { fill: "orange" }),
                             };
                           },
                         },
@@ -425,7 +425,7 @@ export default class App extends React.Component {
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "blue" }),
+                            style: Object.assign({}, props.style, { fill: "blue" }),
                           };
                         },
                       },
@@ -449,7 +449,7 @@ export default class App extends React.Component {
                       childName: "secondBar",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "blue" }),
+                          style: Object.assign({}, props.style, { fill: "blue" }),
                         };
                       },
                     };
@@ -469,14 +469,14 @@ export default class App extends React.Component {
                           return props.style.fill === "cyan"
                             ? null
                             : {
-                                style: merge({}, props.style, { fill: "cyan" }),
+                                style: Object.assign({}, props.style, { fill: "cyan" }),
                               };
                         },
                       },
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "orange" }),
+                            style: Object.assign({}, props.style, { fill: "orange" }),
                           };
                         },
                       },

--- a/demo/js/components/victory-candlestick-demo.js
+++ b/demo/js/components/victory-candlestick-demo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import React from "react";
 import PropTypes from "prop-types";
-import { random, range, merge } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryCandlestick } from "victory-candlestick";
 import { VictoryTheme } from "victory-core";
@@ -98,7 +98,7 @@ export default class App extends React.Component {
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style.labels, {
+                            style: Object.assign({}, props.style.labels, {
                               fill: "orange",
                             }),
                           };
@@ -116,7 +116,7 @@ export default class App extends React.Component {
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "blue" }),
+                            style: Object.assign({}, props.style, { fill: "blue" }),
                           };
                         },
                       },
@@ -149,7 +149,7 @@ export default class App extends React.Component {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style.labels, {
+                          style: Object.assign({}, props.style.labels, {
                             fill: "orange",
                           }),
                         };
@@ -167,7 +167,7 @@ export default class App extends React.Component {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "blue" }),
+                          style: Object.assign({}, props.style, { fill: "blue" }),
                         };
                       },
                     },

--- a/demo/js/components/victory-chart-demo.js
+++ b/demo/js/components/victory-chart-demo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { assign, merge, random, range, omit } from "lodash";
+import { random, range, omit } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
@@ -30,7 +30,7 @@ class Wrapper extends React.Component {
     const props = omit(this.props, ["children"]);
     const children = React.Children.toArray(this.props.children);
     return children.map((child) => {
-      return React.cloneElement(child, assign({}, child.props, props));
+      return React.cloneElement(child, Object.assign({}, child.props, props));
     });
   }
 
@@ -222,7 +222,7 @@ class App extends React.Component {
           </VictoryChart>
 
           <VictoryChart
-            style={assign({}, chartStyle, bgStyle)}
+            style={Object.assign({}, chartStyle, bgStyle)}
             title="Victory Scatter Chart"
             desc="Graph with scattered data points"
           >
@@ -615,7 +615,7 @@ class App extends React.Component {
                         eventKey: "all",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "lime" }),
+                            style: Object.assign({}, props.style, { stroke: "lime" }),
                           };
                         },
                       },
@@ -625,7 +625,7 @@ class App extends React.Component {
                         eventKey: "all",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "green" }),
+                            style: Object.assign({}, props.style, { fill: "green" }),
                             text: "waddup",
                           };
                         },
@@ -701,7 +701,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "gold" }),
+                            style: Object.assign({}, props.style, { fill: "gold" }),
                           };
                         },
                       },
@@ -710,7 +710,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "orange" }),
+                            style: Object.assign({}, props.style, { fill: "orange" }),
                           };
                         },
                       },
@@ -719,7 +719,7 @@ class App extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "red" }),
+                            style: Object.assign({}, props.style, { fill: "red" }),
                           };
                         },
                       },

--- a/demo/js/components/victory-errorbar-demo.js
+++ b/demo/js/components/victory-errorbar-demo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import React from "react";
 import PropTypes from "prop-types";
-import { assign, merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryErrorBar, ErrorBar } from "victory-errorbar";
 import { VictoryScatter } from "victory-scatter";
@@ -84,7 +84,7 @@ export default class App extends React.Component {
             <VictoryContainer
               title="ErrorBar Chart"
               desc="This is a errorbar chart with data points!"
-              style={assign({}, style.parent, { border: "1px solid red" })}
+              style={Object.assign({}, style.parent, { border: "1px solid red" })}
             />
           }
         />
@@ -134,7 +134,7 @@ export default class App extends React.Component {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { stroke: "orange" }),
+                          style: Object.assign({}, props.style, { stroke: "orange" }),
                         };
                       },
                     },

--- a/demo/js/components/victory-histogram-demo.js
+++ b/demo/js/components/victory-histogram-demo.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryHistogram } from "victory-histogram";
 import { VictoryLine } from "victory-line";
@@ -208,7 +208,7 @@ export default class App extends React.Component {
                   {
                     mutation: (props) => {
                       return {
-                        style: merge({}, props.style, { fill: "pink" }),
+                        style: Object.assign({}, props.style, { fill: "pink" }),
                       };
                     },
                   },
@@ -217,7 +217,7 @@ export default class App extends React.Component {
                   {
                     mutation: (props) => {
                       return {
-                        style: merge({}, props.style, { fill: "yellow" }),
+                        style: Object.assign({}, props.style, { fill: "yellow" }),
                       };
                     },
                   },
@@ -317,7 +317,7 @@ export default class App extends React.Component {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "pink" }),
+                          style: Object.assign({}, props.style, { fill: "pink" }),
                         };
                       },
                     },

--- a/demo/js/components/victory-line-demo.js
+++ b/demo/js/components/victory-line-demo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryLine, Curve } from "victory-line";
 import { VictoryContainer, VictoryTheme, Point } from "victory-core";
@@ -142,7 +142,7 @@ export default class App extends React.Component {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { stroke: "orange" }),
+                          style: Object.assign({}, props.style, { stroke: "orange" }),
                         };
                       },
                     },

--- a/demo/js/components/victory-polar-chart-demo.js
+++ b/demo/js/components/victory-polar-chart-demo.js
@@ -12,7 +12,7 @@ import { VictoryZoomContainer } from "victory-zoom-container";
 import { VictoryVoronoiContainer } from "victory-voronoi-container";
 import { VictorySelectionContainer } from "victory-selection-container";
 import { VictoryTooltip } from "victory-tooltip";
-import { random, range, merge, keys } from "lodash";
+import { random, range, keys } from "lodash";
 import { VictoryTheme, VictoryLabel } from "victory-core";
 
 const multiAxisData = [
@@ -312,7 +312,7 @@ class App extends React.Component {
                         childName: "bar-2",
                         mutation: () => {
                           return {
-                            style: merge({}, props.style, { fill: "cyan" }),
+                            style: Object.assign({}, props.style, { fill: "cyan" }),
                           };
                         },
                       },
@@ -320,7 +320,7 @@ class App extends React.Component {
                         childName: "bar-3",
                         mutation: () => {
                           return {
-                            style: merge({}, props.style, { fill: "blue" }),
+                            style: Object.assign({}, props.style, { fill: "blue" }),
                           };
                         },
                       },
@@ -406,7 +406,7 @@ class App extends React.Component {
                       {
                         mutation: () => {
                           return {
-                            style: merge({}, props.style, {
+                            style: Object.assign({}, props.style, {
                               fill: "cyan",
                               stroke: "cyan",
                             }),

--- a/demo/js/components/victory-scatter-demo.js
+++ b/demo/js/components/victory-scatter-demo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { assign, merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryScatter } from "victory-scatter";
 import {
   VictoryLabel,
@@ -137,7 +137,7 @@ export default class App extends React.Component {
             <VictoryContainer
               title="Scatter Chart"
               desc="This is a scatter chart with cat data points!"
-              style={assign({}, style.parent, { border: "1px solid red" })}
+              style={Object.assign({}, style.parent, { border: "1px solid red" })}
             />
           }
         />
@@ -217,7 +217,7 @@ export default class App extends React.Component {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                           symbol: "circle",
                         };
                       },

--- a/demo/js/components/victory-zoom-container-demo.js
+++ b/demo/js/components/victory-zoom-container-demo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { range, merge, random, minBy, maxBy, last } from "lodash";
+import { range, random, minBy, maxBy, last } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
@@ -286,7 +286,7 @@ export default class App extends React.Component {
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "orange" }),
+                            style: Object.assign({}, props.style, { stroke: "orange" }),
                           };
                         },
                       },
@@ -372,7 +372,7 @@ export default class App extends React.Component {
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "gold" }),
+                          style: Object.assign({}, props.style, { fill: "gold" }),
                         };
                       },
                     },
@@ -381,7 +381,7 @@ export default class App extends React.Component {
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },
@@ -390,7 +390,7 @@ export default class App extends React.Component {
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "red" }),
+                          style: Object.assign({}, props.style, { fill: "red" }),
                         };
                       },
                     },

--- a/demo/ts/components/draggable-demo.tsx
+++ b/demo/ts/components/draggable-demo.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 
 import React from "react";
-import { merge } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryAxis } from "victory-axis";
 import { VictoryBar } from "victory-bar";
@@ -63,14 +62,14 @@ class DraggablePoint extends React.Component<TargetPropsInterface, any> {
         onMouseOver: (evt: any, targetProps: TargetPropsInterface) => {
           return [
             {
-              mutation: () => merge(targetProps, { active: true }),
+              mutation: () => Object.assign(targetProps, { active: true }),
             },
           ];
         },
         onMouseDown: (evt: any, targetProps: TargetPropsInterface) => {
           return [
             {
-              mutation: () => merge(targetProps, { dragging: true }),
+              mutation: () => Object.assign(targetProps, { dragging: true }),
             },
           ];
         },
@@ -86,7 +85,7 @@ class DraggablePoint extends React.Component<TargetPropsInterface, any> {
 
             return [
               {
-                mutation: () => merge(targetProps, { x }),
+                mutation: () => Object.assign(targetProps, { x }),
               },
             ];
           }
@@ -96,7 +95,7 @@ class DraggablePoint extends React.Component<TargetPropsInterface, any> {
           return [
             {
               mutation: () =>
-                merge(targetProps, { dragging: false, active: false }),
+                Object.assign(targetProps, { dragging: false, active: false }),
             },
           ];
         },
@@ -104,7 +103,7 @@ class DraggablePoint extends React.Component<TargetPropsInterface, any> {
           return [
             {
               mutation: () =>
-                merge(targetProps, { dragging: false, active: false }),
+                Object.assign(targetProps, { dragging: false, active: false }),
             },
           ];
         },

--- a/demo/ts/components/events-demo.tsx
+++ b/demo/ts/components/events-demo.tsx
@@ -6,7 +6,6 @@ import { VictoryArea } from "victory-area";
 import { VictoryBar, VictoryBarTTargetType } from "victory-bar";
 import { VictoryLine } from "victory-line";
 import { VictoryTheme, VictoryLabel } from "victory-core";
-import { merge } from "lodash";
 
 class EventsDemo extends React.Component {
   render() {
@@ -105,7 +104,7 @@ class EventsDemo extends React.Component {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "lime" }),
+                            style: Object.assign({}, props.style, { stroke: "lime" }),
                           };
                         },
                       },
@@ -114,7 +113,7 @@ class EventsDemo extends React.Component {
                         target: "labels",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "green" }),
+                            style: Object.assign({}, props.style, { fill: "green" }),
                             text: "waddup",
                           };
                         },

--- a/demo/ts/components/immutable-demo.tsx
+++ b/demo/ts/components/immutable-demo.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers, react/no-multi-comp */
 import React from "react";
-import { assign, merge, keys, random, range, round } from "lodash";
+import { keys, random, range, round } from "lodash";
 import { fromJS } from "immutable";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
@@ -37,7 +37,7 @@ class Wrapper extends React.Component<WrapperProps> {
   renderChildren(props: WrapperProps) {
     const children = React.Children.toArray(props.children);
     return children.map((child: any) => {
-      return React.cloneElement(child, assign({}, child.props, props));
+      return React.cloneElement(child, Object.assign({}, child.props, props));
     });
   }
 
@@ -250,7 +250,7 @@ export default class ImmutableDemo extends React.Component<
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "gold" }),
+                            style: Object.assign({}, props.style, { fill: "gold" }),
                           };
                         },
                       },
@@ -259,7 +259,7 @@ export default class ImmutableDemo extends React.Component<
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "orange" }),
+                            style: Object.assign({}, props.style, { fill: "orange" }),
                           };
                         },
                       },
@@ -268,7 +268,7 @@ export default class ImmutableDemo extends React.Component<
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "red" }),
+                            style: Object.assign({}, props.style, { fill: "red" }),
                           };
                         },
                       },
@@ -380,7 +380,7 @@ export default class ImmutableDemo extends React.Component<
 
           <svg height={500} width={500}>
             <VictoryCandlestick
-              style={merge({}, chartStyle, { data: { width: 10 } })}
+              style={Object.assign({}, chartStyle, { data: { width: 10 } })}
               data={fromJS([
                 {
                   x: new Date(2016, 6, 1),
@@ -450,7 +450,7 @@ export default class ImmutableDemo extends React.Component<
                         {
                           mutation: (props) => {
                             return {
-                              style: merge({}, props.style.labels, {
+                              style: Object.assign({}, props.style.labels, {
                                 fill: "orange",
                               }),
                             };
@@ -468,7 +468,7 @@ export default class ImmutableDemo extends React.Component<
                         {
                           mutation: (props) => {
                             return {
-                              style: merge({}, props.style, { fill: "blue" }),
+                              style: Object.assign({}, props.style, { fill: "blue" }),
                             };
                           },
                         },
@@ -504,7 +504,7 @@ export default class ImmutableDemo extends React.Component<
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "lime" }),
+                            style: Object.assign({}, props.style, { stroke: "lime" }),
                           };
                         },
                       },
@@ -513,7 +513,7 @@ export default class ImmutableDemo extends React.Component<
                         target: "labels",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "green" }),
+                            style: Object.assign({}, props.style, { fill: "green" }),
                             text: "waddup",
                           };
                         },
@@ -608,7 +608,7 @@ export default class ImmutableDemo extends React.Component<
           </VictoryChart>
 
           <VictoryVoronoi
-            style={merge({}, chartStyle, {
+            style={Object.assign({}, chartStyle, {
               data: {
                 fill: "gray",
                 opacity: 0.1,
@@ -667,7 +667,7 @@ export default class ImmutableDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "gold" }),
+                          style: Object.assign({}, props.style, { fill: "gold" }),
                         };
                       },
                     },
@@ -676,7 +676,7 @@ export default class ImmutableDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },
@@ -685,7 +685,7 @@ export default class ImmutableDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "red" }),
+                          style: Object.assign({}, props.style, { fill: "red" }),
                         };
                       },
                     },

--- a/demo/ts/components/victory-area-demo.tsx
+++ b/demo/ts/components/victory-area-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
@@ -301,7 +301,7 @@ export default class VictoryAreaDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },

--- a/demo/ts/components/victory-axis-demo.tsx
+++ b/demo/ts/components/victory-axis-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { DomainPropType } from "victory-core";
 import { VictoryAxis, VictoryAxisProps } from "victory-axis";
 import { VictoryLabel, VictoryContainer, VictoryTheme } from "victory-core";
@@ -128,7 +128,7 @@ export default class VictoryAxisDemo extends React.Component<
                       {
                         mutation: (props: any) => {
                           return {
-                            style: merge({}, props.style, { stroke: "orange" }),
+                            style: Object.assign({}, props.style, { stroke: "orange" }),
                           };
                         },
                       },

--- a/demo/ts/components/victory-bar-demo.tsx
+++ b/demo/ts/components/victory-bar-demo.tsx
@@ -6,7 +6,7 @@ import { VictoryGroup } from "victory-group";
 import { VictoryBar } from "victory-bar";
 
 import { VictoryContainer, VictoryTheme, VictoryLabel } from "victory-core";
-import { assign, random, range, merge } from "lodash";
+import { random, range } from "lodash";
 
 interface WrapperProps {
   children?: React.ReactElement | React.ReactElement[];
@@ -23,7 +23,7 @@ class Wrapper extends React.Component<WrapperProps> {
   renderChildren(props: WrapperProps) {
     const children = React.Children.toArray(props.children);
     return children.map((child: any) => {
-      return React.cloneElement(child, assign({}, child.props, props));
+      return React.cloneElement(child, Object.assign({}, child.props, props));
     });
   }
 
@@ -279,7 +279,7 @@ export default class VictoryBarDemo extends React.Component<
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },
@@ -416,7 +416,7 @@ export default class VictoryBarDemo extends React.Component<
                         {
                           mutation: (props) => {
                             return {
-                              style: merge({}, props.style, { fill: "orange" }),
+                              style: Object.assign({}, props.style, { fill: "orange" }),
                             };
                           },
                         },
@@ -442,7 +442,7 @@ export default class VictoryBarDemo extends React.Component<
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "blue" }),
+                            style: Object.assign({}, props.style, { fill: "blue" }),
                           };
                         },
                       },

--- a/demo/ts/components/victory-candlestick-demo.tsx
+++ b/demo/ts/components/victory-candlestick-demo.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import React from "react";
-import { random, range, merge } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryCandlestick } from "victory-candlestick";
 import { VictoryTheme } from "victory-core";
@@ -111,7 +111,7 @@ export default class VictoryCandlestickDemo extends React.Component<
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style.labels, {
+                            style: Object.assign({}, props.style.labels, {
                               fill: "orange",
                             }),
                           };
@@ -129,7 +129,7 @@ export default class VictoryCandlestickDemo extends React.Component<
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "blue" }),
+                            style: Object.assign({}, props.style, { fill: "blue" }),
                           };
                         },
                       },
@@ -162,7 +162,7 @@ export default class VictoryCandlestickDemo extends React.Component<
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style.labels, {
+                          style: Object.assign({}, props.style.labels, {
                             fill: "orange",
                           }),
                         };
@@ -180,7 +180,7 @@ export default class VictoryCandlestickDemo extends React.Component<
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "blue" }),
+                          style: Object.assign({}, props.style, { fill: "blue" }),
                         };
                       },
                     },

--- a/demo/ts/components/victory-chart-demo.tsx
+++ b/demo/ts/components/victory-chart-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { assign, merge, random, range, omit } from "lodash";
+import { random, range, omit } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
@@ -26,7 +26,7 @@ class Wrapper extends React.Component<WrapperProps> {
     const props = omit(this.props, ["children"]);
     const children = React.Children.toArray(this.props.children);
     return children.map((child: any) => {
-      return React.cloneElement(child, assign({}, child.props, props));
+      return React.cloneElement(child, Object.assign({}, child.props, props));
     });
   }
 
@@ -246,7 +246,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
           </VictoryChart>
 
           <VictoryChart
-            style={assign({}, chartStyle, bgStyle)}
+            style={Object.assign({}, chartStyle, bgStyle)}
             title="Victory Scatter Chart"
           >
             <VictoryScatter
@@ -624,7 +624,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
                         eventKey: "all",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "lime" }),
+                            style: Object.assign({}, props.style, { stroke: "lime" }),
                           };
                         },
                       },
@@ -634,7 +634,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
                         eventKey: "all",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "green" }),
+                            style: Object.assign({}, props.style, { fill: "green" }),
                             text: "waddup",
                           };
                         },
@@ -710,7 +710,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "gold" }),
+                            style: Object.assign({}, props.style, { fill: "gold" }),
                           };
                         },
                       },
@@ -719,7 +719,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "orange" }),
+                            style: Object.assign({}, props.style, { fill: "orange" }),
                           };
                         },
                       },
@@ -728,7 +728,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
                         target: "data",
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "red" }),
+                            style: Object.assign({}, props.style, { fill: "red" }),
                           };
                         },
                       },

--- a/demo/ts/components/victory-errorbar-demo.tsx
+++ b/demo/ts/components/victory-errorbar-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryScatter } from "victory-scatter";
 import { ErrorType, VictoryErrorBar } from "victory-errorbar";
@@ -150,7 +150,7 @@ export default class VictoryErrorBarDemo extends React.Component<
                     {
                       mutation: (props: any) => {
                         return {
-                          style: merge({}, props.style, { stroke: "orange" }),
+                          style: Object.assign({}, props.style, { stroke: "orange" }),
                         };
                       },
                     },

--- a/demo/ts/components/victory-histogram-demo.tsx
+++ b/demo/ts/components/victory-histogram-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryHistogram } from "victory-histogram";
 import { VictoryLine } from "victory-line";
@@ -239,7 +239,7 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
                   {
                     mutation: (props) => {
                       return {
-                        style: merge({}, props.style, { fill: "pink" }),
+                        style: Object.assign({}, props.style, { fill: "pink" }),
                       };
                     },
                   },
@@ -248,7 +248,7 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
                   {
                     mutation: (props) => {
                       return {
-                        style: merge({}, props.style, { fill: "yellow" }),
+                        style: Object.assign({}, props.style, { fill: "yellow" }),
                       };
                     },
                   },
@@ -348,7 +348,7 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "pink" }),
+                          style: Object.assign({}, props.style, { fill: "pink" }),
                         };
                       },
                     },

--- a/demo/ts/components/victory-line-demo.tsx
+++ b/demo/ts/components/victory-line-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryLine, Curve } from "victory-line";
 import { VictoryContainer, VictoryTheme, Point } from "victory-core";
@@ -162,7 +162,7 @@ export default class VictoryLineDemo extends React.Component<
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { stroke: "orange" }),
+                          style: Object.assign({}, props.style, { stroke: "orange" }),
                         };
                       },
                     },

--- a/demo/ts/components/victory-scatter-demo.tsx
+++ b/demo/ts/components/victory-scatter-demo.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
 import PropTypes from "prop-types";
-import { assign, merge, random, range } from "lodash";
+import { random, range } from "lodash";
 import { VictoryScatter } from "victory-scatter";
 import {
   ScatterSymbolType,
@@ -177,7 +177,7 @@ export default class VictoryScatterDemo extends React.Component<
             <VictoryContainer
               title="Scatter Chart"
               desc="This is a scatter chart with cat data points!"
-              style={assign({}, style.parent, { border: "1px solid red" })}
+              style={Object.assign({}, style.parent, { border: "1px solid red" })}
             />
           }
         />
@@ -256,7 +256,7 @@ export default class VictoryScatterDemo extends React.Component<
                     {
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                           symbol: "circle",
                         };
                       },

--- a/demo/ts/components/victory-shared-events-demo.tsx
+++ b/demo/ts/components/victory-shared-events-demo.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { VictoryBar } from "victory-bar";
 import { VictorySharedEvents } from "victory-shared-events";
-import { merge } from "lodash";
 
 export default class VictorySharedEventsDemo extends React.Component<any, {}> {
   render() {
@@ -28,7 +27,7 @@ export default class VictorySharedEventsDemo extends React.Component<any, {}> {
                       childName: "secondBar",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "blue" }),
+                          style: Object.assign({}, props.style, { fill: "blue" }),
                         };
                       },
                     };
@@ -48,14 +47,14 @@ export default class VictorySharedEventsDemo extends React.Component<any, {}> {
                           return props.style.fill === "cyan"
                             ? null
                             : {
-                                style: merge({}, props.style, { fill: "cyan" }),
+                                style: Object.assign({}, props.style, { fill: "cyan" }),
                               };
                         },
                       },
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { fill: "orange" }),
+                            style: Object.assign({}, props.style, { fill: "orange" }),
                           };
                         },
                       },

--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
-import { range, merge, random, minBy, maxBy, last } from "lodash";
+import { range, random, minBy, maxBy, last } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
@@ -331,7 +331,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       {
                         mutation: (props) => {
                           return {
-                            style: merge({}, props.style, { stroke: "orange" }),
+                            style: Object.assign({}, props.style, { stroke: "orange" }),
                           };
                         },
                       },
@@ -417,7 +417,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "gold" }),
+                          style: Object.assign({}, props.style, { fill: "gold" }),
                         };
                       },
                     },
@@ -426,7 +426,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, { fill: "orange" }),
                         };
                       },
                     },
@@ -435,7 +435,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: merge({}, props.style, { fill: "red" }),
+                          style: Object.assign({}, props.style, { fill: "red" }),
                         };
                       },
                     },

--- a/docs/src/partials/guides/themes/grayscale.example.js
+++ b/docs/src/partials/guides/themes/grayscale.example.js
@@ -49,7 +49,7 @@ const baseLabelStyles = {
   stroke: "transparent"
 };
 
-const centeredLabelStyles = assign({ textAnchor: "middle" }, baseLabelStyles);
+const centeredLabelStyles = Object.assign({ textAnchor: "middle" }, baseLabelStyles);
 
 // Strokes
 const strokeLinecap = "round";
@@ -57,7 +57,7 @@ const strokeLinejoin = "round";
 
 // Put it all together...
 const theme = {
-  area: assign(
+  area: Object.assign(
     {
       style: {
         data: {
@@ -68,7 +68,7 @@ const theme = {
     },
     baseProps
   ),
-  axis: assign(
+  axis: Object.assign(
     {
       style: {
         axis: {
@@ -78,7 +78,7 @@ const theme = {
           strokeLinecap,
           strokeLinejoin
         },
-        axisLabel: assign({}, centeredLabelStyles, {
+        axisLabel: Object.assign({}, centeredLabelStyles, {
           padding: 25
         }),
         grid: {
@@ -96,7 +96,7 @@ const theme = {
     },
     baseProps
   ),
-  bar: assign(
+  bar: Object.assign(
     {
       style: {
         data: {
@@ -109,32 +109,32 @@ const theme = {
     },
     baseProps
   ),
-  boxplot: assign(
+  boxplot: Object.assign(
     {
       style: {
         max: { padding: 8, stroke: charcoal, strokeWidth: 1 },
-        maxLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        maxLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         median: { padding: 8, stroke: charcoal, strokeWidth: 1 },
-        medianLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        medianLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         min: { padding: 8, stroke: charcoal, strokeWidth: 1 },
-        minLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        minLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q1: { padding: 8, fill: grey },
-        q1Labels: assign({}, baseLabelStyles, { padding: 3 }),
+        q1Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q3: { padding: 8, fill: grey },
-        q3Labels: assign({}, baseLabelStyles, { padding: 3 })
+        q3Labels: Object.assign({}, baseLabelStyles, { padding: 3 })
       },
       boxWidth: 20
     },
     baseProps
   ),
-  candlestick: assign(
+  candlestick: Object.assign(
     {
       style: {
         data: {
           stroke: charcoal,
           strokeWidth: 1
         },
-        labels: assign({}, baseLabelStyles, { padding: 5 })
+        labels: Object.assign({}, baseLabelStyles, { padding: 5 })
       },
       candleColors: {
         positive: "#ffffff",
@@ -144,7 +144,7 @@ const theme = {
     baseProps
   ),
   chart: baseProps,
-  errorbar: assign(
+  errorbar: Object.assign(
     {
       borderWidth: 8,
       style: {
@@ -158,13 +158,13 @@ const theme = {
     },
     baseProps
   ),
-  group: assign(
+  group: Object.assign(
     {
       colorScale: colors
     },
     baseProps
   ),
-  histogram: assign(
+  histogram: Object.assign(
     {
       style: {
         data: {
@@ -187,10 +187,10 @@ const theme = {
         type: "circle"
       },
       labels: baseLabelStyles,
-      title: assign({}, baseLabelStyles, { padding: 5 })
+      title: Object.assign({}, baseLabelStyles, { padding: 5 })
     }
   },
-  line: assign(
+  line: Object.assign(
     {
       style: {
         data: {
@@ -210,14 +210,14 @@ const theme = {
         stroke: "transparent",
         strokeWidth: 1
       },
-      labels: assign({}, baseLabelStyles, { padding: 20 })
+      labels: Object.assign({}, baseLabelStyles, { padding: 20 })
     },
     colorScale: colors,
     width: 400,
     height: 400,
     padding: 50
   },
-  scatter: assign(
+  scatter: Object.assign(
     {
       style: {
         data: {
@@ -230,14 +230,14 @@ const theme = {
     },
     baseProps
   ),
-  stack: assign(
+  stack: Object.assign(
     {
       colorScale: colors
     },
     baseProps
   ),
   tooltip: {
-    style: assign({}, baseLabelStyles, { padding: 0, pointerEvents: "none" }),
+    style: Object.assign({}, baseLabelStyles, { padding: 0, pointerEvents: "none" }),
     flyoutStyle: {
       stroke: charcoal,
       strokeWidth: 1,
@@ -248,7 +248,7 @@ const theme = {
     cornerRadius: 5,
     pointerLength: 10
   },
-  voronoi: assign(
+  voronoi: Object.assign(
     {
       style: {
         data: {
@@ -256,7 +256,7 @@ const theme = {
           stroke: "transparent",
           strokeWidth: 0
         },
-        labels: assign({}, baseLabelStyles, { padding: 5, pointerEvents: "none" }),
+        labels: Object.assign({}, baseLabelStyles, { padding: 5, pointerEvents: "none" }),
         flyout: {
           stroke: charcoal,
           strokeWidth: 1,

--- a/docs/src/partials/guides/themes/material.example.js
+++ b/docs/src/partials/guides/themes/material.example.js
@@ -55,7 +55,7 @@ const baseLabelStyles = {
   strokeWidth: 0
 };
 
-const centeredLabelStyles = assign({ textAnchor: "middle" }, baseLabelStyles);
+const centeredLabelStyles = Object.assign({ textAnchor: "middle" }, baseLabelStyles);
 
 // Strokes
 const strokeDasharray = "10, 5";
@@ -64,7 +64,7 @@ const strokeLinejoin = "round";
 
 // Put it all together...
 const theme = {
-  area: assign(
+  area: Object.assign(
     {
       style: {
         data: {
@@ -75,7 +75,7 @@ const theme = {
     },
     baseProps
   ),
-  axis: assign(
+  axis: Object.assign(
     {
       style: {
         axis: {
@@ -85,7 +85,7 @@ const theme = {
           strokeLinecap,
           strokeLinejoin
         },
-        axisLabel: assign({}, centeredLabelStyles, {
+        axisLabel: Object.assign({}, centeredLabelStyles, {
           padding,
           stroke: "transparent"
         }),
@@ -105,14 +105,14 @@ const theme = {
           strokeLinecap,
           strokeLinejoin
         },
-        tickLabels: assign({}, baseLabelStyles, {
+        tickLabels: Object.assign({}, baseLabelStyles, {
           fill: blueGrey700
         })
       }
     },
     baseProps
   ),
-  polarDependentAxis: assign({
+  polarDependentAxis: Object.assign({
     style: {
       ticks: {
         fill: "transparent",
@@ -121,7 +121,7 @@ const theme = {
       }
     }
   }),
-  bar: assign(
+  bar: Object.assign(
     {
       style: {
         data: {
@@ -134,31 +134,31 @@ const theme = {
     },
     baseProps
   ),
-  boxplot: assign(
+  boxplot: Object.assign(
     {
       style: {
         max: { padding, stroke: blueGrey700, strokeWidth: 1 },
-        maxLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        maxLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         median: { padding, stroke: blueGrey700, strokeWidth: 1 },
-        medianLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        medianLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         min: { padding, stroke: blueGrey700, strokeWidth: 1 },
-        minLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        minLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q1: { padding, fill: blueGrey700 },
-        q1Labels: assign({}, baseLabelStyles, { padding: 3 }),
+        q1Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q3: { padding, fill: blueGrey700 },
-        q3Labels: assign({}, baseLabelStyles, { padding: 3 })
+        q3Labels: Object.assign({}, baseLabelStyles, { padding: 3 })
       },
       boxWidth: 20
     },
     baseProps
   ),
-  candlestick: assign(
+  candlestick: Object.assign(
     {
       style: {
         data: {
           stroke: blueGrey700
         },
-        labels: assign({}, baseLabelStyles, { padding: 5 })
+        labels: Object.assign({}, baseLabelStyles, { padding: 5 })
       },
       candleColors: {
         positive: "#ffffff",
@@ -168,7 +168,7 @@ const theme = {
     baseProps
   ),
   chart: baseProps,
-  errorbar: assign(
+  errorbar: Object.assign(
     {
       borderWidth: 8,
       style: {
@@ -183,13 +183,13 @@ const theme = {
     },
     baseProps
   ),
-  group: assign(
+  group: Object.assign(
     {
       colorScale: colors
     },
     baseProps
   ),
-  histogram: assign(
+  histogram: Object.assign(
     {
       style: {
         data: {
@@ -212,10 +212,10 @@ const theme = {
         type: "circle"
       },
       labels: baseLabelStyles,
-      title: assign({}, baseLabelStyles, { padding: 5 })
+      title: Object.assign({}, baseLabelStyles, { padding: 5 })
     }
   },
-  line: assign(
+  line: Object.assign(
     {
       style: {
         data: {
@@ -229,7 +229,7 @@ const theme = {
     },
     baseProps
   ),
-  pie: assign(
+  pie: Object.assign(
     {
       colorScale: colors,
       style: {
@@ -238,12 +238,12 @@ const theme = {
           stroke: blueGrey50,
           strokeWidth: 1
         },
-        labels: assign({}, baseLabelStyles, { padding: 20 })
+        labels: Object.assign({}, baseLabelStyles, { padding: 20 })
       }
     },
     baseProps
   ),
-  scatter: assign(
+  scatter: Object.assign(
     {
       style: {
         data: {
@@ -257,14 +257,14 @@ const theme = {
     },
     baseProps
   ),
-  stack: assign(
+  stack: Object.assign(
     {
       colorScale: colors
     },
     baseProps
   ),
   tooltip: {
-    style: assign({}, baseLabelStyles, { padding: 0, pointerEvents: "none" }),
+    style: Object.assign({}, baseLabelStyles, { padding: 0, pointerEvents: "none" }),
     flyoutStyle: {
       stroke: grey900,
       strokeWidth: 1,
@@ -275,7 +275,7 @@ const theme = {
     cornerRadius: 5,
     pointerLength: 10
   },
-  voronoi: assign(
+  voronoi: Object.assign(
     {
       style: {
         data: {
@@ -283,7 +283,7 @@ const theme = {
           stroke: "transparent",
           strokeWidth: 0
         },
-        labels: assign({}, baseLabelStyles, { padding: 5, pointerEvents: "none" }),
+        labels: Object.assign({}, baseLabelStyles, { padding: 5, pointerEvents: "none" }),
         flyout: {
           stroke: grey900,
           strokeWidth: 1,

--- a/packages/victory-area/src/area.test.tsx
+++ b/packages/victory-area/src/area.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Area } from "victory-area";
-import { merge } from "lodash";
 import { render } from "@testing-library/react";
 import { VictoryContainer } from "victory-core";
 import * as d3Scale from "victory-vendor/d3-scale";
@@ -25,7 +24,7 @@ describe("victory-primitives/area", () => {
   };
 
   it("should render a single area and no line when no line style is given", () => {
-    const props = merge({}, baseProps, {
+    const props = Object.assign({}, baseProps, {
       style: {
         stroke: "none",
       },

--- a/packages/victory-area/src/area.tsx
+++ b/packages/victory-area/src/area.tsx
@@ -1,7 +1,6 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
-import { assign } from "lodash";
 import * as d3Shape from "victory-vendor/d3-shape";
 import {
   Helpers,
@@ -84,12 +83,12 @@ const evaluateProps = (props: AreaProps) => {
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(
-    assign({ fill: "black" }, props.style),
+    Object.assign({ fill: "black" }, props.style),
     props,
   );
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, { ariaLabel, desc, id, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, desc, id, style, tabIndex });
 };
 
 const defaultProps = {
@@ -145,10 +144,10 @@ export const Area: React.FC<AreaProps> = (initialProps) => {
 
   const area = React.cloneElement(
     pathComponent!,
-    assign(
+    Object.assign(
       {
         key: `${id}-area`,
-        style: assign({}, style, { stroke: areaStroke }),
+        style: Object.assign({}, style, { stroke: areaStroke }),
         d: areaFunction(data),
         desc,
         tabIndex,
@@ -161,10 +160,10 @@ export const Area: React.FC<AreaProps> = (initialProps) => {
   const line = renderLine
     ? React.cloneElement(
         pathComponent!,
-        assign(
+        Object.assign(
           {
             key: `${id}-area-stroke`,
-            style: assign({}, style, { fill: "none" }),
+            style: Object.assign({}, style, { fill: "none" }),
             d: lineFunction(data),
           },
           sharedProps,

--- a/packages/victory-area/src/helper-methods.tsx
+++ b/packages/victory-area/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { assign, isNil } from "lodash";
+import { isNil } from "lodash";
 import {
   Helpers,
   LabelHelpers,
@@ -33,7 +33,7 @@ export const getDataWithBaseline = (props, scale) => {
     const _y0 = datum._y0 !== undefined ? datum._y0 : getDefaultMin("y");
     const _x1 = datum._x1 !== undefined ? datum._x1 : datum._x;
     const _x0 = datum._x0 !== undefined ? datum._x0 : getDefaultMin("x");
-    return assign({}, datum, { _y0, _y1, _x0, _x1 });
+    return Object.assign({}, datum, { _y0, _y1, _x0, _x1 });
   });
 };
 
@@ -70,7 +70,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "area",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     data,
     domain,

--- a/packages/victory-axis/src/helper-methods.tsx
+++ b/packages/victory-axis/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { assign, defaults } from "lodash";
+import { defaults } from "lodash";
 import { Helpers, Scale, Axis } from "victory-core";
 import { VictoryAxisProps } from "./victory-axis";
 
@@ -245,7 +245,7 @@ const getStandaloneOffset = (props, calculatedValues) => {
     const tick = stringTicks ? props.tickValues[data - 1] : data;
     const tickStyle = Helpers.evaluateStyle(
       style.ticks,
-      assign({}, sharedProps, { tick, index }),
+      Object.assign({}, sharedProps, { tick, index }),
     );
     return tickStyle.size || 0;
   });
@@ -582,7 +582,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     globalTransform,
   );
   const initialChildProps = {
-    parent: assign(
+    parent: Object.assign(
       {
         style: style.parent,
         ticks,
@@ -610,7 +610,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     const text = tickFormat(tickValue, index, ticks);
     const styles = getEvaluatedStyles(
       style,
-      assign({}, sharedProps, { tick, tickValue, index, text }),
+      Object.assign({}, sharedProps, { tick, tickValue, index, text }),
     );
     const tickLayout = {
       position: getTickPosition(styles, orientation, isVertical),
@@ -633,14 +633,14 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       },
     };
     childProps[index] = {
-      axis: assign({ dimension: axis }, sharedProps, axisProps),
-      axisLabel: assign({}, sharedProps, axisLabelProps),
-      ticks: assign(
+      axis: Object.assign({ dimension: axis }, sharedProps, axisProps),
+      axisLabel: Object.assign({}, sharedProps, axisLabelProps),
+      ticks: Object.assign(
         {},
         sharedProps,
         getTickProps(tickLayout, styles.tickStyle, tickValue),
       ),
-      tickLabels: assign(
+      tickLabels: Object.assign(
         {},
         sharedProps,
         getTickLabelProps(
@@ -651,7 +651,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
           text,
         ),
       ),
-      grid: assign(
+      grid: Object.assign(
         {},
         sharedProps,
         gridProps,

--- a/packages/victory-axis/src/victory-axis.tsx
+++ b/packages/victory-axis/src/victory-axis.tsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { assign, isEmpty } from "lodash";
+import { isEmpty } from "lodash";
 import {
   PropTypes as CustomPropTypes,
   VictoryLabel,
@@ -255,7 +255,7 @@ class VictoryAxisBase extends React.Component<VictoryAxisProps> {
       .map((child) => child.props);
     const paddingToObject = (padding) =>
       typeof padding === "object"
-        ? assign({}, { top: 0, right: 0, bottom: 0, left: 0 }, padding)
+        ? Object.assign({}, { top: 0, right: 0, bottom: 0, left: 0 }, padding)
         : { top: padding, right: padding, bottom: padding, left: padding };
     const labelsSumSize = labels.reduce((sum, label) => {
       const padding = paddingToObject(label.style.padding);

--- a/packages/victory-bar/src/bar-helper-methods.ts
+++ b/packages/victory-bar/src/bar-helper-methods.ts
@@ -1,4 +1,4 @@
-import { assign, isNil, isPlainObject } from "lodash";
+import { isNil, isPlainObject } from "lodash";
 import { Helpers, VictoryStyleObject } from "victory-core";
 import { BarProps } from "./bar";
 import {
@@ -93,5 +93,5 @@ export const getStyle = (style: VictoryStyleObject = {}, props: BarProps) => {
   }
   const stroke = style.fill || "black";
   const baseStyle = { fill: "black", stroke };
-  return Helpers.evaluateStyle(assign(baseStyle, style), props);
+  return Helpers.evaluateStyle(Object.assign(baseStyle, style), props);
 };

--- a/packages/victory-bar/src/bar.tsx
+++ b/packages/victory-bar/src/bar.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-import { assign } from "lodash";
 import React, { forwardRef } from "react";
 import {
   Helpers,
@@ -44,10 +43,13 @@ const evaluateProps = (props: BarProps) => {
    * `tabIndex`
    */
   const style = getStyle(props.style, props);
-  const barWidth = getBarWidth(props.barWidth, assign({}, props, { style }));
+  const barWidth = getBarWidth(
+    props.barWidth,
+    Object.assign({}, props, { style }),
+  );
   const cornerRadius = getCornerRadius(
     props.cornerRadius,
-    assign({}, props, { style, barWidth }),
+    Object.assign({}, props, { style, barWidth }),
   );
 
   const ariaLabel = Helpers.evaluateProp(props.ariaLabel, props);
@@ -55,7 +57,7 @@ const evaluateProps = (props: BarProps) => {
   const id = Helpers.evaluateProp(props.id, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, {
+  return Object.assign({}, props, {
     ariaLabel,
     style,
     barWidth,

--- a/packages/victory-bar/src/helper-methods.ts
+++ b/packages/victory-bar/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { assign, isNil } from "lodash";
+import { isNil } from "lodash";
 import {
   Collection,
   Data,
@@ -30,7 +30,7 @@ export const getBarPosition = (props, datum) => {
   };
   const _y0 = datum._y0 !== undefined ? datum._y0 : getDefaultMin("y");
   const _x0 = datum._x0 !== undefined ? datum._x0 : getDefaultMin("x");
-  return Helpers.scalePoint(props, assign({}, datum, { _y0, _x0 }));
+  return Helpers.scalePoint(props, Object.assign({}, datum, { _y0, _x0 }));
 };
 
 const getCalculatedValues = (props) => {
@@ -67,7 +67,11 @@ const getCalculatedValues = (props) => {
 
 export const getBaseProps = (initialProps, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(initialProps, fallbackProps, "bar");
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     alignment,
     barRatio,

--- a/packages/victory-box-plot/src/helper-methods.tsx
+++ b/packages/victory-box-plot/src/helper-methods.tsx
@@ -1,13 +1,4 @@
-import {
-  orderBy,
-  defaults,
-  assign,
-  uniq,
-  groupBy,
-  keys,
-  isNaN,
-  isNil,
-} from "lodash";
+import { orderBy, defaults, uniq, groupBy, keys, isNaN, isNil } from "lodash";
 import { Helpers, Scale, Domain, Data, Collection } from "victory-core";
 import {
   min as d3Min,
@@ -51,7 +42,7 @@ const getSummaryStatistics = (data) => {
     _max: nanToNull(d3Max(dependentVars)),
   };
 
-  return assign({}, data[0], quartiles, { _y: data[0]._y });
+  return Object.assign({}, data[0], quartiles, { _y: data[0]._y });
 };
 
 const processData = (data) => {
@@ -73,7 +64,7 @@ const processData = (data) => {
       the depedentVarArray and process each datum separately */
       return data.map((datum) => {
         const dataArray = datum[sortKey].map((d) =>
-          assign({}, datum, { [sortKey]: d }),
+          Object.assign({}, datum, { [sortKey]: d }),
         );
         const sortedData = orderBy(dataArray, sortKey);
         return getSummaryStatistics(sortedData);
@@ -463,7 +454,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "boxplot",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     groupComponent,
     width,
@@ -511,7 +506,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       q1: boxScale(datum._q1),
       q3: boxScale(datum._q3),
     };
-    const dataProps = assign({ index, datum, positions }, props);
+    const dataProps = Object.assign({ index, datum, positions }, props);
     const dataObj = TYPES.reduce((memo, type) => {
       memo[type] = getDataProps(dataProps, type);
       return memo;
@@ -528,7 +523,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       ) {
         const target = `${type}Labels`;
         acc[eventKey][target] = getLabelProps(
-          assign({}, props, dataProps),
+          Object.assign({}, props, dataProps),
           labelText,
           type,
         );

--- a/packages/victory-brush-container/src/brush-helpers.ts
+++ b/packages/victory-brush-container/src/brush-helpers.ts
@@ -1,5 +1,5 @@
 import { Selection } from "victory-core";
-import { assign, throttle, isFunction, defaults, mapValues } from "lodash";
+import { throttle, isFunction, defaults, mapValues } from "lodash";
 import isEqual from "react-fast-compare";
 
 const Helpers = {
@@ -110,7 +110,7 @@ const Helpers = {
       bottom: { y1: Math.min(y1, y2), y2: Math.max(y1, y2), x1, x2 },
     };
     return handles.reduce((memo, current) => {
-      return assign(memo, mutations[current]);
+      return Object.assign(memo, mutations[current]);
     }, {});
   },
 

--- a/packages/victory-brush-container/src/victory-brush-container.tsx
+++ b/packages/victory-brush-container/src/victory-brush-container.tsx
@@ -8,7 +8,7 @@ import {
   VictoryContainerProps,
 } from "victory-core";
 import { BrushHelpers } from "./brush-helpers";
-import { assign, defaults } from "lodash";
+import { defaults } from "lodash";
 import isEqual from "react-fast-compare";
 export interface VictoryBrushContainerProps extends VictoryContainerProps {
   allowDrag?: boolean;
@@ -193,10 +193,10 @@ export const brushContainerMixin = <TBase extends Constructor>(base: TBase) =>
       };
 
       const handleProps = {
-        top: top && assign({ x: top.x1, y: top.y1 }, yProps),
-        bottom: bottom && assign({ x: bottom.x1, y: bottom.y1 }, yProps),
-        left: left && assign({ y: left.y1, x: left.x1 }, xProps),
-        right: right && assign({ y: right.y1, x: right.x1 }, xProps),
+        top: top && Object.assign({ x: top.x1, y: top.y1 }, yProps),
+        bottom: bottom && Object.assign({ x: bottom.x1, y: bottom.y1 }, yProps),
+        left: left && Object.assign({ y: left.y1, x: left.x1 }, xProps),
+        right: right && Object.assign({ y: right.y1, x: right.x1 }, xProps),
       };
       const handles = ["top", "bottom", "left", "right"].reduce(
         (memo, curr) =>
@@ -204,7 +204,10 @@ export const brushContainerMixin = <TBase extends Constructor>(base: TBase) =>
             ? memo.concat(
                 React.cloneElement(
                   handleComponent,
-                  assign({ key: `${name}-handle-${curr}` }, handleProps[curr]),
+                  Object.assign(
+                    { key: `${name}-handle-${curr}` },
+                    handleProps[curr],
+                  ),
                 ),
               )
             : memo,

--- a/packages/victory-brush-line/src/victory-brush-line.tsx
+++ b/packages/victory-brush-line/src/victory-brush-line.tsx
@@ -11,7 +11,7 @@ import {
   DomainTuple,
   VictoryStyleObject,
 } from "victory-core";
-import { assign, defaults, isFunction, pick } from "lodash";
+import { defaults, isFunction, pick } from "lodash";
 import isEqual from "react-fast-compare";
 
 export type VictoryBrushLineTargetType = "data" | "labels" | "parent";
@@ -597,16 +597,16 @@ export class VictoryBrushLine extends React.Component<VictoryBrushLineProps> {
       return null;
     }
     const handleDimensions = this.getHandleDimensions(props);
-    const style = assign({}, fallbackProps.handleStyle, handleStyle);
-    const minDatum = assign(
+    const style = Object.assign({}, fallbackProps.handleStyle, handleStyle);
+    const minDatum = Object.assign(
       { handleValue: Collection.getMinValue(brushDomain) },
       datum,
     );
-    const maxDatum = assign(
+    const maxDatum = Object.assign(
       { handleValue: Collection.getMaxValue(brushDomain) },
       datum,
     );
-    const minHandleProps = assign(
+    const minHandleProps = Object.assign(
       {
         key: `${id}-min`,
         style: Helpers.evaluateStyle(style, {
@@ -616,7 +616,7 @@ export class VictoryBrushLine extends React.Component<VictoryBrushLineProps> {
       },
       handleDimensions.min,
     );
-    const maxHandleProps = assign(
+    const maxHandleProps = Object.assign(
       {
         key: `${id}-max`,
         style: Helpers.evaluateStyle(style, {
@@ -645,12 +645,12 @@ export class VictoryBrushLine extends React.Component<VictoryBrushLineProps> {
     }
     const brushWidth = props.brushWidth || props.width;
     const rectDimensions = this.getRectDimensions(props, brushWidth);
-    const baseStyle = assign({}, fallbackProps.brushStyle, brushStyle);
+    const baseStyle = Object.assign({}, fallbackProps.brushStyle, brushStyle);
     const style = Helpers.evaluateStyle(baseStyle, {
       datum,
       active: activeBrushes.brush,
     });
-    const brushProps = assign({ style }, rectDimensions);
+    const brushProps = Object.assign({ style }, rectDimensions);
     return React.cloneElement(brushComponent, brushProps);
   }
 
@@ -668,7 +668,7 @@ export class VictoryBrushLine extends React.Component<VictoryBrushLineProps> {
       brushAreaWidth,
       getFullDomain(props),
     );
-    const baseStyle = assign(
+    const baseStyle = Object.assign(
       { cursor },
       fallbackProps.brushAreaStyle,
       brushAreaStyle,
@@ -677,7 +677,7 @@ export class VictoryBrushLine extends React.Component<VictoryBrushLineProps> {
       datum,
       active: activeBrushes.brushArea,
     });
-    const brushAreaProps = assign({ style }, rectDimensions);
+    const brushAreaProps = Object.assign({ style }, rectDimensions);
     return React.cloneElement(brushAreaComponent, brushAreaProps);
   }
 

--- a/packages/victory-candlestick/src/candle.tsx
+++ b/packages/victory-candlestick/src/candle.tsx
@@ -7,7 +7,7 @@ import {
   VictoryCommonPrimitiveProps,
   VictoryStyleObject,
 } from "victory-core";
-import { assign, defaults, isFunction } from "lodash";
+import { defaults, isFunction } from "lodash";
 
 export interface CandleProps extends VictoryCommonPrimitiveProps {
   candleRatio?: number;
@@ -90,12 +90,12 @@ const evaluateProps = (props) => {
    * `tabIndex`
    */
   const style = Helpers.evaluateStyle(
-    assign({ stroke: "black" }, props.style),
+    Object.assign({ stroke: "black" }, props.style),
     props,
   );
   const candleWidth = getCandleWidth(
     props.candleWidth,
-    assign({}, props, { style }),
+    Object.assign({}, props, { style }),
   );
 
   const ariaLabel = Helpers.evaluateProp(props.ariaLabel, props);
@@ -103,7 +103,7 @@ const evaluateProps = (props) => {
   const id = Helpers.evaluateProp(props.id, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, {
+  return Object.assign({}, props, {
     ariaLabel,
     style,
     candleWidth,
@@ -151,12 +151,15 @@ export const Candle = (props: CandleProps) => {
     desc,
     tabIndex,
   };
-  const candleProps = assign(getCandleProps(modifiedProps, style), sharedProps);
-  const highWickProps = assign(
+  const candleProps = Object.assign(
+    getCandleProps(modifiedProps, style),
+    sharedProps,
+  );
+  const highWickProps = Object.assign(
     getHighWickProps(modifiedProps, wickStyle),
     sharedProps,
   );
-  const lowWickProps = assign(
+  const lowWickProps = Object.assign(
     getLowWickProps(modifiedProps, wickStyle),
     sharedProps,
   );

--- a/packages/victory-candlestick/src/helper-methods.ts
+++ b/packages/victory-candlestick/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { assign, defaults, isNil, isFunction, isPlainObject } from "lodash";
+import { defaults, isNil, isFunction, isPlainObject } from "lodash";
 import {
   Helpers,
   Scale,
@@ -205,7 +205,7 @@ const getDataStyles = (
   const fill = style.fill || candleColor;
   const strokeColor = style.stroke;
   const stroke = isTransparent(strokeColor) ? fill : strokeColor || "black";
-  return assign({}, style, { stroke, fill });
+  return Object.assign({}, style, { stroke, fill });
 };
 
 const getText = (props, type) => {

--- a/packages/victory-canvas/src/canvas-bar.tsx
+++ b/packages/victory-canvas/src/canvas-bar.tsx
@@ -1,4 +1,3 @@
-import { assign } from "lodash";
 import React from "react";
 import {
   BarProps,
@@ -36,12 +35,19 @@ const evaluateProps = (props: CanvasBarProps) => {
    * 3) `cornerRadius`
    */
   const style = getStyle(props.style, props as BarProps);
-  const barWidth = getBarWidth(props.barWidth, assign({}, props, { style }));
+  const barWidth = getBarWidth(
+    props.barWidth,
+    Object.assign({}, props, { style }),
+  );
   const cornerRadius = getCornerRadius(
     props.cornerRadius,
-    assign({}, props, { style, barWidth }),
+    Object.assign({}, props, { style, barWidth }),
   );
-  const modifiedProps = assign({}, props, { style, barWidth, cornerRadius });
+  const modifiedProps = Object.assign({}, props, {
+    style,
+    barWidth,
+    cornerRadius,
+  });
   return modifiedProps;
 };
 

--- a/packages/victory-canvas/src/canvas-point.tsx
+++ b/packages/victory-canvas/src/canvas-point.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { assign } from "lodash";
 import {
   Helpers,
   PointPathHelpers,
@@ -53,7 +52,7 @@ const evaluateProps = (props: CanvasPointProps) => {
   const style = Helpers.evaluateStyle(props.style, props);
   const symbol = Helpers.evaluateProp(props.symbol, props);
 
-  return assign({}, props, {
+  return Object.assign({}, props, {
     size,
     style,
     symbol,

--- a/packages/victory-chart/src/helper-methods.tsx
+++ b/packages/victory-chart/src/helper-methods.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Helpers, Scale, Axis, Wrapper } from "victory-core";
-import { defaults, assign } from "lodash";
+import { defaults } from "lodash";
 
 const fallbackProps = {
   width: 450,
@@ -90,8 +90,16 @@ export function getCalculatedProps(initialProps, childComponents) {
   const categories = Wrapper.getCategories(props, childComponents, allStrings);
   const stringMap = createStringMap(props, childComponents, allStrings);
   const domain = {
-    x: getDomain(assign({}, props, { categories }), "x", childComponents),
-    y: getDomain(assign({}, props, { categories }), "y", childComponents),
+    x: getDomain(
+      Object.assign({}, props, { categories }),
+      "x",
+      childComponents,
+    ),
+    y: getDomain(
+      Object.assign({}, props, { categories }),
+      "y",
+      childComponents,
+    ),
   };
 
   const range = {

--- a/packages/victory-chart/src/victory-chart.tsx
+++ b/packages/victory-chart/src/victory-chart.tsx
@@ -1,4 +1,4 @@
-import { defaults, assign, isEmpty } from "lodash";
+import { defaults, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import {
@@ -97,7 +97,7 @@ const VictoryChartImpl: React.FC<VictoryChartProps> = (initialProps) => {
     const children = getChildren(props, childComponents, calculatedProps);
 
     const mappedChildren = children.map((child, index) => {
-      const childProps = assign(
+      const childProps = Object.assign(
         { animate: getAnimationProps(props, child, index) },
         child.props,
       );

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.tsx
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.tsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import * as CustomPropTypes from "../victory-util/prop-types";
 import * as Helpers from "../victory-util/helpers";
 import * as UserProps from "../victory-util/user-props";
-import { assign, defaults, isObject, uniqueId } from "lodash";
+import { defaults, isObject, uniqueId } from "lodash";
 import { ClipPath } from "../victory-primitives/clip-path";
 import { Circle } from "../victory-primitives/circle";
 import { Rect } from "../victory-primitives/rect";
@@ -120,7 +120,7 @@ export class VictoryClipContainer extends React.Component<VictoryClipContainerPr
       tabIndex,
     } = props;
     const clipComponent = this.renderClipComponent(props, clipId);
-    const groupProps = assign(
+    const groupProps = Object.assign(
       {
         className,
         style,
@@ -149,7 +149,7 @@ export class VictoryClipContainer extends React.Component<VictoryClipContainerPr
     } = props;
     return React.cloneElement(
       groupComponent,
-      assign(
+      Object.assign(
         {
           className,
           style,
@@ -199,7 +199,7 @@ export class VictoryClipContainer extends React.Component<VictoryClipContainerPr
 
     return React.cloneElement(
       clipPathComponent,
-      assign({ key: `clip-path-${clipId}` }, props, { clipId }),
+      Object.assign({ key: `clip-path-${clipId}` }, props, { clipId }),
       child,
     );
   }

--- a/packages/victory-core/src/victory-container/victory-container.tsx
+++ b/packages/victory-core/src/victory-container/victory-container.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import * as CustomPropTypes from "../victory-util/prop-types";
-import { assign, defaults, uniqueId, isObject, isFunction } from "lodash";
+import { defaults, uniqueId, isObject, isFunction } from "lodash";
 import { Portal } from "../victory-portal/portal";
 import { PortalContext } from "../victory-portal/portal-context";
 import TimerContext from "../victory-util/timer-context";
@@ -170,7 +170,7 @@ export class VictoryContainer extends React.Component<VictoryContainerProps> {
     const dimensions = responsive
       ? { width: "100%", height: "100%" }
       : { width, height };
-    const divStyle = assign(
+    const divStyle = Object.assign(
       {
         pointerEvents: "none",
         touchAction: "none",
@@ -178,12 +178,12 @@ export class VictoryContainer extends React.Component<VictoryContainerProps> {
       } as const,
       dimensions,
     );
-    const portalDivStyle = assign(
+    const portalDivStyle = Object.assign(
       { zIndex: portalZIndex, position: "absolute", top: 0, left: 0 } as const,
       dimensions,
     );
-    const svgStyle = assign({ pointerEvents: "all" }, dimensions);
-    const portalSvgStyle = assign({ overflow: "visible" }, dimensions);
+    const svgStyle = Object.assign({ pointerEvents: "all" }, dimensions);
+    const portalSvgStyle = Object.assign({ overflow: "visible" }, dimensions);
     const portalProps = {
       width,
       height,
@@ -244,7 +244,7 @@ export class VictoryContainer extends React.Component<VictoryContainerProps> {
 
     const userProps = UserProps.getSafeUserProps(this.props);
 
-    const svgProps = assign(
+    const svgProps = Object.assign(
       {
         width,
         height,

--- a/packages/victory-core/src/victory-label/victory-label.tsx
+++ b/packages/victory-core/src/victory-label/victory-label.tsx
@@ -1,5 +1,5 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-0.5, 0.5, 0, 1, 2] }]*/
-import { assign, defaults, isEmpty } from "lodash";
+import { defaults, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import { VictoryPortal } from "../victory-portal/victory-portal";
@@ -125,7 +125,7 @@ const getStyles = (style, props) => {
       s ? defaults({}, s, defaultStyles) : defaultStyles,
       props,
     );
-    return assign({}, baseStyles, { fontSize: getFontSize(baseStyles) });
+    return Object.assign({}, baseStyles, { fontSize: getFontSize(baseStyles) });
   };
 
   return Array.isArray(style) && !isEmpty(style)
@@ -464,16 +464,16 @@ const evaluateProps = (props) => {
     3) everything else
   */
   const text = getContent(props.text, props);
-  const style = getStyles(props.style, assign({}, props, { text }));
+  const style = getStyles(props.style, Object.assign({}, props, { text }));
   const backgroundStyle = getBackgroundStyles(
     props.backgroundStyle,
-    assign({}, props, { text, style }),
+    Object.assign({}, props, { text, style }),
   );
   const backgroundPadding = getBackgroundPadding(
-    assign({}, props, { text, style, backgroundStyle }),
+    Object.assign({}, props, { text, style, backgroundStyle }),
   );
   const id = Helpers.evaluateProp(props.id, props);
-  return assign({}, props, {
+  return Object.assign({}, props, {
     backgroundStyle,
     backgroundPadding,
     style,
@@ -501,7 +501,7 @@ const getCalculatedProps = <T extends VictoryLabelProps>(props: T) => {
   const y = props.y !== undefined ? props.y : getPosition(props, "y");
   const transform = getTransform(props, x, y);
 
-  return assign({}, props, {
+  return Object.assign({}, props, {
     ariaLabel,
     lineHeight,
     direction,

--- a/packages/victory-core/src/victory-primitives/arc.tsx
+++ b/packages/victory-core/src/victory-primitives/arc.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import * as Helpers from "../victory-util/helpers";
-import { assign } from "lodash";
 import {
   CommonProps,
   VictoryCommonPrimitiveProps,
@@ -54,12 +53,12 @@ const evaluateProps = (props) => {
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(
-    assign({ stroke: "black", fill: "none" }, props.style),
+    Object.assign({ stroke: "black", fill: "none" }, props.style),
     props,
   );
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, { ariaLabel, desc, id, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, desc, id, style, tabIndex });
 };
 
 const defaultProps = {

--- a/packages/victory-core/src/victory-primitives/background.tsx
+++ b/packages/victory-core/src/victory-primitives/background.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { assign } from "lodash";
 import * as Helpers from "../victory-util/helpers";
 import {
   CommonProps,
@@ -27,7 +26,7 @@ const evaluateProps = (props) => {
    */
   const id = Helpers.evaluateProp(props.id, props);
 
-  return assign({}, props, { id });
+  return Object.assign({}, props, { id });
 };
 
 const defaultProps = {

--- a/packages/victory-core/src/victory-primitives/border.tsx
+++ b/packages/victory-core/src/victory-primitives/border.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import * as Helpers from "../victory-util/helpers";
-import { assign } from "lodash";
 import {
   CommonProps,
   VictoryCommonPrimitiveProps,
@@ -29,12 +28,12 @@ const evaluateProps = (props) => {
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(
-    assign({ fill: "none" }, props.style),
+    Object.assign({ fill: "none" }, props.style),
     props,
   );
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, { ariaLabel, desc, id, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, desc, id, style, tabIndex });
 };
 
 const defaultProps = {

--- a/packages/victory-core/src/victory-primitives/line-segment.tsx
+++ b/packages/victory-core/src/victory-primitives/line-segment.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import * as Helpers from "../victory-util/helpers";
-import { assign } from "lodash";
 import {
   CommonProps,
   VictoryCommonPrimitiveProps,
@@ -30,12 +29,12 @@ const evaluateProps = (props) => {
   const desc = Helpers.evaluateProp(props.desc, props);
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(
-    assign({ stroke: "black" }, props.style),
+    Object.assign({ stroke: "black" }, props.style),
     props,
   );
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, { ariaLabel, desc, id, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, desc, id, style, tabIndex });
 };
 
 const defaultProps = {

--- a/packages/victory-core/src/victory-primitives/point.test.tsx
+++ b/packages/victory-core/src/victory-primitives/point.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "@testing-library/react";
-import { assign } from "lodash";
 import React from "react";
 import { PointPathHelpers as pathHelpers, Point } from "victory-core";
 import { SVGWrapper } from "../../../../test/helpers";
@@ -29,7 +28,7 @@ describe("victory-primitives/point", () => {
         .spyOn(pathHelpers, symbol)
         // eslint-disable-next-line max-nested-callbacks
         .mockImplementation(() => `${symbol} symbol`);
-      const props = assign({}, baseProps, { symbol });
+      const props = Object.assign({}, baseProps, { symbol });
       const { container } = render(<Point {...props} />, {
         wrapper: SVGWrapper,
       });

--- a/packages/victory-core/src/victory-primitives/point.tsx
+++ b/packages/victory-core/src/victory-primitives/point.tsx
@@ -1,4 +1,3 @@
-import { assign } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import * as Helpers from "../victory-util/helpers";
@@ -55,7 +54,7 @@ const evaluateProps = (props) => {
   const symbol = Helpers.evaluateProp(props.symbol, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, {
+  return Object.assign({}, props, {
     ariaLabel,
     desc,
     id,

--- a/packages/victory-core/src/victory-primitives/whisker.tsx
+++ b/packages/victory-core/src/victory-primitives/whisker.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { assign } from "lodash";
 import PropTypes from "prop-types";
 import * as Helpers from "../victory-util/helpers";
 import {
@@ -37,7 +36,7 @@ const evaluateProps = (props) => {
   const style = Helpers.evaluateStyle(props.style, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, { ariaLabel, desc, id, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, desc, id, style, tabIndex });
 };
 
 const defaultProps = {
@@ -80,7 +79,7 @@ export const Whisker = (initialProps: WhiskerProps) => {
   return React.cloneElement(groupComponent, {}, [
     React.cloneElement(
       lineComponent,
-      assign(
+      Object.assign(
         { key: "major-whisker", "aria-label": ariaLabel },
         baseProps,
         majorWhisker,
@@ -88,7 +87,7 @@ export const Whisker = (initialProps: WhiskerProps) => {
     ),
     React.cloneElement(
       lineComponent,
-      assign(
+      Object.assign(
         { key: "minor-whisker", "aria-label": ariaLabel },
         baseProps,
         minorWhisker,

--- a/packages/victory-core/src/victory-theme/grayscale.tsx
+++ b/packages/victory-core/src/victory-theme/grayscale.tsx
@@ -1,4 +1,3 @@
-import { assign } from "lodash";
 import { VictoryThemeDefinition } from "./types";
 
 // *
@@ -43,7 +42,10 @@ const baseLabelStyles = {
   stroke: "transparent",
 };
 
-const centeredLabelStyles = assign({ textAnchor: "middle" }, baseLabelStyles);
+const centeredLabelStyles = Object.assign(
+  { textAnchor: "middle" },
+  baseLabelStyles,
+);
 // *
 // * Strokes
 // *
@@ -51,7 +53,7 @@ const strokeLinecap = "round";
 const strokeLinejoin = "round";
 
 export const grayscale: VictoryThemeDefinition = {
-  area: assign(
+  area: Object.assign(
     {
       style: {
         data: {
@@ -62,7 +64,7 @@ export const grayscale: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  axis: assign(
+  axis: Object.assign(
     {
       style: {
         axis: {
@@ -72,7 +74,7 @@ export const grayscale: VictoryThemeDefinition = {
           strokeLinecap,
           strokeLinejoin,
         },
-        axisLabel: assign({}, centeredLabelStyles, {
+        axisLabel: Object.assign({}, centeredLabelStyles, {
           padding: 25,
         }),
         grid: {
@@ -90,7 +92,7 @@ export const grayscale: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  bar: assign(
+  bar: Object.assign(
     {
       style: {
         data: {
@@ -103,32 +105,32 @@ export const grayscale: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  boxplot: assign(
+  boxplot: Object.assign(
     {
       style: {
         max: { padding: 8, stroke: charcoal, strokeWidth: 1 },
-        maxLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        maxLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         median: { padding: 8, stroke: charcoal, strokeWidth: 1 },
-        medianLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        medianLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         min: { padding: 8, stroke: charcoal, strokeWidth: 1 },
-        minLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        minLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q1: { padding: 8, fill: grey },
-        q1Labels: assign({}, baseLabelStyles, { padding: 3 }),
+        q1Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q3: { padding: 8, fill: grey },
-        q3Labels: assign({}, baseLabelStyles, { padding: 3 }),
+        q3Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
       },
       boxWidth: 20,
     },
     baseProps,
   ),
-  candlestick: assign(
+  candlestick: Object.assign(
     {
       style: {
         data: {
           stroke: charcoal,
           strokeWidth: 1,
         },
-        labels: assign({}, baseLabelStyles, { padding: 5 }),
+        labels: Object.assign({}, baseLabelStyles, { padding: 5 }),
       },
       candleColors: {
         positive: "#ffffff",
@@ -138,7 +140,7 @@ export const grayscale: VictoryThemeDefinition = {
     baseProps,
   ),
   chart: baseProps,
-  errorbar: assign(
+  errorbar: Object.assign(
     {
       borderWidth: 8,
       style: {
@@ -152,13 +154,13 @@ export const grayscale: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  group: assign(
+  group: Object.assign(
     {
       colorScale: colors,
     },
     baseProps,
   ),
-  histogram: assign(
+  histogram: Object.assign(
     {
       style: {
         data: {
@@ -181,10 +183,10 @@ export const grayscale: VictoryThemeDefinition = {
         type: "circle",
       },
       labels: baseLabelStyles,
-      title: assign({}, baseLabelStyles, { padding: 5 }),
+      title: Object.assign({}, baseLabelStyles, { padding: 5 }),
     },
   },
-  line: assign(
+  line: Object.assign(
     {
       style: {
         data: {
@@ -204,14 +206,14 @@ export const grayscale: VictoryThemeDefinition = {
         stroke: "transparent",
         strokeWidth: 1,
       },
-      labels: assign({}, baseLabelStyles, { padding: 20 }),
+      labels: Object.assign({}, baseLabelStyles, { padding: 20 }),
     },
     colorScale: colors,
     width: 400,
     height: 400,
     padding: 50,
   },
-  scatter: assign(
+  scatter: Object.assign(
     {
       style: {
         data: {
@@ -224,14 +226,17 @@ export const grayscale: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  stack: assign(
+  stack: Object.assign(
     {
       colorScale: colors,
     },
     baseProps,
   ),
   tooltip: {
-    style: assign({}, baseLabelStyles, { padding: 0, pointerEvents: "none" }),
+    style: Object.assign({}, baseLabelStyles, {
+      padding: 0,
+      pointerEvents: "none",
+    }),
     flyoutStyle: {
       stroke: charcoal,
       strokeWidth: 1,
@@ -242,7 +247,7 @@ export const grayscale: VictoryThemeDefinition = {
     cornerRadius: 5,
     pointerLength: 10,
   },
-  voronoi: assign(
+  voronoi: Object.assign(
     {
       style: {
         data: {
@@ -250,7 +255,7 @@ export const grayscale: VictoryThemeDefinition = {
           stroke: "transparent",
           strokeWidth: 0,
         },
-        labels: assign({}, baseLabelStyles, {
+        labels: Object.assign({}, baseLabelStyles, {
           padding: 5,
           pointerEvents: "none",
         }),

--- a/packages/victory-core/src/victory-theme/material.tsx
+++ b/packages/victory-core/src/victory-theme/material.tsx
@@ -1,4 +1,3 @@
-import { assign } from "lodash";
 import { VictoryThemeDefinition } from "./types";
 
 // *
@@ -50,7 +49,10 @@ const baseLabelStyles = {
   strokeWidth: 0,
 };
 
-const centeredLabelStyles = assign({ textAnchor: "middle" }, baseLabelStyles);
+const centeredLabelStyles = Object.assign(
+  { textAnchor: "middle" },
+  baseLabelStyles,
+);
 // *
 // * Strokes
 // *
@@ -59,7 +61,7 @@ const strokeLinecap = "round";
 const strokeLinejoin = "round";
 
 export const material: VictoryThemeDefinition = {
-  area: assign(
+  area: Object.assign(
     {
       style: {
         data: {
@@ -70,7 +72,7 @@ export const material: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  axis: assign(
+  axis: Object.assign(
     {
       style: {
         axis: {
@@ -80,7 +82,7 @@ export const material: VictoryThemeDefinition = {
           strokeLinecap,
           strokeLinejoin,
         },
-        axisLabel: assign({}, centeredLabelStyles, {
+        axisLabel: Object.assign({}, centeredLabelStyles, {
           padding,
           stroke: "transparent",
         }),
@@ -100,14 +102,14 @@ export const material: VictoryThemeDefinition = {
           strokeLinecap,
           strokeLinejoin,
         },
-        tickLabels: assign({}, baseLabelStyles, {
+        tickLabels: Object.assign({}, baseLabelStyles, {
           fill: blueGrey700,
         }),
       },
     },
     baseProps,
   ),
-  polarDependentAxis: assign({
+  polarDependentAxis: Object.assign({
     style: {
       ticks: {
         fill: "transparent",
@@ -116,7 +118,7 @@ export const material: VictoryThemeDefinition = {
       },
     },
   }),
-  bar: assign(
+  bar: Object.assign(
     {
       style: {
         data: {
@@ -129,31 +131,31 @@ export const material: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  boxplot: assign(
+  boxplot: Object.assign(
     {
       style: {
         max: { padding, stroke: blueGrey700, strokeWidth: 1 },
-        maxLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        maxLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         median: { padding, stroke: blueGrey700, strokeWidth: 1 },
-        medianLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        medianLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         min: { padding, stroke: blueGrey700, strokeWidth: 1 },
-        minLabels: assign({}, baseLabelStyles, { padding: 3 }),
+        minLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q1: { padding, fill: blueGrey700 },
-        q1Labels: assign({}, baseLabelStyles, { padding: 3 }),
+        q1Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         q3: { padding, fill: blueGrey700 },
-        q3Labels: assign({}, baseLabelStyles, { padding: 3 }),
+        q3Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
       },
       boxWidth: 20,
     },
     baseProps,
   ),
-  candlestick: assign(
+  candlestick: Object.assign(
     {
       style: {
         data: {
           stroke: blueGrey700,
         },
-        labels: assign({}, baseLabelStyles, { padding: 5 }),
+        labels: Object.assign({}, baseLabelStyles, { padding: 5 }),
       },
       candleColors: {
         positive: "#ffffff",
@@ -163,7 +165,7 @@ export const material: VictoryThemeDefinition = {
     baseProps,
   ),
   chart: baseProps,
-  errorbar: assign(
+  errorbar: Object.assign(
     {
       borderWidth: 8,
       style: {
@@ -178,13 +180,13 @@ export const material: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  group: assign(
+  group: Object.assign(
     {
       colorScale: colors,
     },
     baseProps,
   ),
-  histogram: assign(
+  histogram: Object.assign(
     {
       style: {
         data: {
@@ -207,10 +209,10 @@ export const material: VictoryThemeDefinition = {
         type: "circle",
       },
       labels: baseLabelStyles,
-      title: assign({}, baseLabelStyles, { padding: 5 }),
+      title: Object.assign({}, baseLabelStyles, { padding: 5 }),
     },
   },
-  line: assign(
+  line: Object.assign(
     {
       style: {
         data: {
@@ -224,7 +226,7 @@ export const material: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  pie: assign(
+  pie: Object.assign(
     {
       colorScale: colors,
       style: {
@@ -233,12 +235,12 @@ export const material: VictoryThemeDefinition = {
           stroke: blueGrey50,
           strokeWidth: 1,
         },
-        labels: assign({}, baseLabelStyles, { padding: 20 }),
+        labels: Object.assign({}, baseLabelStyles, { padding: 20 }),
       },
     },
     baseProps,
   ),
-  scatter: assign(
+  scatter: Object.assign(
     {
       style: {
         data: {
@@ -252,14 +254,17 @@ export const material: VictoryThemeDefinition = {
     },
     baseProps,
   ),
-  stack: assign(
+  stack: Object.assign(
     {
       colorScale: colors,
     },
     baseProps,
   ),
   tooltip: {
-    style: assign({}, baseLabelStyles, { padding: 0, pointerEvents: "none" }),
+    style: Object.assign({}, baseLabelStyles, {
+      padding: 0,
+      pointerEvents: "none",
+    }),
     flyoutStyle: {
       stroke: grey900,
       strokeWidth: 1,
@@ -270,7 +275,7 @@ export const material: VictoryThemeDefinition = {
     cornerRadius: 5,
     pointerLength: 10,
   },
-  voronoi: assign(
+  voronoi: Object.assign(
     {
       style: {
         data: {
@@ -278,7 +283,7 @@ export const material: VictoryThemeDefinition = {
           stroke: "transparent",
           strokeWidth: 0,
         },
-        labels: assign({}, baseLabelStyles, {
+        labels: Object.assign({}, baseLabelStyles, {
           padding: 5,
           pointerEvents: "none",
         }),

--- a/packages/victory-core/src/victory-util/add-events.tsx
+++ b/packages/victory-core/src/victory-util/add-events.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  assign,
   defaults,
   difference,
   isEmpty,
@@ -389,7 +388,7 @@ export function addEvents<
           componentProps.events,
         );
 
-        return assign({}, componentProps, { events });
+        return Object.assign({}, componentProps, { events });
       }
 
       return defaults({ index, key: id }, currentProps, baseProps, { id });

--- a/packages/victory-core/src/victory-util/axis.tsx
+++ b/packages/victory-core/src/victory-util/axis.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  assign,
   defaults,
   identity,
   isFunction,
@@ -393,9 +392,9 @@ export function modifyProps(props, fallbackProps) {
     return Helpers.modifyProps(props, fallbackProps, "axis");
   }
   const axisTheme = defaults({}, props.theme[role], props.theme.axis);
-  const theme = assign({}, props.theme, { axis: axisTheme });
+  const theme = Object.assign({}, props.theme, { axis: axisTheme });
   return Helpers.modifyProps(
-    assign({}, props, { theme }),
+    Object.assign({}, props, { theme }),
     fallbackProps,
     "axis",
   );

--- a/packages/victory-core/src/victory-util/data.ts
+++ b/packages/victory-core/src/victory-util/data.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-use-before-define */
 import React from "react";
 import {
-  assign,
   uniq,
   range,
   last,
@@ -84,7 +83,7 @@ function cleanData(dataset, props) {
     const _x = rules(datum, "x") ? datum._x : smallNumber;
     const _y = rules(datum, "y") ? datum._y : smallNumber;
     const _y0 = rules(datum, "y0") ? datum._y0 : smallNumber;
-    return assign({}, datum, { _x, _y, _y0 });
+    return Object.assign({}, datum, { _x, _y, _y0 });
   };
 
   return dataset.map((datum) => {
@@ -117,7 +116,9 @@ function addEventKeys(props, data) {
       return datum;
     } else if (hasEventKeyAccessor) {
       const eventKey = eventKeyAccessor(datum, index);
-      return eventKey !== undefined ? assign({ eventKey }, datum) : datum;
+      return eventKey !== undefined
+        ? Object.assign({ eventKey }, datum)
+        : datum;
     }
     return datum;
   });
@@ -170,7 +171,7 @@ export function formatDataFromDomain(dataset, domain, defaultBaseline?) {
     // baseline and value with only baseline above max, set baseline to maxDomainY
     if (isOverMaxY(baseline) && !isOverMaxY(value)) _y0 = maxDomainY;
 
-    return assign({}, datum, omitBy({ _x, _y, _y0, _y1 }, isUndefined));
+    return Object.assign({}, datum, omitBy({ _x, _y, _y0, _y1 }, isUndefined));
   });
 }
 
@@ -304,7 +305,7 @@ export function formatData(
           return memo;
         }, {});
 
-        const formattedDatum = assign({}, processedValues, parsedDatum);
+        const formattedDatum = Object.assign({}, processedValues, parsedDatum);
         if (!isEmpty(formattedDatum)) {
           dataArr.push(formattedDatum);
         }

--- a/packages/victory-core/src/victory-util/events.ts
+++ b/packages/victory-core/src/victory-util/events.ts
@@ -214,7 +214,9 @@ export function getScopedEvents(
               [key]: Object.assign(state[key] || {}, mutatedProps),
             })
           : Object.assign(state, {
-              [key]: Object.assign(state[key] || {}, { [target]: mutatedProps }),
+              [key]: Object.assign(state[key] || {}, {
+                [target]: mutatedProps,
+              }),
             });
       };
 

--- a/packages/victory-core/src/victory-util/events.ts
+++ b/packages/victory-core/src/victory-util/events.ts
@@ -211,10 +211,10 @@ export function getScopedEvents(
       const extendState = (state) => {
         return target === "parent"
           ? Object.assign(state, {
-              [key]: Object.assign(state[key], mutatedProps),
+              [key]: Object.assign(state[key] || {}, mutatedProps),
             })
           : Object.assign(state, {
-              [key]: Object.assign(state[key], { [target]: mutatedProps }),
+              [key]: Object.assign(state[key] || {}, { [target]: mutatedProps }),
             });
       };
 

--- a/packages/victory-core/src/victory-util/events.ts
+++ b/packages/victory-core/src/victory-util/events.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-use-before-define */
 import {
-  assign,
   isEmpty,
   isFunction,
   without,
@@ -82,7 +81,7 @@ export function getEvents(
     return (
       Array.isArray(selectedEvents) &&
       selectedEvents.reduce((memo, event) => {
-        return event ? assign(memo, event.eventHandlers) : memo;
+        return event ? Object.assign(memo, event.eventHandlers) : memo;
       }, {} as ComponentEvent["eventHandlers"])
     );
   };
@@ -115,7 +114,7 @@ export function getEvents(
   const sharedEvents =
     props.sharedEvents.events &&
     getSharedEvents(getEventsByTarget(props.sharedEvents.events), target);
-  return assign({}, sharedEvents, ownEvents);
+  return Object.assign({}, sharedEvents, ownEvents);
 }
 
 /* Returns a modified events object where each event handler is replaced by a new
@@ -194,7 +193,7 @@ export function getScopedEvents(
         "state",
       );
       const mutatedProps = eventReturn.mutation(
-        assign({}, mutationTargetProps, mutationTargetState),
+        Object.assign({}, mutationTargetProps, mutationTargetState),
         newBaseProps,
       );
       const childState = baseState[childName] || {};
@@ -211,9 +210,11 @@ export function getScopedEvents(
 
       const extendState = (state) => {
         return target === "parent"
-          ? assign(state, { [key]: assign(state[key], mutatedProps) })
-          : assign(state, {
-              [key]: assign(state[key], { [target]: mutatedProps }),
+          ? Object.assign(state, {
+              [key]: Object.assign(state[key], mutatedProps),
+            })
+          : Object.assign(state, {
+              [key]: Object.assign(state[key], { [target]: mutatedProps }),
             });
       };
 
@@ -222,7 +223,7 @@ export function getScopedEvents(
       };
 
       return childName !== undefined && childName !== null
-        ? assign(baseState, { [childName]: updateState(childState) })
+        ? Object.assign(baseState, { [childName]: updateState(childState) })
         : updateState(baseState);
     };
 
@@ -231,7 +232,7 @@ export function getScopedEvents(
       const mutationKeys = getKeys(childName);
       return Array.isArray(mutationKeys)
         ? mutationKeys.reduce((memo, key) => {
-            return assign(memo, getMutationObject(key, childName));
+            return Object.assign(memo, getMutationObject(key, childName));
           }, {})
         : getMutationObject(mutationKeys, childName);
     };
@@ -241,7 +242,7 @@ export function getScopedEvents(
       childNames === "all" ? without(keys(newBaseProps), "parent") : childNames;
     return Array.isArray(allChildNames)
       ? allChildNames.reduce((memo, childName) => {
-          return assign(memo, getReturnByChild(childName));
+          return Object.assign(memo, getReturnByChild(childName));
         }, {})
       : getReturnByChild(allChildNames);
   };
@@ -250,7 +251,7 @@ export function getScopedEvents(
   const parseEventReturn = (eventReturn, eventKey) => {
     return Array.isArray(eventReturn)
       ? eventReturn.reduce(
-          (memo, props) => assign({}, memo, parseEvent(props, eventKey)),
+          (memo, props) => Object.assign({}, memo, parseEvent(props, eventKey)),
           {},
         )
       : parseEvent(eventReturn, eventKey);
@@ -394,7 +395,9 @@ export function getExternalMutations(
         identifier,
       );
       memo[eventKey] =
-        mutation !== undefined ? assign({}, keyState, mutation) : keyState;
+        mutation !== undefined
+          ? Object.assign({}, keyState, mutation)
+          : keyState;
     } else {
       // use keys from both state and props so that elements not intially included in baseProps
       // will be used. (i.e. labels)
@@ -409,7 +412,7 @@ export function getExternalMutations(
         );
         m[target] =
           mutation !== undefined
-            ? assign({}, keyState[target], mutation)
+            ? Object.assign({}, keyState[target], mutation)
             : keyState[target];
         return pickBy(m, (v) => !isEmpty(v));
       }, {});
@@ -466,8 +469,10 @@ export function getExternalMutation(
   return keyMutations.reduce((memo, curr) => {
     const mutationFunction =
       curr && isFunction(curr.mutation) ? curr.mutation : () => undefined;
-    const currentMutation = mutationFunction(assign({}, baseProps, baseState));
-    return assign({}, memo, currentMutation);
+    const currentMutation = mutationFunction(
+      Object.assign({}, baseProps, baseState),
+    );
+    return Object.assign({}, memo, currentMutation);
   }, {});
 }
 
@@ -503,4 +508,4 @@ export const omitGlobalEvents = (events) =>
   omitBy(events, (_, key) => GLOBAL_EVENT_REGEX.test(key));
 
 export const emulateReactEvent = (event) =>
-  assign(event, { nativeEvent: event });
+  Object.assign(event, { nativeEvent: event });

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 import React, { isValidElement } from "react";
-import { defaults, isFunction, property, pick, assign, keys } from "lodash";
+import { defaults, isFunction, property, pick, keys } from "lodash";
 import { CallbackArgs } from "../types/callbacks";
 import { ValueOrAccessor } from "../types/prop-types";
 
@@ -262,7 +262,7 @@ export function reduceChildren<
       const childRole = child.type && child.type.role;
       const childName = child.props.name || `${childRole}-${names[index]}`;
       if (child.props && child.props.children) {
-        const childProps = assign(
+        const childProps = Object.assign(
           {},
           child.props,
           pick(parentProps, sharedProps),
@@ -278,7 +278,7 @@ export function reduceChildren<
                   child.props.children,
                 ) as Array<React.ReactElement>
               ).map((c) => {
-                const nestedChildProps = assign(
+                const nestedChildProps = Object.assign(
                   {},
                   c.props,
                   pick(childProps, sharedProps),

--- a/packages/victory-core/src/victory-util/label-helpers.test.tsx
+++ b/packages/victory-core/src/victory-util/label-helpers.test.tsx
@@ -1,5 +1,4 @@
 /* eslint max-nested-callbacks: 0 */
-import { assign } from "lodash";
 import React from "react";
 import { LabelHelpers, VictoryLabel } from "victory-core";
 import * as d3Scale from "victory-vendor/d3-scale";
@@ -25,7 +24,7 @@ describe("victory-util/label-helpers", () => {
     });
     it("returns the correct label text from a labels array", () => {
       const labels = ["one", "two"];
-      const props = assign({ labels }, basicProps);
+      const props = Object.assign({ labels }, basicProps);
       data.forEach((datum, index) => {
         const labelProps = LabelHelpers.getProps(props, index);
         expect(labelProps.text).toEqual(labels[index]);
@@ -36,7 +35,7 @@ describe("victory-util/label-helpers", () => {
         { x: 0, y: 0, label: "one" },
         { x: 0.5, y: 0.5, label: "two" },
       ];
-      const props = assign({}, basicProps, { data: dataWithLabels });
+      const props = Object.assign({}, basicProps, { data: dataWithLabels });
       data.forEach((datum, index) => {
         const labelProps = LabelHelpers.getProps(props, index);
         expect(labelProps.text).toEqual(dataWithLabels[index].label);
@@ -48,7 +47,7 @@ describe("victory-util/label-helpers", () => {
         y: d3Scale.scaleLinear(),
       };
       data.forEach((datum, index) => {
-        const props = assign({}, basicProps, {
+        const props = Object.assign({}, basicProps, {
           scale: polarScale,
           polar: true,
         });

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -1,6 +1,6 @@
 // http://www.pearsonified.com/2012/01/characters-per-line.php
 /* eslint-disable no-magic-numbers */
-import { assign, defaults, memoize } from "lodash";
+import { defaults, memoize } from "lodash";
 
 // Based on measuring specific character widths
 // as in the following example https://bl.ocks.org/tophtucker/62f93a4658387bb61e4510c37e2e97cf
@@ -189,7 +189,7 @@ export const convertLengthToPixels = (
 const _prepareParams = (inputStyle, index) => {
   const lineStyle = Array.isArray(inputStyle) ? inputStyle[index] : inputStyle;
   const style = defaults({}, lineStyle, defaultStyle);
-  return assign({}, style, {
+  return Object.assign({}, style, {
     fontFamily: style.fontFamily,
     letterSpacing:
       typeof style.letterSpacing === "number"

--- a/packages/victory-core/src/victory-util/transitions.ts
+++ b/packages/victory-core/src/victory-util/transitions.ts
@@ -1,4 +1,4 @@
-import { assign, defaults, identity, keys } from "lodash";
+import { defaults, identity, keys } from "lodash";
 import React from "react";
 import { AnimatePropTypeInterface } from "../types/prop-types";
 
@@ -131,13 +131,15 @@ function getInitialChildProps(animate, data): TransitionProps {
   const after =
     animate.onEnter && animate.onEnter.after ? animate.onEnter.after : identity;
   return {
-    data: data.map((datum, idx) => assign({}, datum, after(datum, idx, data))),
+    data: data.map((datum, idx) =>
+      Object.assign({}, datum, after(datum, idx, data)),
+    ),
   };
 }
 
 // eslint-disable-next-line max-params
 function getChildBeforeLoad(animate, child, data, cb): TransitionProps {
-  const newAnimate = assign({}, animate, { onEnd: cb });
+  const newAnimate = Object.assign({}, animate, { onEnd: cb });
 
   if (newAnimate && newAnimate.onLoad && !newAnimate.onLoad.duration) {
     return { animate: newAnimate, data };
@@ -148,7 +150,7 @@ function getChildBeforeLoad(animate, child, data, cb): TransitionProps {
       : identity;
   // If nodes need to exit, transform them with the provided onLoad.before function.
   const newData = data.map((datum, idx) => {
-    return assign({}, datum, before(datum, idx, data));
+    return Object.assign({}, datum, before(datum, idx, data));
   });
 
   return { animate: newAnimate, data: newData, clipWidth: 0 };
@@ -156,7 +158,7 @@ function getChildBeforeLoad(animate, child, data, cb): TransitionProps {
 
 // eslint-disable-next-line max-params
 function getChildOnLoad(animate, data, cb): TransitionProps {
-  const newAnimate = assign({}, animate, { onEnd: cb });
+  const newAnimate = Object.assign({}, animate, { onEnd: cb });
   let newData = data;
 
   if (newAnimate && newAnimate.onLoad && !newAnimate.onLoad.duration) {
@@ -166,7 +168,7 @@ function getChildOnLoad(animate, data, cb): TransitionProps {
     animate.onLoad && animate.onLoad.after ? animate.onLoad.after : identity;
   // If nodes need to exit, transform them with the provided onLoad.after function.
   newData = data.map((datum, idx) => {
-    return assign({}, datum, after(datum, idx, data));
+    return Object.assign({}, datum, after(datum, idx, data));
   });
 
   return { animate: newAnimate, data: newData };
@@ -183,7 +185,7 @@ function getChildPropsOnExit(
   // Whether or not _this_ child has exiting nodes, we want the exit-
   // transition for all children to have the same duration, delay, etc.
   const onExit = animate && animate.onExit;
-  const newAnimate = assign({}, animate, onExit);
+  const newAnimate = Object.assign({}, animate, onExit);
   let newData = data;
 
   if (exitingNodes) {
@@ -198,7 +200,7 @@ function getChildPropsOnExit(
     newData = data.map((datum, idx) => {
       const key = (datum.key || idx).toString();
       return exitingNodes[key]
-        ? assign({}, datum, before(datum, idx, data))
+        ? Object.assign({}, datum, before(datum, idx, data))
         : datum;
     });
   }
@@ -219,7 +221,7 @@ function getChildPropsBeforeEnter(
   if (enteringNodes) {
     // Perform a normal animation here, except - when it finishes - trigger
     // the transition for entering nodes.
-    newAnimate = assign({}, animate, { onEnd: cb });
+    newAnimate = Object.assign({}, animate, { onEnd: cb });
     const before =
       animate.onEnter && animate.onEnter.before
         ? animate.onEnter.before
@@ -230,7 +232,7 @@ function getChildPropsBeforeEnter(
     newData = data.map((datum, idx) => {
       const key = (datum.key || idx).toString();
       return enteringNodes[key]
-        ? assign({}, datum, before(datum, idx, data))
+        ? Object.assign({}, datum, before(datum, idx, data))
         : datum;
     });
   }
@@ -248,7 +250,7 @@ function getChildPropsOnEnter(
   // Whether or not _this_ child has entering nodes, we want the entering-
   // transition for all children to have the same duration, delay, etc.
   const onEnter = animate && animate.onEnter;
-  const newAnimate = assign({}, animate, onEnter);
+  const newAnimate = Object.assign({}, animate, onEnter);
   let newData = data;
 
   if (enteringNodes) {
@@ -263,7 +265,7 @@ function getChildPropsOnEnter(
     newData = data.map((datum, idx) => {
       const key = getDatumKey(datum, idx);
       return enteringNodes[key]
-        ? assign({}, datum, after(datum, idx, data))
+        ? Object.assign({}, datum, after(datum, idx, data))
         : datum;
     });
   }
@@ -392,7 +394,7 @@ export function getTransitionPropsFactory(props, state, setState) {
           ? transitionDurations.load
           : getChildTransitionDuration(child, "onLoad");
       const animation = { duration: load };
-      return onLoad(child, data, assign({}, animate, animation));
+      return onLoad(child, data, Object.assign({}, animate, animation));
     } else if (nodesWillExit) {
       const exitingNodes = childTransitions && childTransitions.exiting;
       const exit =
@@ -401,7 +403,12 @@ export function getTransitionPropsFactory(props, state, setState) {
           : getChildTransitionDuration(child, "onExit");
       // if nodesWillExit, but this child has no exiting nodes, set a delay instead of a duration
       const animation = exitingNodes ? { duration: exit } : { delay: exit };
-      return onExit(exitingNodes, child, data, assign({}, animate, animation));
+      return onExit(
+        exitingNodes,
+        child,
+        data,
+        Object.assign({}, animate, animation),
+      );
     } else if (nodesWillEnter) {
       const enteringNodes = childTransitions && childTransitions.entering;
       const enter =
@@ -419,7 +426,7 @@ export function getTransitionPropsFactory(props, state, setState) {
         enteringNodes,
         child,
         data,
-        assign({}, animate, animation),
+        Object.assign({}, animate, animation),
       );
     } else if (!state && animate && animate.onExit) {
       // This is the initial render, and nodes may enter when props change. Because

--- a/packages/victory-core/src/victory-util/wrapper.tsx
+++ b/packages/victory-core/src/victory-util/wrapper.tsx
@@ -1,5 +1,4 @@
 import {
-  assign,
   defaults,
   flatten,
   isFunction,
@@ -100,7 +99,7 @@ export function getDataFromChildren(props, childComponents) {
   });
 
   const iteratee = (child, childName, parent) => {
-    const childProps = assign({}, child.props, parentProps);
+    const childProps = Object.assign({}, child.props, parentProps);
     let childData;
     let childElement = child;
     if (!Data.isDataComponent(child)) {
@@ -113,7 +112,7 @@ export function getDataFromChildren(props, childComponents) {
     }
     stack += 1;
     return childData.map((datum, index) =>
-      assign({ _stack: stack, _group: index }, datum),
+      Object.assign({ _stack: stack, _group: index }, datum),
     );
   };
 
@@ -222,11 +221,11 @@ export function getDomainFromChildren(props, axis, childComponents) {
     categories,
   };
   const parentProps = parentData
-    ? assign(baseParentProps, { data: parentData })
+    ? Object.assign(baseParentProps, { data: parentData })
     : baseParentProps;
 
   const iteratee = (child) => {
-    const sharedProps = assign({}, child.props, parentProps);
+    const sharedProps = Object.assign({}, child.props, parentProps);
     if (!Domain.isDomainComponent(child)) {
       return null;
     } else if (child.type && isFunction(child.type.getDomain)) {
@@ -266,7 +265,11 @@ export function getDomain(props, axis, childComponents) {
       maxDomain || Collection.getMaxValue([...dataDomain, ...childDomain]);
     domain = Domain.getDomainFromMinMax(min, max);
   }
-  return Domain.formatDomain(domain, assign({ domainPadding }, props), axis);
+  return Domain.formatDomain(
+    domain,
+    Object.assign({ domainPadding }, props),
+    axis,
+  );
 }
 
 export function getScale(props, axis, childComponents?) {
@@ -277,7 +280,7 @@ export function getScale(props, axis, childComponents?) {
     ? childComponents.slice(0)
     : React.Children.toArray(props.children);
   const iteratee = (child) => {
-    const sharedProps = assign({}, child.props, {
+    const sharedProps = Object.assign({}, child.props, {
       horizontal: props.horizontal,
     });
     return Scale.getScaleType(sharedProps, axis);
@@ -347,7 +350,7 @@ export function getChildStyle(child, index, calculatedProps) {
   const dataStyle = defaults(
     {},
     childStyle.data,
-    assign({}, dataWidth, style.data, defaultColor),
+    Object.assign({}, dataWidth, style.data, defaultColor),
   );
   const labelsStyle = defaults({}, childStyle.labels, style.labels);
   return {

--- a/packages/victory-cursor-container/src/victory-cursor-container.tsx
+++ b/packages/victory-cursor-container/src/victory-cursor-container.tsx
@@ -10,7 +10,7 @@ import {
   VictoryLabelProps,
   ValueOrAccessor,
 } from "victory-core";
-import { defaults, assign, isObject } from "lodash";
+import { defaults, isObject } from "lodash";
 import { CursorHelpers } from "./cursor-helpers";
 
 export type CursorCoordinatesPropType = CoordinatesPropType | number;
@@ -192,7 +192,7 @@ export function cursorContainerMixin<
         );
       }
 
-      const cursorStyle = assign(
+      const cursorStyle = Object.assign(
         { stroke: "black" },
         cursorComponent.props.style,
       );

--- a/packages/victory-errorbar/src/error-bar.tsx
+++ b/packages/victory-errorbar/src/error-bar.tsx
@@ -9,7 +9,6 @@ import {
   VictoryCommonPrimitiveProps,
   EventsMixinClass,
 } from "victory-core";
-import { assign } from "lodash";
 
 const renderBorder = (props, error, type) => {
   const vertical = type === "right" || type === "left";
@@ -79,12 +78,12 @@ const evaluateProps = (props) => {
   const ariaLabel = Helpers.evaluateProp(props.ariaLabel, props);
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(
-    assign({ stroke: "black" }, props.style),
+    Object.assign({ stroke: "black" }, props.style),
     props,
   );
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, { ariaLabel, id, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, id, style, tabIndex });
 };
 
 export interface ErrorBarProps extends VictoryCommonPrimitiveProps {

--- a/packages/victory-errorbar/src/helper-methods.tsx
+++ b/packages/victory-errorbar/src/helper-methods.tsx
@@ -171,7 +171,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "errorbar",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     borderWidth,
     data,
@@ -242,7 +246,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       (labels && (events || sharedEvents))
     ) {
       childProps[eventKey].labels = getLabelProps(
-        assign({}, props, dataProps),
+        Object.assign({}, props, dataProps),
         text,
         style,
       );

--- a/packages/victory-group/src/helper-methods.tsx
+++ b/packages/victory-group/src/helper-methods.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-use-before-define */
-import { assign } from "lodash";
 import React from "react";
 import { Data, Helpers, Scale, Wrapper } from "victory-core";
 import isEqual from "react-fast-compare";
@@ -22,12 +21,12 @@ export function getCalculatedProps(initialProps, childComponents) {
   const datasets = props.datasets || Wrapper.getDataFromChildren(props, null);
   const domain = {
     x: Wrapper.getDomain(
-      assign({}, props, { categories }),
+      Object.assign({}, props, { categories }),
       "x",
       childComponents,
     ),
     y: Wrapper.getDomain(
-      assign({}, props, { categories }),
+      Object.assign({}, props, { categories }),
       "y",
       childComponents,
     ),
@@ -184,7 +183,7 @@ function getDataWithOffset(props, defaultDataset = [], offset) {
         ? new Date(datum._x.getTime() + xOffset)
         : datum._x + xOffset;
 
-    return assign({}, datum, { _x1 });
+    return Object.assign({}, datum, { _x1 });
   });
 }
 
@@ -212,7 +211,7 @@ export function getChildren(initialProps, childComponents?, calculatedProps?) {
     const name = child.props.name || `${parentName}-${role}-${index}`;
     return React.cloneElement(
       child,
-      assign(
+      Object.assign(
         {
           labels,
           style,

--- a/packages/victory-group/src/victory-group.tsx
+++ b/packages/victory-group/src/victory-group.tsx
@@ -1,4 +1,4 @@
-import { assign, defaults, isEmpty } from "lodash";
+import { defaults, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import {
@@ -95,7 +95,7 @@ const VictoryGroupBase: React.FC<VictoryGroupProps> = (initialProps) => {
   const newChildren = React.useMemo(() => {
     const children = getChildren(props, childComponents, calculatedProps);
     return children.map((child, index) => {
-      const childProps = assign(
+      const childProps = Object.assign(
         { animate: getAnimationProps(props, child, index) },
         child.props,
       );

--- a/packages/victory-histogram/src/helper-methods.ts
+++ b/packages/victory-histogram/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { assign, isNil } from "lodash";
+import { isNil } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 import { getBarPosition } from "victory-bar";
 import isEqual from "react-fast-compare";
@@ -187,7 +187,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "histogram",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
 
   const {
     binSpacing,

--- a/packages/victory-legend/src/helper-methods.ts
+++ b/packages/victory-legend/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { defaults, assign, groupBy, keys, sum, range, isNil } from "lodash";
+import { defaults, groupBy, keys, sum, range, isNil } from "lodash";
 import { Helpers, Style, TextSize } from "victory-core";
 import { VictoryLegendProps } from "./victory-legend";
 
@@ -37,7 +37,12 @@ const getCalculatedValues = (props) => {
   const colorScale = getColorScale(props);
   const isHorizontal = orientation === "horizontal";
   const borderPadding = Helpers.getPadding({ padding: props.borderPadding });
-  return assign({}, props, { style, isHorizontal, colorScale, borderPadding });
+  return Object.assign({}, props, {
+    style,
+    isHorizontal,
+    colorScale,
+    borderPadding,
+  });
 };
 
 const getColumn = (props, index) => {
@@ -196,7 +201,13 @@ const getBorderProps = (props, contentHeight, contentWidth) => {
   const height =
     (contentHeight || 0) + borderPadding.top + borderPadding.bottom;
   const width = (contentWidth || 0) + borderPadding.left + borderPadding.right;
-  return { x, y, height, width, style: assign({ fill: "none" }, style.border) };
+  return {
+    x,
+    y,
+    height,
+    width,
+    style: Object.assign({ fill: "none" }, style.border),
+  };
 };
 
 export const getDimensions = (initialProps, fallbackProps) => {
@@ -205,7 +216,11 @@ export const getDimensions = (initialProps, fallbackProps) => {
     fallbackProps,
     "legend",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const { title, titleOrientation } = props;
   const groupedData = groupData(props);
   const columnWidths = getColumnWidths(props, groupedData);
@@ -232,7 +247,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "legend",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     data,
     standalone,

--- a/packages/victory-line/src/curve.tsx
+++ b/packages/victory-line/src/curve.tsx
@@ -1,7 +1,6 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
-import { assign } from "lodash";
 import {
   Helpers,
   CommonProps,
@@ -24,7 +23,7 @@ const evaluateProps = (props) => {
   const ariaLabel = Helpers.evaluateProp(props.ariaLabel, props);
   const id = Helpers.evaluateProp(props.id, props);
   const style = Helpers.evaluateStyle(
-    assign(
+    Object.assign(
       { fill: "none", stroke: "black", pointerEvents: "stroke" },
       props.style,
     ),
@@ -32,7 +31,7 @@ const evaluateProps = (props) => {
   );
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, { ariaLabel, id, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, id, style, tabIndex });
 };
 
 const defaultProps = {

--- a/packages/victory-line/src/helper-methods.ts
+++ b/packages/victory-line/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { assign, isNil } from "lodash";
+import { isNil } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
 const getCalculatedValues = (props) => {
@@ -39,7 +39,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "line",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     data,
     domain,

--- a/packages/victory-native/src/components/victory-container.js
+++ b/packages/victory-native/src/components/victory-container.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Svg, { Rect } from "react-native-svg";
-import { assign, get } from "lodash";
+import { get } from "lodash";
 import { View, PanResponder } from "react-native";
 import { VictoryContainer } from "victory-core/es";
 import NativeHelpers from "../helpers/native-helpers";
@@ -11,7 +11,7 @@ const yes = () => true;
 const no = () => false;
 
 export default class extends VictoryContainer {
-  static propTypes = assign({}, VictoryContainer.propTypes, {
+  static propTypes = Object.assign({}, VictoryContainer.propTypes, {
     disableContainerEvents: PropTypes.bool,
     onTouchEnd: PropTypes.func,
     onTouchStart: PropTypes.func,
@@ -107,14 +107,14 @@ export default class extends VictoryContainer {
       ? { width: "100%", height: "100%" }
       : { width, height };
     const baseStyle = NativeHelpers.getStyle(style, ["width", "height"]);
-    const divStyle = assign({}, baseStyle, { position: "relative" });
+    const divStyle = Object.assign({}, baseStyle, { position: "relative" });
     const portalDivStyle = {
       zIndex: portalZIndex,
       position: "absolute",
       top: 0,
       left: 0,
     };
-    const portalSvgStyle = assign({ overflow: "visible" }, dimensions);
+    const portalSvgStyle = Object.assign({ overflow: "visible" }, dimensions);
     const portalProps = {
       width,
       height,

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -1,5 +1,5 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2, 45, 90, 135, 180, 225, 270, 315, 360] }]*/
-import { assign, defaults, isFunction, isPlainObject, isNil } from "lodash";
+import { defaults, isFunction, isPlainObject, isNil } from "lodash";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 import { Helpers, Data, Style } from "victory-core";
@@ -71,7 +71,7 @@ const getCalculatedValues = (props) => {
   const origin = getOrigin(props, padding);
   const data = Data.getData(props);
   const slices = getSlices(props, data);
-  return assign({}, props, {
+  return Object.assign({}, props, {
     style,
     colors,
     padding,
@@ -85,7 +85,7 @@ const getCalculatedValues = (props) => {
 const getSliceStyle = (index, calculatedValues) => {
   const { style, colors } = calculatedValues;
   const fill = getColor(style, colors, index);
-  return assign({ fill }, style.data);
+  return Object.assign({ fill }, style.data);
 };
 
 const getLabelText = (props, datum, index) => {
@@ -114,7 +114,7 @@ const getLabelPosition = (arc, slice, position) => {
     startAngle: position === "startAngle" ? slice.startAngle : slice.endAngle,
     endAngle: position === "endAngle" ? slice.endAngle : slice.startAngle,
   };
-  const clonedArc = assign({}, slice, construct);
+  const clonedArc = Object.assign({}, slice, construct);
   return arc.centroid(clonedArc);
 };
 
@@ -181,22 +181,22 @@ const getLabelProps = (text, dataProps, calculatedValues) => {
   const { style, defaultRadius, origin, width, height } = calculatedValues;
   const labelRadius = Helpers.evaluateProp(
     calculatedValues.labelRadius,
-    assign({ text }, dataProps),
+    Object.assign({ text }, dataProps),
   );
   const labelPosition =
     Helpers.evaluateProp(
       calculatedValues.labelPosition,
-      assign({ text }, dataProps),
+      Object.assign({ text }, dataProps),
     ) || "centroid";
   const labelPlacement =
     Helpers.evaluateProp(
       calculatedValues.labelPlacement,
-      assign({ text }, dataProps),
+      Object.assign({ text }, dataProps),
     ) || "vertical";
-  const labelStyle = assign({ padding: 0 }, style.labels);
+  const labelStyle = Object.assign({ padding: 0 }, style.labels);
   const evaluatedStyle = Helpers.evaluateStyle(
     labelStyle,
-    assign({ labelRadius, text }, dataProps),
+    Object.assign({ labelRadius, text }, dataProps),
   );
   const calculatedLabelRadius = getCalculatedLabelRadius(
     defaultRadius,
@@ -346,7 +346,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       const evaluatedText = Helpers.evaluateProp(text, dataProps);
       childProps[eventKey].labels = getLabelProps(
         evaluatedText,
-        assign({}, props, dataProps),
+        Object.assign({}, props, dataProps),
         calculatedValues,
       );
       if (labelIndicator) {
@@ -354,7 +354,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
         if (labelProps.calculatedLabelRadius > radius) {
           childProps[eventKey].labelIndicators =
             getLabelIndicatorPropsForLineSegment(
-              assign({}, props, dataProps),
+              Object.assign({}, props, dataProps),
               calculatedValues,
               labelProps,
             );

--- a/packages/victory-pie/src/slice.tsx
+++ b/packages/victory-pie/src/slice.tsx
@@ -10,7 +10,7 @@ import {
   VictoryCommonProps,
   VictoryStyleInterface,
 } from "victory-core";
-import { defaults, isFunction, assign } from "lodash";
+import { defaults, isFunction } from "lodash";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 export type VictorySliceLabelPositionType =
@@ -81,11 +81,11 @@ const evaluateProps = (props) => {
   const style = Helpers.evaluateStyle(props.style, props);
   const radius = Helpers.evaluateProp(
     props.radius,
-    assign({}, props, { style }),
+    Object.assign({}, props, { style }),
   );
   const innerRadius = Helpers.evaluateProp(
     props.innerRadius,
-    assign({}, props, { style, radius }),
+    Object.assign({}, props, { style, radius }),
   );
 
   const ariaLabel = Helpers.evaluateProp(props.ariaLabel, props);
@@ -96,7 +96,7 @@ const evaluateProps = (props) => {
   const sliceEndAngle = Helpers.evaluateProp(props.sliceEndAngle, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
 
-  return assign({}, props, {
+  return Object.assign({}, props, {
     ariaLabel,
     style,
     radius,

--- a/packages/victory-polar-axis/src/helper-methods.ts
+++ b/packages/victory-polar-axis/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { assign, uniqBy, defaults } from "lodash";
+import { uniqBy, defaults } from "lodash";
 import { Helpers, LabelHelpers, Scale, Axis } from "victory-core";
 import { VictoryPolarAxisProps } from "./types";
 
@@ -268,7 +268,7 @@ const getTickLabelProps = (
   const textAngle =
     labelStyle.angle === undefined
       ? LabelHelpers.getPolarAngle(
-          assign({}, props, { labelPlacement }),
+          Object.assign({}, props, { labelPlacement }),
           labelAngle,
         )
       : labelStyle.angle;
@@ -277,7 +277,7 @@ const getTickLabelProps = (
   const textAnchor =
     labelStyle.textAnchor ||
     LabelHelpers.getPolarTextAnchor(
-      assign({}, props, { labelPlacement }),
+      Object.assign({}, props, { labelPlacement }),
       labelAngle,
     );
   return {
@@ -377,7 +377,7 @@ const getAxisLabelProps = (
   const textAngle =
     labelStyle.angle === undefined
       ? LabelHelpers.getPolarAngle(
-          assign({}, props, { labelPlacement }),
+          Object.assign({}, props, { labelPlacement }),
           axisAngle,
         )
       : labelStyle.angle;
@@ -385,13 +385,13 @@ const getAxisLabelProps = (
   const textAnchor =
     labelStyle.textAnchor ||
     LabelHelpers.getPolarTextAnchor(
-      assign({}, props, { labelPlacement }),
+      Object.assign({}, props, { labelPlacement }),
       axisAngle,
     );
   const verticalAnchor =
     labelStyle.verticalAnchor ||
     LabelHelpers.getPolarVerticalAnchor(
-      assign({}, props, { labelPlacement }),
+      Object.assign({}, props, { labelPlacement }),
       axisAngle,
     );
   return {
@@ -435,7 +435,7 @@ const getAxisProps = (modifiedProps, calculatedValues) => {
 };
 
 const getCalculatedValues = (initialProps: VictoryPolarAxisProps) => {
-  const props = assign({ polar: true }, initialProps);
+  const props = Object.assign({ polar: true }, initialProps);
   const defaultStyles = getStyleObject(props);
   const style = getStyles(props, defaultStyles);
   const padding = Helpers.getPadding(props);

--- a/packages/victory-polar-axis/src/victory-polar-axis.tsx
+++ b/packages/victory-polar-axis/src/victory-polar-axis.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { assign, isEmpty } from "lodash";
+import { isEmpty } from "lodash";
 import {
   VictoryLabel,
   VictoryContainer,
@@ -118,7 +118,7 @@ class VictoryPolarAxisBase extends React.Component<VictoryPolarAxisProps> {
       axisType === "radial" ? props.circularGridComponent : props.gridComponent;
     const tickComponents = this.dataKeys
       .map((key, index) => {
-        const tickProps = assign(
+        const tickProps = Object.assign(
           { key: `${name}-tick-${key}` },
           this.getComponentProps(tickComponent, "ticks", index),
         );
@@ -129,7 +129,7 @@ class VictoryPolarAxisBase extends React.Component<VictoryPolarAxisProps> {
 
     const gridComponents = this.dataKeys
       .map((key, index) => {
-        const gridProps = assign(
+        const gridProps = Object.assign(
           { key: `${name}-grid-${key}` },
           this.getComponentProps(gridComponent, "grid", index),
         );
@@ -139,7 +139,7 @@ class VictoryPolarAxisBase extends React.Component<VictoryPolarAxisProps> {
       .filter(Boolean);
 
     const tickLabelComponents = this.dataKeys.map((key, index) => {
-      const tickLabelProps = assign(
+      const tickLabelProps = Object.assign(
         { key: `${name}-tick-${key}` },
         this.getComponentProps(tickLabelComponent, "tickLabels", index),
       );

--- a/packages/victory-scatter/src/helper-methods.tsx
+++ b/packages/victory-scatter/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { assign, values, isNil } from "lodash";
+import { values, isNil } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
 export const getSymbol = (data, props) => {
@@ -80,7 +80,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "scatter",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     data,
     domain,

--- a/packages/victory-selection-container/src/selection-helpers.test.tsx
+++ b/packages/victory-selection-container/src/selection-helpers.test.tsx
@@ -1,4 +1,3 @@
-import { assign } from "lodash";
 import React from "react";
 import { VictoryBar } from "victory-bar";
 import { SelectionHelpers } from "victory-selection-container";

--- a/packages/victory-selection-container/src/selection-helpers.test.tsx
+++ b/packages/victory-selection-container/src/selection-helpers.test.tsx
@@ -60,7 +60,7 @@ describe("helpers/selection", () => {
       const props = { scale, x1: 0, y1: 0, x2: 0.5, y2: 0.5 };
       const filteredData = SelectionHelpers.filterDatasets(props, datasets);
       const expected = { eventKey: [0], data: [data[0]] };
-      expect(filteredData).toEqual([assign({ childName }, expected)]);
+      expect(filteredData).toEqual([Object.assign({ childName }, expected)]);
     });
   });
 });

--- a/packages/victory-selection-container/src/selection-helpers.tsx
+++ b/packages/victory-selection-container/src/selection-helpers.tsx
@@ -1,5 +1,5 @@
 import { Selection, Data, Helpers, Datum } from "victory-core";
-import { assign, defaults, throttle, isFunction, includes } from "lodash";
+import { defaults, throttle, isFunction, includes } from "lodash";
 import React from "react";
 
 const ON_MOUSE_MOVE_THROTTLE_MS = 16;
@@ -209,7 +209,7 @@ class SelectionHelpersClass {
               eventKey: d.eventKey,
               target: "data",
               mutation: () => {
-                return assign({ active: true }, callbackMutation);
+                return Object.assign({ active: true }, callbackMutation);
               },
             };
           })

--- a/packages/victory-shared-events/src/victory-shared-events.tsx
+++ b/packages/victory-shared-events/src/victory-shared-events.tsx
@@ -1,5 +1,4 @@
 import {
-  assign,
   isFunction,
   defaults,
   isEmpty,
@@ -182,7 +181,7 @@ export class VictorySharedEvents extends React.Component<VictorySharedEventsProp
     const children = React.Children.toArray(this.props.children);
     const childBaseProps = this.getBasePropsFromChildren(children);
     const parentBaseProps = container ? container.props : {};
-    return assign({}, childBaseProps, { parent: parentBaseProps });
+    return Object.assign({}, childBaseProps, { parent: parentBaseProps });
   }
 
   getBasePropsFromChildren(childComponents) {
@@ -254,7 +253,7 @@ export class VictorySharedEvents extends React.Component<VictorySharedEventsProp
           return memo.concat(
             React.cloneElement(
               child,
-              assign(
+              Object.assign(
                 { key: `events-${name}`, sharedEvents, eventKey, name },
                 child.props,
               ),
@@ -308,7 +307,7 @@ export class VictorySharedEvents extends React.Component<VictorySharedEventsProp
     return role === "container"
       ? React.cloneElement(
           container,
-          assign({}, parentProps, { events: localEvents }),
+          Object.assign({}, parentProps, { events: localEvents }),
         )
       : React.cloneElement(container, localEvents, children);
   }

--- a/packages/victory-stack/src/helper-methods.tsx
+++ b/packages/victory-stack/src/helper-methods.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define */
-import { assign, keys, orderBy } from "lodash";
+import { keys, orderBy } from "lodash";
 import React from "react";
 import { Helpers, Scale, Wrapper } from "victory-core";
 import isEqual from "react-fast-compare";
@@ -85,7 +85,7 @@ function addLayoutData(props, datasets, index) {
   const xOffset = props.xOffset || 0;
   return datasets[index].map((datum) => {
     const yOffset = getY0(datum, index, datasets) || 0;
-    return assign({}, datum, {
+    return Object.assign({}, datum, {
       _y0: !(datum._y instanceof Date)
         ? yOffset
         : yOffset
@@ -130,12 +130,12 @@ export function getCalculatedProps(initialProps, childComponents) {
   });
   const domain = {
     x: Wrapper.getDomain(
-      assign({}, props, { categories }),
+      Object.assign({}, props, { categories }),
       "x",
       clonedChildren,
     ),
     y: Wrapper.getDomain(
-      assign({}, props, { categories }),
+      Object.assign({}, props, { categories }),
       "y",
       clonedChildren,
     ),
@@ -250,7 +250,7 @@ export function getChildren(initialProps, childComponents, calculatedProps) {
     const name = child.props.name || `${parentName}-${role}-${index}`;
     return React.cloneElement(
       child,
-      assign(
+      Object.assign(
         {
           key: `${name}-key-${index}`,
           labels,

--- a/packages/victory-stack/src/victory-stack.tsx
+++ b/packages/victory-stack/src/victory-stack.tsx
@@ -1,4 +1,4 @@
-import { assign, defaults, isEmpty } from "lodash";
+import { defaults, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import {
@@ -93,7 +93,7 @@ const VictoryStackBase = (initialProps: VictoryStackProps) => {
   const newChildren = React.useMemo(() => {
     const children = getChildren(props, childComponents, calculatedProps);
     const orderedChildren = children.map((child, index) => {
-      const childProps = assign(
+      const childProps = Object.assign(
         { animate: getAnimationProps(props, child, index) },
         child.props,
       );

--- a/packages/victory-tooltip/src/victory-tooltip.tsx
+++ b/packages/victory-tooltip/src/victory-tooltip.tsx
@@ -16,7 +16,7 @@ import {
   OrientationTypes,
   VictoryThemeDefinition,
 } from "victory-core";
-import { assign, defaults, uniqueId, isPlainObject, orderBy } from "lodash";
+import { defaults, uniqueId, isPlainObject, orderBy } from "lodash";
 
 import { Flyout } from "./flyout";
 
@@ -188,7 +188,7 @@ export class VictoryTooltip extends React.Component<VictoryTooltipProps> {
       : Helpers.evaluateStyle(baseLabelStyle, props);
     const flyoutStyle = Helpers.evaluateStyle(
       baseFlyoutStyle,
-      assign({}, props, { style }),
+      Object.assign({}, props, { style }),
     );
     return { style, flyoutStyle };
   }
@@ -198,7 +198,10 @@ export class VictoryTooltip extends React.Component<VictoryTooltipProps> {
 
     const active = Helpers.evaluateProp(props.active, props);
 
-    let text = Helpers.evaluateProp(props.text, assign({}, props, { active }));
+    let text = Helpers.evaluateProp(
+      props.text,
+      Object.assign({}, props, { active }),
+    );
     if (text === undefined || text === null) {
       text = "";
     }
@@ -207,35 +210,53 @@ export class VictoryTooltip extends React.Component<VictoryTooltipProps> {
     }
 
     const { style, flyoutStyle } = this.getStyles(
-      assign({}, props, { active, text }),
+      Object.assign({}, props, { active, text }),
     );
     const orientation =
       Helpers.evaluateProp(
         props.orientation,
-        assign({}, props, { active, text, style, flyoutStyle }),
+        Object.assign({}, props, { active, text, style, flyoutStyle }),
       ) || this.getDefaultOrientation(props);
 
     const padding =
       Helpers.evaluateProp(
         props.flyoutPadding,
-        assign({}, props, { active, text, style, flyoutStyle, orientation }),
+        Object.assign({}, props, {
+          active,
+          text,
+          style,
+          flyoutStyle,
+          orientation,
+        }),
       ) || this.getLabelPadding(style);
 
     const flyoutPadding = Helpers.getPadding({ padding });
 
     const pointerWidth = Helpers.evaluateProp(
       props.pointerWidth,
-      assign({}, props, { active, text, style, flyoutStyle, orientation }),
+      Object.assign({}, props, {
+        active,
+        text,
+        style,
+        flyoutStyle,
+        orientation,
+      }),
     );
 
     const pointerLength = Helpers.evaluateProp(
       props.pointerLength,
-      assign({}, props, { active, text, style, flyoutStyle, orientation }),
+      Object.assign({}, props, {
+        active,
+        text,
+        style,
+        flyoutStyle,
+        orientation,
+      }),
     );
     const labelSize = TextSize.approximateTextSize(text, style);
 
     const { flyoutHeight, flyoutWidth } = this.getDimensions(
-      assign({}, props, {
+      Object.assign({}, props, {
         style,
         flyoutStyle,
         active,
@@ -248,7 +269,7 @@ export class VictoryTooltip extends React.Component<VictoryTooltipProps> {
       labelSize,
     );
 
-    const evaluatedProps = assign({}, props, {
+    const evaluatedProps = Object.assign({}, props, {
       active,
       text,
       style,

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
@@ -182,7 +182,7 @@ export function voronoiContainerMixin<
       }, []);
 
       // remove properties from first point to make datum
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { childName, eventKey, style, continuous, ...datum } = points[0];
       const name =
         props.name === childName ? childName : `${props.name}-${childName}`;

--- a/packages/victory-voronoi-container/src/voronoi-helpers.ts
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.ts
@@ -1,6 +1,5 @@
 import { Collection, Selection, Data, Helpers } from "victory-core";
 import {
-  assign,
   isFunction,
   isEmpty,
   includes,
@@ -47,7 +46,7 @@ class VoronoiHelpersClass {
         const voronoiX = (Number(x) + Number(x0)) / 2;
         const voronoiY = (Number(y) + Number(y0)) / 2;
 
-        return assign(
+        return Object.assign(
           {
             _voronoiX: props.voronoiDimension === "y" ? minDomain.x : voronoiX,
             _voronoiY: props.voronoiDimension === "x" ? minDomain.y : voronoiY,

--- a/packages/victory-voronoi/src/helper-methods.ts
+++ b/packages/victory-voronoi/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { assign, without, isNil } from "lodash";
+import { without, isNil } from "lodash";
 // victory-vendor note: This module is still CommonJS, so not part of victory-vendor.
 import { voronoi as d3Voronoi } from "d3-voronoi";
 import { Helpers, LabelHelpers, Scale, Domain, Data } from "victory-core";
@@ -81,7 +81,11 @@ export const getBaseProps = (initialProps, fallbackProps) => {
     fallbackProps,
     "scatter",
   );
-  const props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const props = Object.assign(
+    {},
+    modifiedProps,
+    getCalculatedValues(modifiedProps),
+  );
   const {
     data,
     domain,

--- a/packages/victory-voronoi/src/voronoi.tsx
+++ b/packages/victory-voronoi/src/voronoi.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { assign } from "lodash";
 import {
   Helpers,
   ClipPath,
@@ -43,7 +42,7 @@ function evaluateProps<T extends VoronoiProps>(props: T) {
   const size = Helpers.evaluateProp(props.size, props);
   const style = Helpers.evaluateStyle(props.style, props);
   const tabIndex = Helpers.evaluateProp(props.tabIndex, props);
-  return assign({}, props, { ariaLabel, id, size, style, tabIndex });
+  return Object.assign({}, props, { ariaLabel, id, size, style, tabIndex });
 }
 
 const defaultProps = {


### PR DESCRIPTION
Replace instances of `lodash.assign` with `Object.assign`. 

Functionally, in all our use cases these two methods are equivalent. The exception is that `lodash.assign` allows undefined as a first argument. The only case we had where this is an issue was [events.ts](https://github.com/FormidableLabs/victory/pull/2757/files#diff-30b0d4ab0618a010dd0a3f489a42300dc1993a416be951a01b3b9ffa92e6d16fL214) where we simply check for undefined as a workaround. All other usages pass a new object as a first argument.

Also replaces usages of `lodash.merge` in the demo. We didn't use any specific to merge so its safe to use assign instead.

