### PR TITLE
Add path alias to TS demo tsconfig

### DIFF
--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,3 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "victory*": ["../packages/victory*"],
+    }
+  }
 }


### PR DESCRIPTION
The imports were all squiggly in the `/demo/ts/*` files due to webpack aliases being used, but no corresponding paths definitions in the tsconfig.

## Before
<img width="839" alt="Screenshot 2024-02-01 at 14 22 24" src="https://github.com/FormidableLabs/victory/assets/9557798/78630611-6a81-489a-8838-a745b9670afb">

## After
<img width="842" alt="Screenshot 2024-02-01 at 14 22 38" src="https://github.com/FormidableLabs/victory/assets/9557798/8d296042-ceac-4a6c-adcc-dfefb1c9eb21">
