### PR TITLE
Replace lodash isNil and isNan with native code

### DIFF
--- a/.changeset/warm-pugs-hope.md
+++ b/.changeset/warm-pugs-hope.md
@@ -1,0 +1,16 @@
+---
+"victory-area": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-candlestick": patch
+"victory-core": patch
+"victory-errorbar": patch
+"victory-histogram": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-pie": patch
+"victory-scatter": patch
+"victory-voronoi": patch
+---
+
+Replace lodash isNil and isNan with native code

--- a/packages/victory-area/src/helper-methods.tsx
+++ b/packages/victory-area/src/helper-methods.tsx
@@ -1,4 +1,3 @@
-import { isNil } from "lodash";
 import {
   Helpers,
   LabelHelpers,
@@ -132,7 +131,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       (text !== undefined && text !== null) ||
       (labels && (events || sharedEvents))
     ) {
-      const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+      const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
       childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
     }
     return childProps;

--- a/packages/victory-bar/src/bar-helper-methods.ts
+++ b/packages/victory-bar/src/bar-helper-methods.ts
@@ -1,4 +1,4 @@
-import { isNil, isPlainObject } from "lodash";
+import { isPlainObject } from "lodash";
 import { Helpers, VictoryStyleObject } from "victory-core";
 import { BarProps } from "./bar";
 import {
@@ -41,12 +41,12 @@ const getCornerRadiusFromObject = (
     corner: VictoryBarCornerRadiusKey,
     fallback: "top" | "bottom",
   ) => {
-    if (!isNil(cornerRadius[corner])) {
+    if (!Helpers.isNil(cornerRadius[corner])) {
       realCornerRadius[corner] = Helpers.evaluateProp(
         cornerRadius[corner],
         props,
       );
-    } else if (!isNil(cornerRadius[fallback])) {
+    } else if (!Helpers.isNil(cornerRadius[fallback])) {
       realCornerRadius[corner] = Helpers.evaluateProp(
         cornerRadius[fallback],
         props,

--- a/packages/victory-bar/src/helper-methods.ts
+++ b/packages/victory-bar/src/helper-methods.ts
@@ -1,4 +1,3 @@
-import { isNil } from "lodash";
 import {
   Collection,
   Data,
@@ -115,7 +114,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
   };
 
   return data.reduce((childProps, datum, index) => {
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
     const { x, y, y0, x0 } = getBarPosition(props, datum);
 
     const dataProps = {

--- a/packages/victory-box-plot/src/helper-methods.tsx
+++ b/packages/victory-box-plot/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { orderBy, defaults, uniq, groupBy, keys, isNaN, isNil } from "lodash";
+import { orderBy, defaults, uniq, groupBy, keys } from "lodash";
 import { Helpers, Scale, Domain, Data, Collection } from "victory-core";
 import {
   min as d3Min,
@@ -30,7 +30,7 @@ const checkProcessedData = (data) => {
   return false;
 };
 
-const nanToNull = (val) => (isNaN(val) ? null : val);
+const nanToNull = (val) => (Number.isNaN(val) ? null : val);
 
 const getSummaryStatistics = (data) => {
   const dependentVars = data.map((datum) => datum._y);
@@ -493,7 +493,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
   };
   const boxScale = scale.y;
   return data.reduce((acc, datum, index) => {
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
 
     if (isDatumOutOfBounds(datum, domain)) return acc;
 

--- a/packages/victory-box-plot/src/victory-box-plot.tsx
+++ b/packages/victory-box-plot/src/victory-box-plot.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { flatten, isNil } from "lodash";
+import { flatten } from "lodash";
 import {
   Helpers,
   VictoryLabel,
@@ -234,14 +234,14 @@ class VictoryBoxPlotBase extends React.Component<VictoryBoxPlotProps> {
   }
 
   shouldRenderDatum(datum) {
-    const hasX = !isNil(datum._x);
-    const hasY = !isNil(datum._y);
+    const hasX = !Helpers.isNil(datum._x);
+    const hasY = !Helpers.isNil(datum._y);
     const hasSummaryStatistics =
-      !isNil(datum._min) &&
-      !isNil(datum._max) &&
-      !isNil(datum._median) &&
-      !isNil(datum._q1) &&
-      !isNil(datum._q3);
+      !Helpers.isNil(datum._min) &&
+      !Helpers.isNil(datum._max) &&
+      !Helpers.isNil(datum._median) &&
+      !Helpers.isNil(datum._q1) &&
+      !Helpers.isNil(datum._q3);
 
     return hasSummaryStatistics && (this.props.horizontal ? hasY : hasX);
   }

--- a/packages/victory-candlestick/src/helper-methods.ts
+++ b/packages/victory-candlestick/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { defaults, isNil, isFunction, isPlainObject } from "lodash";
+import { defaults, isFunction, isPlainObject } from "lodash";
 import {
   Helpers,
   Scale,
@@ -417,7 +417,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
 
   // eslint-disable-next-line complexity
   return data.reduce((childProps, datum, index) => {
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
     const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
     const formattedDatum = formatDataFromDomain(datum, domain);
     const { _low, _open, _close, _high } = formattedDatum;

--- a/packages/victory-candlestick/src/victory-candlestick.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.tsx
@@ -19,7 +19,6 @@ import {
   NumberOrCallback,
   EventsMixinClass,
 } from "victory-core";
-import { isNil } from "lodash";
 import { Candle } from "./candle";
 import { getDomain, getData, getBaseProps } from "./helper-methods";
 
@@ -127,7 +126,7 @@ const defaultData = [
 ];
 /* eslint-enable no-magic-numbers */
 const datumHasXandY = (datum) => {
-  return !isNil(datum._x) && !isNil(datum._y);
+  return !Helpers.isNil(datum._x) && !Helpers.isNil(datum._y);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -192,11 +191,11 @@ class VictoryCandlestickBase extends React.Component<VictoryCandlestickProps> {
 
   shouldRenderDatum = (datum) => {
     return (
-      !isNil(datum._x) &&
-      !isNil(datum._high) &&
-      !isNil(datum._low) &&
-      !isNil(datum._close) &&
-      !isNil(datum._open)
+      !Helpers.isNil(datum._x) &&
+      !Helpers.isNil(datum._high) &&
+      !Helpers.isNil(datum._low) &&
+      !Helpers.isNil(datum._close) &&
+      !Helpers.isNil(datum._open)
     );
   };
 

--- a/packages/victory-core/src/exports.test.ts
+++ b/packages/victory-core/src/exports.test.ts
@@ -310,6 +310,7 @@ describe("victory-core", () => {
             "getRange": [Function],
             "getStyles": [Function],
             "isHorizontal": [Function],
+            "isNil": [Function],
             "isTooltip": [Function],
             "modifyProps": [Function],
             "omit": [Function],

--- a/packages/victory-core/src/victory-util/add-events.tsx
+++ b/packages/victory-core/src/victory-util/add-events.tsx
@@ -4,7 +4,6 @@ import {
   difference,
   isEmpty,
   isFunction,
-  isNil,
   keys,
   pick,
   without,
@@ -15,6 +14,7 @@ import isEqual from "react-fast-compare";
 import { VictoryTransition } from "../victory-transition/victory-transition";
 import { VictoryCommonProps, VictoryDatableProps } from "./common-props";
 import { VictoryLabelableProps } from "../types/prop-types";
+import { isNil } from "./helpers";
 
 // DISCLAIMER:
 // This file is not currently tested, and it is first on the list of files

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -185,6 +185,15 @@ export function getRange(props, axis) {
     : getCartesianRange(props, axis);
 }
 
+/**
+ * Checks if `value` is `null` or `undefined`.
+ * @returns {boolean} Returns `true` if `value` is nullish, else `false`.
+ */
+export function isNil(value: any): boolean {
+  // eslint-disable-next-line eqeqeq
+  return value == null;
+}
+
 export function createAccessor(key) {
   // creates a data accessor function
   // given a property key, path, array index, or null for identity.

--- a/packages/victory-errorbar/src/helper-methods.tsx
+++ b/packages/victory-errorbar/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { defaults, assign, isNil } from "lodash";
+import { defaults, assign } from "lodash";
 import {
   Helpers,
   LabelHelpers,
@@ -216,7 +216,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
   };
 
   return data.reduce((childProps, datum, index) => {
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
     const { x, y } = Helpers.scalePoint(assign({}, props, { scale }), datum);
     const formattedDatum = formatDataFromDomain(datum, domain);
     const errorX = getErrors(props, formattedDatum, "x");

--- a/packages/victory-histogram/src/helper-methods.ts
+++ b/packages/victory-histogram/src/helper-methods.ts
@@ -1,4 +1,3 @@
-import { isNil } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 import { getBarPosition } from "victory-bar";
 import isEqual from "react-fast-compare";
@@ -122,7 +121,7 @@ export const getFormattedData = cacheLastValue(
 
 export const getData = (props: VictoryHistogramProps) => {
   const { bins, data, x } = props;
-  const dataIsPreformatted = data?.some(({ _y }) => !isNil(_y));
+  const dataIsPreformatted = data?.some(({ _y }) => !Helpers.isNil(_y));
 
   const formattedData = dataIsPreformatted
     ? data
@@ -244,7 +243,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
   };
 
   return data.reduce((childProps, datum, index) => {
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
 
     const { x, y, y0, x0 } = getBarPosition(props, datum);
     const barWidth = getBarWidth(datum);

--- a/packages/victory-legend/src/helper-methods.ts
+++ b/packages/victory-legend/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { defaults, groupBy, keys, sum, range, isNil } from "lodash";
+import { defaults, groupBy, keys, sum, range } from "lodash";
 import { Helpers, Style, TextSize } from "victory-core";
 import { VictoryLegendProps } from "./victory-legend";
 
@@ -302,7 +302,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
   return groupedData.reduce((childProps, datum, i) => {
     const color = colorScale[i % colorScale.length];
     const dataStyle = defaults({}, datum.symbol, style.data, { fill: color });
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : i;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : i;
     const offset = getOffset(datum, rowHeights, columnWidths);
     const originY = y + borderPadding.top + datum.symbolSpacer;
     const originX = x + borderPadding.left + datum.symbolSpacer;

--- a/packages/victory-line/src/helper-methods.ts
+++ b/packages/victory-line/src/helper-methods.ts
@@ -1,4 +1,3 @@
-import { isNil } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
 const getCalculatedValues = (props) => {
@@ -101,7 +100,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       (text !== undefined && text !== null) ||
       (labels && (events || sharedEvents))
     ) {
-      const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+      const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
       childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
     }
     return childProps;

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -1,5 +1,5 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2, 45, 90, 135, 180, 225, 270, 315, 360] }]*/
-import { defaults, isFunction, isPlainObject, isNil } from "lodash";
+import { defaults, isFunction, isPlainObject } from "lodash";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 import { Helpers, Data, Style } from "victory-core";
@@ -321,7 +321,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
       endAngle: Helpers.radiansToDegrees(slice.endAngle),
       padAngle: Helpers.radiansToDegrees(slice.padAngle),
     });
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
     const dataProps = {
       index,
       slice,

--- a/packages/victory-pie/src/victory-pie.tsx
+++ b/packages/victory-pie/src/victory-pie.tsx
@@ -21,7 +21,6 @@ import {
   EventsMixinClass,
   VictoryDatableProps,
 } from "victory-core";
-import { isNil } from "lodash";
 import { getBaseProps } from "./helper-methods";
 import {
   Slice,
@@ -90,7 +89,7 @@ const fallbackProps = {
 };
 
 const datumHasXandY = (datum) => {
-  return !isNil(datum._x) && !isNil(datum._y);
+  return !Helpers.isNil(datum._x) && !Helpers.isNil(datum._y);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/victory-scatter/src/helper-methods.tsx
+++ b/packages/victory-scatter/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { values, isNil } from "lodash";
+import { values } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
 export const getSymbol = (data, props) => {
@@ -123,7 +123,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
   };
 
   return data.reduce((childProps, datum, index) => {
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
     const { x, y } = Helpers.scalePoint(props, datum);
     const dataProps = {
       x,

--- a/packages/victory-voronoi/src/helper-methods.ts
+++ b/packages/victory-voronoi/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { without, isNil } from "lodash";
+import { without } from "lodash";
 // victory-vendor note: This module is still CommonJS, so not part of victory-vendor.
 import { voronoi as d3Voronoi } from "d3-voronoi";
 import { Helpers, LabelHelpers, Scale, Domain, Data } from "victory-core";
@@ -123,7 +123,7 @@ export const getBaseProps = (initialProps, fallbackProps) => {
 
   return data.reduce((childProps, datum, index) => {
     const polygon = without(polygons[index], "data");
-    const eventKey = !isNil(datum.eventKey) ? datum.eventKey : index;
+    const eventKey = !Helpers.isNil(datum.eventKey) ? datum.eventKey : index;
     const { x, y } = Helpers.scalePoint(props, datum);
     const dataProps = {
       x,


### PR DESCRIPTION
Replace lodash isNil and isNan with native code.

### isNil

Replaced with code directly from the lodash code base which is:

```
export function isNil(value: any): boolean {
  return value == null;
}
```

### isNan

The ES6 equivalent of lodash `isNan` is `Number.isNan`