### PR TITLE
Replace instances of lodash.range with native code

### DIFF
--- a/.changeset/shiny-cows-bathe.md
+++ b/.changeset/shiny-cows-bathe.md
@@ -1,0 +1,14 @@
+---
+"victory-area": patch
+"victory-bar": patch
+"victory-candlestick": patch
+"victory-core": patch
+"victory-errorbar": patch
+"victory-histogram": patch
+"victory-line": patch
+"victory-pie": patch
+"victory-scatter": patch
+"victory-voronoi": patch
+---
+
+Replace instances of lodash.range with equivalent native code

--- a/packages/victory-area/src/victory-area.test.tsx
+++ b/packages/victory-area/src/victory-area.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { Area, VictoryArea, VictoryAreaProps } from "victory-area";
 import { VictoryChart } from "victory-chart";
-import { Helpers } from 'victory-core';
+import { Helpers } from "victory-core";
 import { curveCatmullRom } from "victory-vendor/d3-shape";
 import { calculateD3Path } from "../../../test/helpers/svg";
 

--- a/packages/victory-area/src/victory-area.test.tsx
+++ b/packages/victory-area/src/victory-area.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { range } from "lodash";
 import React from "react";
 import { Area, VictoryArea, VictoryAreaProps } from "victory-area";
 import { VictoryChart } from "victory-chart";
+import { Helpers } from 'victory-core';
 import { curveCatmullRom } from "victory-vendor/d3-shape";
 import { calculateD3Path } from "../../../test/helpers/svg";
 
@@ -115,7 +115,7 @@ describe("components/victory-area", () => {
         scale: "linear",
         interpolation: "linear",
         sortKey: "x",
-        data: range(5)
+        data: Helpers.range(5)
           // eslint-disable-next-line max-nested-callbacks
           .map((i) => ({ x: i, y: i, y0: 0 }))
           .reverse(),
@@ -145,7 +145,7 @@ describe("components/victory-area", () => {
         interpolation: "linear",
         sortKey: "x",
         sortOrder: "descending",
-        data: range(5)
+        data: Helpers.range(5)
           .map((i) => ({ x: i, y: i, y0: 0 }))
           .reverse(),
       };

--- a/packages/victory-bar/src/victory-bar.test.tsx
+++ b/packages/victory-bar/src/victory-bar.test.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
-import { range } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { Bar, VictoryBar } from "victory-bar";
+import { Helpers } from "victory-core";
+
 import { isBar, getBarHeight } from "../../../test/helpers";
 
 describe("components/victory-bar", () => {
@@ -70,14 +71,14 @@ describe("components/victory-bar", () => {
 
   describe("rendering data", () => {
     it("renders bars for {x, y} shaped data (default)", () => {
-      const data = range(10).map((i) => ({ x: i, y: i }));
+      const data = Helpers.range(10).map((i) => ({ x: i, y: i }));
       const { container } = render(<VictoryBar data={data} />);
       const bars = container.querySelectorAll("path");
       expect(bars.length).toEqual(10);
     });
 
     it("renders ordered bars when sortKey is passed", () => {
-      const data = range(5)
+      const data = Helpers.range(5)
         .map((i) => ({ x: i, y: i }))
         .reverse();
       const { container } = render(<VictoryBar data={data} sortKey="x" />);
@@ -94,7 +95,7 @@ describe("components/victory-bar", () => {
     });
 
     it("renders reverse ordered bars when sortOrder is descending", () => {
-      const data = range(5)
+      const data = Helpers.range(5)
         .map((i) => ({ x: i, y: i }))
         .reverse();
       const { container } = render(
@@ -112,14 +113,16 @@ describe("components/victory-bar", () => {
     });
 
     it("renders bars for array-shaped data", () => {
-      const data = range(20).map((i) => [i, i]);
+      const data = Helpers.range(20).map((i) => [i, i]);
       const { container } = render(<VictoryBar data={data} x={0} y={1} />);
       const bars = container.querySelectorAll("path");
       expect(bars).toHaveLength(20);
     });
 
     it("renders bars for deeply-nested data", () => {
-      const data = range(8).map((i) => ({ a: { b: [{ x: i, y: i }] } }));
+      const data = Helpers.range(8).map((i) => ({
+        a: { b: [{ x: i, y: i }] },
+      }));
       const { container } = render(
         <VictoryBar data={data} x="a.b[0].x" y="a.b[0].y" />,
       );
@@ -128,7 +131,7 @@ describe("components/victory-bar", () => {
     });
 
     it("renders bars values with null accessor", () => {
-      const data = range(8);
+      const data = Helpers.range(8);
       const { container } = render(
         // @ts-expect-error "'null' is not assignable to 'x'"
         <VictoryBar data={data} x={null} y={null} />,
@@ -249,14 +252,14 @@ describe("components/victory-bar", () => {
 
   describe("accessibility", () => {
     it("adds an aria role to each bar in the series", () => {
-      const data = range(10).map((y, x) => ({ x, y }));
+      const data = Helpers.range(10).map((y, x) => ({ x, y }));
       render(<VictoryBar data={data} />);
       const presentationElements = screen.getAllByRole("presentation");
       expect(presentationElements).toHaveLength(11); // bars plus container
     });
 
     it("applies aria-label and tabIndex to the Bar primitive", () => {
-      const data = range(5, 11).map((y, x) => ({ y, x }));
+      const data = Helpers.range(5, 11).map((y, x) => ({ y, x }));
       const { container } = render(
         <VictoryBar
           data={data}

--- a/packages/victory-candlestick/src/helper-methods.test.ts
+++ b/packages/victory-candlestick/src/helper-methods.test.ts
@@ -1,6 +1,6 @@
-import { range } from "lodash";
 import { fromJS } from "immutable";
 import { getData, getDomain } from "victory-candlestick/lib/helper-methods";
+import { Helpers } from "victory-core";
 
 const immutableGetDataTest = {
   createData: (x) => fromJS(x),
@@ -16,7 +16,7 @@ const getDataTest = {
     describe("getData", () => {
       it("sorts data by sortKey", () => {
         const data = createData(
-          range(5)
+          Helpers.range(5)
             .map((i) => ({ x: i, open: i, close: i, high: i, low: i }))
             .reverse(),
         );

--- a/packages/victory-candlestick/src/victory-candlestick.test.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { range } from "lodash";
 import React from "react";
 import { Candle, VictoryCandlestick } from "victory-candlestick";
 import { VictoryChart } from "victory-chart";
+import { Helpers } from "victory-core";
 
 const MyCandle = () => <div data-testid="my-candle" />;
 
@@ -66,7 +66,7 @@ describe("components/victory-candlestick", () => {
 
   describe("rendering data", () => {
     it("renders injected points for {x, y} shaped data (default)", () => {
-      const data = range(5).map((i) => ({
+      const data = Helpers.range(5).map((i) => ({
         x: i,
         open: i,
         close: i,
@@ -80,7 +80,7 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders points for {x, y} shaped data (default)", () => {
-      const data = range(5).map((i) => ({
+      const data = Helpers.range(5).map((i) => ({
         x: i,
         open: i,
         close: i,
@@ -93,7 +93,7 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders ordered bars when sortKey is passed", () => {
-      const data = range(5)
+      const data = Helpers.range(5)
         .map((i) => ({ x: i, open: i, close: i, high: i, low: i }))
         .reverse();
       const { container } = render(
@@ -108,7 +108,7 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders reverse ordered bars when sortOrder is descending", () => {
-      const data = range(5)
+      const data = Helpers.range(5)
         .map((i) => ({ x: i, open: i, close: i, high: i, low: i }))
         .reverse();
       const { container } = render(
@@ -123,7 +123,7 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders points for array-shaped data", () => {
-      const data = range(10).map((i) => [i, i, i, i, i]);
+      const data = Helpers.range(10).map((i) => [i, i, i, i, i]);
       const { container } = render(
         <VictoryCandlestick
           data={data}
@@ -139,7 +139,7 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders points for deeply-nested data", () => {
-      const data = range(20).map((i) => ({
+      const data = Helpers.range(20).map((i) => ({
         a: { b: [{ x: i, open: i, close: i, high: i, low: i }] },
       }));
       const { container } = render(
@@ -157,7 +157,7 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders data values with null accessor", () => {
-      const data = range(10);
+      const data = Helpers.range(10);
       const { container } = render(
         // @ts-expect-error "'null' is not assignable to 'x'"
         <VictoryCandlestick

--- a/packages/victory-core/src/exports.test.ts
+++ b/packages/victory-core/src/exports.test.ts
@@ -319,6 +319,7 @@ describe("victory-core", () => {
             "modifyProps": [Function],
             "omit": [Function],
             "radiansToDegrees": [Function],
+            "range": [Function],
             "reduceChildren": [Function],
             "scalePoint": [Function],
           },

--- a/packages/victory-core/src/victory-util/axis.tsx
+++ b/packages/victory-core/src/victory-util/axis.tsx
@@ -6,7 +6,6 @@ import {
   isObject,
   invert,
   uniq,
-  range,
   orderBy,
   values,
   includes,
@@ -207,7 +206,7 @@ function getTickArray(props) {
   if (tickValues && Collection.containsStrings(tickValues)) {
     ticks = stringMap
       ? tickValues.map((tick) => stringMap[tick])
-      : range(1, tickValues.length + 1);
+      : Helpers.range(1, tickValues.length + 1);
   }
   const tickArray = ticks ? uniq(ticks) : getTicksFromFormat();
   const buildTickArray = (arr: number[]) => {

--- a/packages/victory-core/src/victory-util/data.test.tsx
+++ b/packages/victory-core/src/victory-util/data.test.tsx
@@ -336,6 +336,16 @@ describe("victory-util/data", () => {
       expect(returnData).toEqual(generatedReturn);
     });
 
+    it("generates a dataset from negative domain", () => {
+      const generatedReturn = [
+        { x: -10, y: 0 },
+        { x: 10, y: 10 },
+      ];
+      const props = { x: "x", y: "y", domain: { x: [-10, 10], y: [0, 10] } };
+      const returnData = Data.generateData(props);
+      expect(returnData).toEqual(generatedReturn);
+    });
+
     it("generates a dataset from domain and samples", () => {
       const generatedReturn = [
         { x: 0, y: 0 },

--- a/packages/victory-core/src/victory-util/data.ts
+++ b/packages/victory-core/src/victory-util/data.ts
@@ -2,7 +2,6 @@
 import React from "react";
 import {
   uniq,
-  range,
   last,
   isFunction,
   isPlainObject,
@@ -46,7 +45,7 @@ function generateDataArray(props, axis) {
   const domainMax = Math.max(...domain);
   const domainMin = Math.min(...domain);
   const step = (domainMax - domainMin) / samples;
-  const values = range(domainMin, domainMax, step);
+  const values = Helpers.range(domainMin, domainMax, step);
   return last(values) === domainMax ? values : values.concat(domainMax);
 }
 

--- a/packages/victory-core/src/victory-util/helpers.test.ts
+++ b/packages/victory-core/src/victory-util/helpers.test.ts
@@ -218,11 +218,11 @@ describe("victory-util/helpers", () => {
       expect(Helpers.range(5)).toEqual([0, 1, 2, 3, 4]);
     });
 
-    it('returns an array of integers from start to end exclusive', () => {
+    it("returns an array of integers from start to end exclusive", () => {
       expect(Helpers.range(2, 5)).toEqual([2, 3, 4]);
     });
 
-    it('returns an array of integers using an increment', () => {
+    it("returns an array of integers using an increment", () => {
       expect(Helpers.range(0, 20, 5)).toEqual([0, 5, 10, 15]);
       expect(Helpers.range(-10, 20, 5)).toEqual([-10, -5, 0, 5, 10, 15]);
     });

--- a/packages/victory-core/src/victory-util/helpers.test.ts
+++ b/packages/victory-core/src/victory-util/helpers.test.ts
@@ -231,5 +231,21 @@ describe("victory-util/helpers", () => {
     it("returns an array of integers using an increment and negative start", () => {
       expect(Helpers.range(-10, 20, 5)).toEqual([-10, -5, 0, 5, 10, 15]);
     });
+
+    it("returns an array of numbers from a floating point increment", () => {
+      expect(Helpers.range(0, 1, 0.2)).toEqual([0, 0.2, 0.4, 0.6, 0.8]);
+    });
+
+    it("should parse non-integer values", () => {
+      expect(Helpers.range(4.7)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it("should not throw on undefined start value", () => {
+      expect(Helpers.range(undefined as any)).toEqual([]);
+    });
+
+    it("should not throw on NaN start value", () => {
+      expect(Helpers.range(NaN as any)).toEqual([]);
+    });
   });
 });

--- a/packages/victory-core/src/victory-util/helpers.test.ts
+++ b/packages/victory-core/src/victory-util/helpers.test.ts
@@ -233,7 +233,7 @@ describe("victory-util/helpers", () => {
     });
 
     it("returns an array of numbers from a floating point increment", () => {
-      expect(Helpers.range(0, 1, 0.2)).toEqual([0, 0.2, 0.4, 0.6, 0.8]);
+      expect(Helpers.range(0, 1, 0.2).length).toEqual(5);
     });
 
     it("should parse non-integer values", () => {

--- a/packages/victory-core/src/victory-util/helpers.test.ts
+++ b/packages/victory-core/src/victory-util/helpers.test.ts
@@ -204,26 +204,31 @@ describe("victory-util/helpers", () => {
   });
 
   describe("range", () => {
-    it("returns an array of length n", () => {
-      expect(Helpers.range(5)).toHaveLength(5);
+    it("returns an array of integers", () => {
+      expect(Helpers.range(4)).toEqual([0, 1, 2, 3]);
     });
 
-    it("returns an array of length for non-positive n", () => {
-      expect(Helpers.range(0)).toHaveLength(0);
-      expect(Helpers.range(-1)).toHaveLength(1);
-      expect(Helpers.range(-4)).toHaveLength(4);
+    it("returns an array of integers for negative n", () => {
+      expect(Helpers.range(-4)).toEqual([0, -1, -2, -3]);
     });
 
-    it("returns an array of integers from 0 to n - 1", () => {
-      expect(Helpers.range(5)).toEqual([0, 1, 2, 3, 4]);
+    it("returns an array of integers from start to end", () => {
+      expect(Helpers.range(1, 5)).toEqual([1, 2, 3, 4]);
     });
 
-    it("returns an array of integers from start to end exclusive", () => {
-      expect(Helpers.range(2, 5)).toEqual([2, 3, 4]);
+    it("returns an array of integers from negative start to end", () => {
+      expect(Helpers.range(-5, 5)).toEqual([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4]);
+    });
+
+    it("returns an array of integers from start to negative end", () => {
+      expect(Helpers.range(5, -5)).toEqual([5, 4, 3, 2, 1, 0, -1, -2, -3, -4]);
     });
 
     it("returns an array of integers using an increment", () => {
       expect(Helpers.range(0, 20, 5)).toEqual([0, 5, 10, 15]);
+    });
+
+    it("returns an array of integers using an increment and negative start", () => {
       expect(Helpers.range(-10, 20, 5)).toEqual([-10, -5, 0, 5, 10, 15]);
     });
   });

--- a/packages/victory-core/src/victory-util/helpers.test.ts
+++ b/packages/victory-core/src/victory-util/helpers.test.ts
@@ -202,4 +202,29 @@ describe("victory-util/helpers", () => {
       expect(undefinedAccessor(14)).toEqual(14);
     });
   });
+
+  describe("range", () => {
+    it("returns an array of length n", () => {
+      expect(Helpers.range(5)).toHaveLength(5);
+    });
+
+    it("returns an array of length for non-positive n", () => {
+      expect(Helpers.range(0)).toHaveLength(0);
+      expect(Helpers.range(-1)).toHaveLength(1);
+      expect(Helpers.range(-4)).toHaveLength(4);
+    });
+
+    it("returns an array of integers from 0 to n - 1", () => {
+      expect(Helpers.range(5)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('returns an array of integers from start to end exclusive', () => {
+      expect(Helpers.range(2, 5)).toEqual([2, 3, 4]);
+    });
+
+    it('returns an array of integers using an increment', () => {
+      expect(Helpers.range(0, 20, 5)).toEqual([0, 5, 10, 15]);
+      expect(Helpers.range(-10, 20, 5)).toEqual([-10, -5, 0, 5, 10, 15]);
+    });
+  });
 });

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -225,14 +225,16 @@ export function getCurrentAxis(axis, horizontal) {
  */
 export function range(start: number, end?: number, increment?: number) {
   const startIndex = end ? start : 0;
-  const endIndex = end ? end : start;
+  let endIndex = end ? end : start;
+  if (!endIndex) endIndex = 0;
 
   const k = endIndex - startIndex;
   const length = Math.abs(k);
-  const sign = k / length;
+  const sign = k / length || 1;
   const inc = increment || 1;
+  const arrayLength = Math.max(Math.ceil(length / inc), 0);
 
-  return Array.from(Array(length / inc), (_, i) => startIndex + i * sign * inc);
+  return Array.from(Array(arrayLength), (_, i) => startIndex + i * sign * inc);
 }
 
 /**

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -218,20 +218,31 @@ export function getCurrentAxis(axis, horizontal) {
 }
 
 /**
- * Creates an array of numbers from the start to the exclusive end value
+ * Creates an array of numbers (positive and/or negative) progressing
+ * from start up to, but not including, end. 
+ * A step of -1 is used if a negative start is specified without an end or step.
+ * If end is not specified, it's set to start with start then set to 0.
+ * 
  * @param start The length of the array to create, or the start value
  * @param end [The end value] If this is defined, start is the start value
  * @returns An array of the given length
  */
 export function range(start: number, end?: number, increment?: number) {
+  // when the end index is not given, start from 0
   const startIndex = end ? start : 0;
+
+  // when the end index is not given, the end of the range is the start index
   let endIndex = end ? end : start;
+
+  // ensure endIndex is not a falsy value
   if (!endIndex) endIndex = 0;
 
-  const k = endIndex - startIndex;
-  const length = Math.abs(k);
-  const sign = k / length || 1;
-  const inc = increment || 1;
+  const k = endIndex - startIndex;  // the value range
+  const length = Math.abs(k);       // the length of the range
+  const sign = k / length || 1;     // the sign of the range (negative or positive)
+  const inc = increment || 1;       // the step size of each increment
+
+  // normalize the array length when dealing with floating point values
   const arrayLength = Math.max(Math.ceil(length / inc), 0);
 
   return Array.from(Array(arrayLength), (_, i) => startIndex + i * sign * inc);

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -218,23 +218,21 @@ export function getCurrentAxis(axis, horizontal) {
 }
 
 /**
- * Creates an array of numbers
+ * Creates an array of numbers from the start to the exclusive end value
  * @param start The length of the array to create, or the start value
  * @param end [The end value] If this is defined, start is the start value
  * @returns An array of the given length
  */
 export function range(start: number, end?: number, increment?: number) {
-  if (end === undefined) {
-    return Array.from({ length: start }, (_, i) => i);
-  }
+  const startIndex = end ? start : 0;
+  const endIndex = end ? end : start;
 
+  const k = endIndex - startIndex;
+  const length = Math.abs(k);
+  const sign = k / length;
   const inc = increment || 1;
-  const ordinal = (end - start) / Math.abs(end - start);
 
-  return Array.from(
-    Array(Math.abs(end - start) + 1),
-    (_, i) => start + i * ordinal * inc,
-  );
+  return Array.from(Array(length / inc), (_, i) => startIndex + i * sign * inc);
 }
 
 /**

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -225,7 +225,7 @@ export function getCurrentAxis(axis, horizontal) {
  */
 export function range(start: number, end?: number, increment?: number) {
   if (end === undefined) {
-    return Array.from({length: start}, (_, i) => i);
+    return Array.from({ length: start }, (_, i) => i);
   }
 
   const inc = increment || 1;

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -218,6 +218,26 @@ export function getCurrentAxis(axis, horizontal) {
 }
 
 /**
+ * Creates an array of numbers
+ * @param start The length of the array to create, or the start value
+ * @param end [The end value] If this is defined, start is the start value
+ * @returns An array of the given length
+ */
+export function range(start: number, end?: number, increment?: number) {
+  if (end === undefined) {
+    return Array.from({length: start}, (_, i) => i);
+  }
+
+  const inc = increment || 1;
+  const ordinal = (end - start) / Math.abs(end - start);
+
+  return Array.from(
+    Array(Math.abs(end - start) + 1),
+    (_, i) => start + i * ordinal * inc,
+  );
+}
+
+/**
  * @param {Array} children: an array of child components
  * @param {Function} iteratee: a function with arguments "child", "childName", and "parent"
  * @param {Object} parentProps: props from the parent that are applied to children

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -219,10 +219,10 @@ export function getCurrentAxis(axis, horizontal) {
 
 /**
  * Creates an array of numbers (positive and/or negative) progressing
- * from start up to, but not including, end. 
+ * from start up to, but not including, end.
  * A step of -1 is used if a negative start is specified without an end or step.
  * If end is not specified, it's set to start with start then set to 0.
- * 
+ *
  * @param start The length of the array to create, or the start value
  * @param end [The end value] If this is defined, start is the start value
  * @returns An array of the given length
@@ -237,10 +237,10 @@ export function range(start: number, end?: number, increment?: number) {
   // ensure endIndex is not a falsy value
   if (!endIndex) endIndex = 0;
 
-  const k = endIndex - startIndex;  // the value range
-  const length = Math.abs(k);       // the length of the range
-  const sign = k / length || 1;     // the sign of the range (negative or positive)
-  const inc = increment || 1;       // the step size of each increment
+  const k = endIndex - startIndex; // the value range
+  const length = Math.abs(k); //      the length of the range
+  const sign = k / length || 1; //    the sign of the range (negative or positive)
+  const inc = increment || 1; //      the step size of each increment
 
   // normalize the array length when dealing with floating point values
   const arrayLength = Math.max(Math.ceil(length / inc), 0);

--- a/packages/victory-core/src/victory-util/point-path-helpers.ts
+++ b/packages/victory-core/src/victory-util/point-path-helpers.ts
@@ -1,5 +1,6 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [0, 1, 2, 2.5, 3] }]*/
-import { range } from "lodash";
+
+import * as Helpers from "./helpers";
 
 export function circle(x: number, y: number, size: number) {
   return `M ${x}, ${y}
@@ -110,7 +111,7 @@ export function star(x: number, y: number, size: number) {
   const baseSize = 1.35 * size; // eslint-disable-line no-magic-numbers
   const angle = Math.PI / 5; // eslint-disable-line no-magic-numbers
   // eslint-disable-next-line no-magic-numbers
-  const starCoords = range(10).map((index) => {
+  const starCoords = Helpers.range(10).map((index) => {
     const length = index % 2 === 0 ? baseSize : baseSize / 2;
     return `${length * Math.sin(angle * (index + 1)) + x},
         ${length * Math.cos(angle * (index + 1)) + y}`;

--- a/packages/victory-errorbar/src/victory-errorbars.test.tsx
+++ b/packages/victory-errorbar/src/victory-errorbars.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { fromJS } from "immutable";
-import { range } from "lodash";
 import React from "react";
+import { Helpers } from "victory-core";
 import { ErrorBar, VictoryErrorBar } from "victory-errorbar";
 import * as d3Scale from "victory-vendor/d3-scale";
 
@@ -78,7 +78,12 @@ describe("components/victory-errorbar", () => {
       describe(`symmetric error, rendering data ${testLabel}`, () => {
         it("renders injected errors for {x, y}", () => {
           const data = createData(
-            range(10).map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 })),
+            Helpers.range(10).map((i) => ({
+              x: i,
+              y: i,
+              errorX: 0.1,
+              errorY: 0.2,
+            })),
           );
           render(<VictoryErrorBar data={data} {...defaultProps} />);
 
@@ -88,7 +93,12 @@ describe("components/victory-errorbar", () => {
 
         it("renders errors for {x, y}", () => {
           const data = createData(
-            range(10).map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 })),
+            Helpers.range(10).map((i) => ({
+              x: i,
+              y: i,
+              errorX: 0.1,
+              errorY: 0.2,
+            })),
           );
           render(<VictoryErrorBar data={data} {...defaultProps} />);
           const errors = screen.getAllByTestId("error-bar");
@@ -97,7 +107,7 @@ describe("components/victory-errorbar", () => {
 
         it("sorts data by sortKey getAttribute", () => {
           const data = createData(
-            range(5)
+            Helpers.range(5)
               .map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 }))
               .reverse(),
           );
@@ -110,7 +120,7 @@ describe("components/victory-errorbar", () => {
 
         it("reversed sorted data with the sortOrder getAttribute", () => {
           const data = createData(
-            range(5)
+            Helpers.range(5)
               .map((i) => ({ x: i, y: i, errorX: 0.1, errorY: 0.2 }))
               .reverse(),
           );
@@ -550,7 +560,7 @@ describe("components/victory-errorbar", () => {
       describe(`asymmetric error, rendering data ${testLabel}`, () => {
         it("renders injected errors for {x, y}", () => {
           const data = createData(
-            range(10).map((i) => ({
+            Helpers.range(10).map((i) => ({
               x: i,
               y: i,
               errorX: [0.1, 0.2],
@@ -565,7 +575,7 @@ describe("components/victory-errorbar", () => {
 
         it("renders errors for {x, y}", () => {
           const data = createData(
-            range(10).map((i) => ({
+            Helpers.range(10).map((i) => ({
               x: i,
               y: i,
               errorX: [0.1, 0.2],

--- a/packages/victory-histogram/src/victory-histogram.test.tsx
+++ b/packages/victory-histogram/src/victory-histogram.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { range } from "lodash";
 import { VictoryHistogram } from "victory-histogram";
+import { Helpers } from 'victory-core';
+
 import { isBar, getBarHeight } from "../../../test/helpers";
 
 describe("components/victory-histogram", () => {
@@ -59,14 +60,14 @@ describe("components/victory-histogram", () => {
 
   describe("rendering data", () => {
     it("renders bars for {x} shaped data (default)", () => {
-      const data = range(5).map((i) => ({ x: i }));
+      const data = Helpers.range(5).map((i) => ({ x: i }));
       const { container } = render(<VictoryHistogram data={data} />);
       const bars = container.querySelectorAll("path");
       expect(bars.length).toEqual(4);
     });
 
     it("renders bars for deeply-nested data", () => {
-      const data = range(5).map((i) => ({ a: { b: [{ x: i }] } }));
+      const data = Helpers.range(5).map((i) => ({ a: { b: [{ x: i }] } }));
       const { container } = render(
         <VictoryHistogram data={data} x="a.b[0].x" />,
       );
@@ -90,7 +91,7 @@ describe("components/victory-histogram", () => {
     });
 
     it("renders bars values with null accessor", () => {
-      const data = range(10);
+      const data = Helpers.range(10);
       render(
         <VictoryHistogram
           data={data}
@@ -201,7 +202,7 @@ describe("components/victory-histogram", () => {
 
   describe("accessibility", () => {
     it("adds an aria role to each bar in the series", () => {
-      const data = range(5).map((x) => ({ x }));
+      const data = Helpers.range(5).map((x) => ({ x }));
       const { container } = render(<VictoryHistogram data={data} />);
 
       container.querySelectorAll("path").forEach((bar) => {

--- a/packages/victory-histogram/src/victory-histogram.test.tsx
+++ b/packages/victory-histogram/src/victory-histogram.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { VictoryHistogram } from "victory-histogram";
-import { Helpers } from 'victory-core';
+import { Helpers } from "victory-core";
 
 import { isBar, getBarHeight } from "../../../test/helpers";
 

--- a/packages/victory-line/src/victory-line.test.tsx
+++ b/packages/victory-line/src/victory-line.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { random } from "lodash";
 import React from "react";
 import { VictoryChart } from "victory-chart";
-import { Helpers } from 'victory-core';
+import { Helpers } from "victory-core";
 import { Curve, VictoryLine } from "victory-line";
 import { curveCatmullRom } from "victory-vendor/d3-shape";
 
@@ -300,7 +300,10 @@ describe("components/victory-line", () => {
     });
 
     it("adds aria-label and tabIndex to Curve primitive", () => {
-      const ariaTestData = Helpers.range(4).map((x) => ({ x, y: random(1, 7) }));
+      const ariaTestData = Helpers.range(4).map((x) => ({
+        x,
+        y: random(1, 7),
+      }));
       const { container } = render(
         <VictoryLine
           data={ariaTestData}

--- a/packages/victory-line/src/victory-line.test.tsx
+++ b/packages/victory-line/src/victory-line.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { random, range } from "lodash";
+import { random } from "lodash";
 import React from "react";
 import { VictoryChart } from "victory-chart";
+import { Helpers } from 'victory-core';
 import { Curve, VictoryLine } from "victory-line";
 import { curveCatmullRom } from "victory-vendor/d3-shape";
+
 import { calculateD3Path } from "../../../test/helpers";
 import { VictoryLineProps } from "./victory-line";
 
@@ -298,7 +300,7 @@ describe("components/victory-line", () => {
     });
 
     it("adds aria-label and tabIndex to Curve primitive", () => {
-      const ariaTestData = range(4).map((x) => ({ x, y: random(1, 7) }));
+      const ariaTestData = Helpers.range(4).map((x) => ({ x, y: random(1, 7) }));
       const { container } = render(
         <VictoryLine
           data={ariaTestData}

--- a/packages/victory-pie/src/victory-pie.test.tsx
+++ b/packages/victory-pie/src/victory-pie.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { range } from "lodash";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { Style } from "victory-core";
+import { Helpers, Style } from "victory-core";
 import { Slice, VictoryPie } from "victory-pie";
 import {
   isCircularSector,
@@ -92,21 +91,21 @@ describe("components/victory-pie", () => {
 
   describe("rendering data", () => {
     it("renders dataComponents for {x, y} shaped data (default)", () => {
-      const data = range(5).map((i) => ({ x: i, y: i }));
+      const data = Helpers.range(5).map((i) => ({ x: i, y: i }));
       render(<VictoryPie data={data} dataComponent={<PizzaSlice />} />);
       const pizzaSlices = screen.getAllByText(pizzaSliceInnerText);
       expect(pizzaSlices).toHaveLength(5);
     });
 
     it("renders points for {x, y} shaped data (default)", () => {
-      const data = range(5).map((i) => ({ x: i, y: i }));
+      const data = Helpers.range(5).map((i) => ({ x: i, y: i }));
       const { container } = render(<VictoryPie data={data} />);
       const slices = container.querySelectorAll("path");
       expect(slices).toHaveLength(5);
     });
 
     it("renders points for array-shaped data", () => {
-      const data = range(6).map((i) => [i, i]);
+      const data = Helpers.range(6).map((i) => [i, i]);
       const { container } = render(<VictoryPie data={data} x={0} y={1} />);
       const slices = container.querySelectorAll("path");
 
@@ -114,7 +113,7 @@ describe("components/victory-pie", () => {
     });
 
     it("renders points for deeply-nested data", () => {
-      const data = range(7).map((i) => ({ a: { b: [{ x: i, y: i }] } }));
+      const data = Helpers.range(7).map((i) => ({ a: { b: [{ x: i, y: i }] } }));
       const { container } = render(
         <VictoryPie data={data} x="a.b[0].x" y="a.b[0].y" />,
       );
@@ -124,7 +123,7 @@ describe("components/victory-pie", () => {
     });
 
     it("renders data values with null accessor", () => {
-      const data = range(8);
+      const data = Helpers.range(8);
       const { container } = render(
         // @ts-expect-error "'null' is not assignable to 'x'"
         <VictoryPie data={data} x={null} y={null} />,
@@ -135,7 +134,7 @@ describe("components/victory-pie", () => {
     });
 
     it("renders data values in their given order", () => {
-      const data = range(9).map((i) => ({ x: i, y: i }));
+      const data = Helpers.range(9).map((i) => ({ x: i, y: i }));
 
       render(<VictoryPie data={data} dataComponent={<PizzaSlice />} />);
       const xValues = Array.from(screen.getAllByText(pizzaSliceInnerText)).map(
@@ -150,7 +149,7 @@ describe("components/victory-pie", () => {
     });
 
     it("renders data values sorted by sortKey prop", () => {
-      const data = range(9)
+      const data = Helpers.range(9)
         .map((i) => ({ x: i, y: i }))
         .reverse();
 
@@ -171,7 +170,7 @@ describe("components/victory-pie", () => {
     });
 
     it("renders data values sorted by sortKey prop and sortOrder", () => {
-      const data = range(9).map((i) => ({ x: i, y: i }));
+      const data = Helpers.range(9).map((i) => ({ x: i, y: i }));
 
       render(
         <VictoryPie
@@ -304,7 +303,7 @@ describe("components/victory-pie", () => {
   describe("the `colorScale` prop", () => {
     describe("if provided an array of CSS colors", () => {
       it("renders each slice with the next color in the array, reiterating through colors as necessary", () => {
-        const data = range(5);
+        const data = Helpers.range(5);
         const colorScale = ["#fffff", "#eeeee", "#ddddd"];
         const { container } = render(
           <VictoryPie data={data} colorScale={colorScale} />,
@@ -336,7 +335,7 @@ describe("components/victory-pie", () => {
 
           VALID_VICTORY_COLOR_SCALE_NAMES.map((colorScaleName) => {
             const colorScale = Style.getColorScale(colorScaleName);
-            const data = range(colorScale.length + 1);
+            const data = Helpers.range(colorScale.length + 1);
             const { container } = render(
               <VictoryPie colorScale={colorScale} data={data} />,
             );

--- a/packages/victory-pie/src/victory-pie.test.tsx
+++ b/packages/victory-pie/src/victory-pie.test.tsx
@@ -113,7 +113,9 @@ describe("components/victory-pie", () => {
     });
 
     it("renders points for deeply-nested data", () => {
-      const data = Helpers.range(7).map((i) => ({ a: { b: [{ x: i, y: i }] } }));
+      const data = Helpers.range(7).map((i) => ({
+        a: { b: [{ x: i, y: i }] },
+      }));
       const { container } = render(
         <VictoryPie data={data} x="a.b[0].x" y="a.b[0].y" />,
       );

--- a/packages/victory-scatter/src/victory-scatter.test.tsx
+++ b/packages/victory-scatter/src/victory-scatter.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { range } from "lodash";
 import React from "react";
-import { Point, VictoryLabel } from "victory-core";
+import { Helpers, Point, VictoryLabel } from "victory-core";
 import { VictoryScatter } from "victory-scatter";
 import {
   convertSvgCoordinatesToCartesian,
@@ -58,7 +57,7 @@ describe("components/victory-scatter", () => {
 
   describe("rendering data", () => {
     it("renders injected points for {x, y} shaped data (default)", () => {
-      const data = range(10).map((i) => ({ x: i, y: i }));
+      const data = Helpers.range(10).map((i) => ({ x: i, y: i }));
       render(
         <VictoryScatter
           data={data}
@@ -71,21 +70,23 @@ describe("components/victory-scatter", () => {
     });
 
     it("renders points for {x, y} shaped data (default)", () => {
-      const data = range(10).map((i) => ({ x: i, y: i }));
+      const data = Helpers.range(10).map((i) => ({ x: i, y: i }));
       const { container } = render(<VictoryScatter data={data} />);
       const points = container.querySelectorAll("path");
       expect(points).toHaveLength(10);
     });
 
     it("renders points for array-shaped data", () => {
-      const data = range(4).map((i) => [i, i]);
+      const data = Helpers.range(4).map((i) => [i, i]);
       const { container } = render(<VictoryScatter data={data} x={0} y={1} />);
       const points = container.querySelectorAll("path");
       expect(points).toHaveLength(4);
     });
 
     it("renders points for deeply-nested data", () => {
-      const data = range(4).map((i) => ({ a: { b: [{ x: i, y: i }] } }));
+      const data = Helpers.range(4).map((i) => ({
+        a: { b: [{ x: i, y: i }] },
+      }));
       const { container } = render(
         <VictoryScatter data={data} x="a.b[0].x" y="a.b[0].y" />,
       );
@@ -94,7 +95,7 @@ describe("components/victory-scatter", () => {
     });
 
     it("renders data values with null accessor", () => {
-      const data = range(30);
+      const data = Helpers.range(30);
       const { container } = render(
         // @ts-expect-error "'null' is not assignable to 'x'"
         <VictoryScatter data={data} x={null} y={null} />,
@@ -223,14 +224,14 @@ describe("components/victory-scatter", () => {
 
   describe("accessibility", () => {
     it("adds an aria role to each point in the series", () => {
-      const data = range(5).map((y, x) => ({ x, y }));
+      const data = Helpers.range(5).map((y, x) => ({ x, y }));
       render(<VictoryScatter data={data} />);
 
       expect(screen.getAllByRole("presentation")).toHaveLength(5);
     });
 
     it("adds an aria-label and tabIndex to Point primitive", () => {
-      const data = range(2, 7).map((x) => ({ x, y: x + 2 }));
+      const data = Helpers.range(2, 7).map((x) => ({ x, y: x + 2 }));
       render(
         <VictoryScatter
           data={data}

--- a/packages/victory-voronoi/src/victory-voronoi.test.tsx
+++ b/packages/victory-voronoi/src/victory-voronoi.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { random, range } from "lodash";
+import { random } from "lodash";
 import { calculateD3Path } from "../../../test/helpers";
 import { VictoryVoronoi, VictoryVoronoiProps, Voronoi } from "victory-voronoi";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { Helpers } from "victory-core";
 
 describe("components/victory-voronoi", () => {
   describe("default component rendering", () => {
@@ -53,7 +54,7 @@ describe("components/victory-voronoi", () => {
     });
 
     it("sorts data by sortKey prop", () => {
-      const data = range(5)
+      const data = Helpers.range(5)
         .map((i) => ({ x: i, y: i }))
         .reverse();
       render(
@@ -75,7 +76,7 @@ describe("components/victory-voronoi", () => {
     });
 
     it("reverses sorted data with the sortOrder prop", () => {
-      const data = range(5)
+      const data = Helpers.range(5)
         .map((i) => ({ x: i, y: i }))
         .reverse();
       render(
@@ -203,7 +204,7 @@ describe("components/victory-voronoi", () => {
     });
 
     it("adds an aria-label and tabindex to Voronoi primitive", () => {
-      const data = range(3, 6).map((x) => ({ x, y: random(5) }));
+      const data = Helpers.range(3, 6).map((x) => ({ x, y: random(5) }));
       const { container } = render(
         <VictoryVoronoi
           data={data}


### PR DESCRIPTION
Replace instances of `lodash.range` with equivalent native code. Includes tests built using comparisons to lodash as seen in the screenshot below.

Snapshot comparison

![image](https://github.com/FormidableLabs/victory/assets/1521394/3dbcd191-24fa-41c4-bf93-4eadaa2d3517)

Relevant Code: https://github.com/FormidableLabs/victory/pull/2760/files#diff-40c5efad413c1e9989261214118a2c9e7d4de98b8b7b239f83778368f54e9991R220
Tests: https://github.com/FormidableLabs/victory/pull/2760/files#diff-1cf5b854b54e9f10213cc171a475a7d58b03f6006f4efdcb1eeba38811e0e8b6R206
