### PR TITLE
Add config for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,8 +40,8 @@ body:
         You can use our preset [here](https://codesandbox.io/s/dj4f7t).
 
   - type: textarea
-    render: markdown
     attributes:
+      render: markdown
       label: Bug report
       description: |
         A clear and concise description of what the bug is. Please include any
@@ -50,8 +50,8 @@ body:
       required: true
 
   - type: textarea
-    render: markdown
     attributes:
+      render: markdown
       label: Steps to reproduce
       placeholder: |
         Steps to reproduce the behavior:
@@ -61,20 +61,20 @@ body:
         4. See error
 
   - type: textarea
-    render: markdown
     attributes:
+      render: markdown
       label: Expected behavior
       description: A clear and concise description of what you expected to happen.
 
   - type: textarea
-    render: markdown
     attributes:
+      render: markdown
       label: Actual behavior
       description: A clear and concise description of what actually happened.
 
   - type: textarea
-    render: markdown
     attributes:
+      render: markdown
       label: Environment
       description: |
         examples:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Victory Issues Board
+    url: https://github.com/FormidableLabs/victory/issues
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,8 +21,8 @@ body:
           required: true
 
   - type: textarea
-    render: markdown
     attributes:
+      render: markdown
       label: Feature Request
       description: |
         **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -21,8 +21,8 @@ body:
           required: true
 
   - type: textarea
-    render: markdown
     attributes:
+      render: markdown
       label: Question
       description: |
         Any background information that might help us answer your questions.


### PR DESCRIPTION
- Add config for issue templates so the template chooser shows up and does not allow blank submissions
- Fixes a bug with the `textarea` attributes