### PR TITLE
Use legacy npm dist-tag to avoid conflicts with victory-native-xl

### DIFF
--- a/.changeset/pink-hats-count.md
+++ b/.changeset/pink-hats-count.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Use legacy npm dist-tag to avoid conflicts with victory-native-xl

--- a/docs/src/content/introduction/native.md
+++ b/docs/src/content/introduction/native.md
@@ -8,8 +8,8 @@ scope: null
 
 # Getting Started with Victory Native
 
-> These docs are for the legacy versions of Victory Native. If you're looking for Victory Native XL docs, please [see here]
-(https://formidable.com/open-source/victory-native/).
+> These docs are for the legacy versions of Victory Native. Victory Native XL is our rewrite of Victory Native designed specifically for React Native. Please [see here for more information]
+(https://formidable.com/open-source/victory-native/). If you would like to continue to use this version of Victory with React Native, follow the legacy guide below.
 
 In this guide, we’ll show you how to get started with Victory Native and the React Native SVG dependency running in your React Native app for iOS and Android.
 
@@ -22,7 +22,7 @@ Victory Native is compatible with React Native 0.50 or higher.
 To add Victory Native to your React Native app install `victory-native`.
 
 ```bash
-$ yarn add victory-native # or npm install --save victory-native
+$ yarn add victory-native@legacy # or npm install --save victory-native@legacy
 ```
 
 #### 2. Add React Native SVG to your app

--- a/packages/victory-native/README.md
+++ b/packages/victory-native/README.md
@@ -6,7 +6,7 @@
 
 Install victory-native:
 ```sh
-$ npm install victory-native --save
+$ npm install victory-native@legacy --save
 ```
 
 Install react-native-svg:
@@ -96,4 +96,3 @@ Please review our [Code of Conduct][code] before contributing.
 [victory-native-demo]:https://github.com/FormidableLabs/victory-native-demo
 [react-native-svg-readme]: https://github.com/react-native-community/react-native-svg#notice
 [maintenance-image]: https://img.shields.io/badge/maintenance-active-green.svg
-

--- a/packages/victory-native/package.json
+++ b/packages/victory-native/package.json
@@ -65,7 +65,8 @@
     "react": ">=16.6.0"
   },
   "publishConfig": {
-    "provenance": true
+    "provenance": true,
+    "tag": "legacy"
   },
   "scripts": {
     "build": "wireit",

--- a/packages/victory/README.md
+++ b/packages/victory/README.md
@@ -38,8 +38,9 @@ Projects using Victory should also depend on [React][] and [prop-types][].
 
 ## Victory Native
 
-Want to use `Victory` with React Native? Check out [victory-native](https://github.com/FormidableLabs/victory-native)
-Victory Native shares most of its code with Victory, and has a nearly identical api!
+Want to use `Victory` with React Native? Check out [victory-native-xl](https://github.com/FormidableLabs/victory-native-xl)
+
+If you would like to use this version of `Victory` with React Native, you can install the legacy version using the `legacy` npm tag. See the [available versions in npm](https://www.npmjs.com/package/victory-native?activeTab=versions).
 
 ## [Contributing](CONTRIBUTING.md)
 


### PR DESCRIPTION
Use legacy npm dist-tag to avoid conflicts with victory-native-xl

This repository and victory-native-xl are both deploying to an npm package named `victory-native`. When they deploy the versions are conflicting under the `latest` tag.

Set this repo to deploy to the `legacy` tag.