### PR TITLE
Replaces lodash isFunction with native code

### DIFF
--- a/.changeset/weak-apes-clap.md
+++ b/.changeset/weak-apes-clap.md
@@ -1,0 +1,25 @@
+---
+"victory-area": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-brush-container": patch
+"victory-brush-line": patch
+"victory-candlestick": patch
+"victory-core": patch
+"victory-create-container": patch
+"victory-cursor-container": patch
+"victory-errorbar": patch
+"victory-histogram": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-native": patch
+"victory-pie": patch
+"victory-scatter": patch
+"victory-selection-container": patch
+"victory-shared-events": patch
+"victory-voronoi": patch
+"victory-voronoi-container": patch
+"victory-zoom-container": patch
+---
+
+Replace lodash isFunction with native code

--- a/packages/victory-brush-container/src/brush-helpers.ts
+++ b/packages/victory-brush-container/src/brush-helpers.ts
@@ -1,5 +1,5 @@
-import { Selection } from "victory-core";
-import { throttle, isFunction, defaults, mapValues } from "lodash";
+import { Helpers as CoreHelpers, Selection } from "victory-core";
+import { throttle, defaults, mapValues } from "lodash";
 import isEqual from "react-fast-compare";
 
 const Helpers = {
@@ -370,7 +370,7 @@ const Helpers = {
         ...constrainedBox,
       };
 
-      if (isFunction(onBrushDomainChange)) {
+      if (CoreHelpers.isFunction(onBrushDomainChange)) {
         onBrushDomainChange(
           currentDomain,
           defaults({}, mutatedProps, targetProps),
@@ -400,7 +400,7 @@ const Helpers = {
       });
 
       const mutatedProps = { x2, y2, currentDomain, parentSVG };
-      if (isFunction(onBrushDomainChange)) {
+      if (CoreHelpers.isFunction(onBrushDomainChange)) {
         onBrushDomainChange(
           currentDomain,
           defaults({}, mutatedProps, targetProps),
@@ -458,23 +458,23 @@ const Helpers = {
         evt,
       );
       mutatedProps.currentDomain = defaultDomain;
-      if (isFunction(onBrushDomainChange)) {
+      if (CoreHelpers.isFunction(onBrushDomainChange)) {
         onBrushDomainChange(
           defaultDomain,
           defaults({}, mutatedProps, targetProps),
         );
       }
-      if (isFunction(onBrushDomainChangeEnd)) {
+      if (CoreHelpers.isFunction(onBrushDomainChangeEnd)) {
         onBrushDomainChangeEnd(
           defaultDomain,
           defaults({}, mutatedProps, targetProps),
         );
       }
-      if (isFunction(onBrushCleared)) {
+      if (CoreHelpers.isFunction(onBrushCleared)) {
         onBrushCleared(defaultDomain, defaults({}, mutatedProps, targetProps));
       }
     } else if ((allowDrag && isPanning) || (allowResize && isSelecting)) {
-      if (isFunction(onBrushDomainChangeEnd)) {
+      if (CoreHelpers.isFunction(onBrushDomainChangeEnd)) {
         onBrushDomainChangeEnd(
           currentDomain,
           defaults({}, mutatedProps, targetProps),

--- a/packages/victory-brush-line/src/victory-brush-line.tsx
+++ b/packages/victory-brush-line/src/victory-brush-line.tsx
@@ -10,7 +10,7 @@ import {
   DomainTuple,
   VictoryStyleObject,
 } from "victory-core";
-import { defaults, isFunction, pick } from "lodash";
+import { defaults, pick } from "lodash";
 import isEqual from "react-fast-compare";
 
 export type VictoryBrushLineTargetType = "data" | "labels" | "parent";
@@ -372,7 +372,7 @@ export class VictoryBrushLine<
                     parentSVG,
                   };
 
-                  if (isFunction(onBrushDomainChange)) {
+                  if (Helpers.isFunction(onBrushDomainChange)) {
                     onBrushDomainChange(
                       currentDomain,
                       defaults({}, mutatedProps, targetProps),
@@ -423,7 +423,7 @@ export class VictoryBrushLine<
                       maxHandle: activeHandle === "max",
                     },
                   };
-                  if (isFunction(onBrushDomainChange)) {
+                  if (Helpers.isFunction(onBrushDomainChange)) {
                     onBrushDomainChange(
                       currentDomain,
                       defaults({}, mutatedProps, targetProps),
@@ -453,7 +453,7 @@ export class VictoryBrushLine<
                   brushDomain,
                   activeBrushes,
                 };
-                if (allowResize && isFunction(onBrushDomainChange)) {
+                if (allowResize && Helpers.isFunction(onBrushDomainChange)) {
                   onBrushDomainChange(
                     brushDomain,
                     defaults({}, mutatedProps, targetProps),

--- a/packages/victory-candlestick/src/candle.tsx
+++ b/packages/victory-candlestick/src/candle.tsx
@@ -7,7 +7,7 @@ import {
   VictoryCommonPrimitiveProps,
   VictoryStyleObject,
 } from "victory-core";
-import { defaults, isFunction } from "lodash";
+import { defaults } from "lodash";
 
 export interface CandleProps extends VictoryCommonPrimitiveProps {
   candleRatio?: number;
@@ -31,7 +31,7 @@ const getCandleWidth = (
 ) => {
   const { style } = props;
   if (candleWidth) {
-    return isFunction(candleWidth)
+    return Helpers.isFunction(candleWidth)
       ? Helpers.evaluateProp(candleWidth, props)
       : candleWidth;
   } else if (style.width) {

--- a/packages/victory-candlestick/src/helper-methods.ts
+++ b/packages/victory-candlestick/src/helper-methods.ts
@@ -1,4 +1,4 @@
-import { defaults, isFunction, isPlainObject } from "lodash";
+import { defaults, isPlainObject } from "lodash";
 import {
   Helpers,
   Scale,
@@ -224,7 +224,7 @@ const getText = (props, type) => {
 const getCandleWidth = (props, style?: VictoryStyleObject) => {
   const { data, candleWidth, scale } = props;
   if (candleWidth) {
-    return isFunction(candleWidth)
+    return Helpers.isFunction(candleWidth)
       ? Helpers.evaluateProp(candleWidth, props)
       : candleWidth;
   } else if (style && style.width) {

--- a/packages/victory-core/src/exports.test.ts
+++ b/packages/victory-core/src/exports.test.ts
@@ -309,6 +309,7 @@ describe("victory-core", () => {
             "getRadius": [Function],
             "getRange": [Function],
             "getStyles": [Function],
+            "isFunction": [Function],
             "isHorizontal": [Function],
             "isNil": [Function],
             "isTooltip": [Function],

--- a/packages/victory-core/src/victory-container/victory-container.tsx
+++ b/packages/victory-core/src/victory-container/victory-container.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults, uniqueId, isObject, isFunction } from "lodash";
+import { defaults, uniqueId, isObject } from "lodash";
 import { Portal } from "../victory-portal/portal";
 import { PortalContext } from "../victory-portal/portal-context";
 import TimerContext from "../victory-util/timer-context";
@@ -81,7 +81,7 @@ export class VictoryContainer<
   portalDeregister = (key) => this.portalRef.portalDeregister(key);
 
   saveContainerRef = (container: HTMLElement) => {
-    if (isFunction(this.props.containerRef)) {
+    if (Helpers.isFunction(this.props.containerRef)) {
       this.props.containerRef(container);
     }
     this.containerRef = container;

--- a/packages/victory-core/src/victory-transition/victory-transition.tsx
+++ b/packages/victory-core/src/victory-transition/victory-transition.tsx
@@ -4,7 +4,7 @@ import * as Collection from "../victory-util/collection";
 import * as Helpers from "../victory-util/helpers";
 import TimerContext from "../victory-util/timer-context";
 import * as Transitions from "../victory-util/transitions";
-import { defaults, isFunction, pick } from "lodash";
+import { defaults, pick } from "lodash";
 import isEqual from "react-fast-compare";
 import Timer from "../victory-util/timer";
 
@@ -119,7 +119,7 @@ export class VictoryTransition extends React.Component<
   ) {
     const getChildDomains = (children) => {
       return children.reduce((memo, child) => {
-        if (child.type && isFunction(child.type.getDomain)) {
+        if (child.type && Helpers.isFunction(child.type.getDomain)) {
           const childDomain =
             child.props && child.type.getDomain(child.props, axis);
           return childDomain ? memo.concat(childDomain) : memo;

--- a/packages/victory-core/src/victory-util/add-events.tsx
+++ b/packages/victory-core/src/victory-util/add-events.tsx
@@ -1,20 +1,12 @@
 import React from "react";
-import {
-  defaults,
-  difference,
-  isEmpty,
-  isFunction,
-  keys,
-  pick,
-  without,
-} from "lodash";
+import { defaults, difference, isEmpty, keys, pick, without } from "lodash";
 import type { ComponentEvent } from "./events";
 import * as Events from "./events";
 import isEqual from "react-fast-compare";
 import { VictoryTransition } from "../victory-transition/victory-transition";
 import { VictoryCommonProps, VictoryDatableProps } from "./common-props";
 import { VictoryLabelableProps } from "../types/prop-types";
-import { isNil } from "./helpers";
+import { isFunction, isNil } from "./helpers";
 
 // DISCLAIMER:
 // This file is not currently tested, and it is first on the list of files

--- a/packages/victory-core/src/victory-util/axis.tsx
+++ b/packages/victory-core/src/victory-util/axis.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import {
   defaults,
   identity,
-  isFunction,
   isObject,
   invert,
   uniq,
@@ -250,7 +249,7 @@ export function getTickFormat(props, scale) {
     // by default. This changed the default formatting for some scale types when
     // we upgraded to d3-scale@4..
     const scaleTickFormat =
-      scale.tickFormat && isFunction(scale.tickFormat)
+      scale.tickFormat && Helpers.isFunction(scale.tickFormat)
         ? scale.tickFormat()
         : (x) => x;
     return defaultTickFormat || scaleTickFormat;
@@ -261,7 +260,7 @@ export function getTickFormat(props, scale) {
       tickArrayIndices?.includes(index),
     );
     return (x, index) => filteredTickFormat[index];
-  } else if (tickFormat && isFunction(tickFormat)) {
+  } else if (tickFormat && Helpers.isFunction(tickFormat)) {
     const applyStringTicks = (tick, index, ticks) => {
       const invertedStringMap = invert(stringMap);
       const stringTickArray = ticks.map((t) => invertedStringMap[t]);
@@ -291,7 +290,7 @@ export function getTicks(props, scale: D3Scale, filterZero = false) {
   const tickValues = tickArray ? tickArray.map((v) => v.value) : undefined;
   if (tickValues) {
     return downsampleTicks(tickValues, tickCount);
-  } else if (scale.ticks && isFunction(scale.ticks)) {
+  } else if (scale.ticks && Helpers.isFunction(scale.ticks)) {
     // eslint-disable-next-line no-magic-numbers
     const defaultTickCount = tickCount || 5;
     const scaleTicks = scale.ticks(defaultTickCount);
@@ -362,7 +361,7 @@ export function getAxisValue(props, axis) {
   }
   const scaleAxis = axis === "x" ? "y" : "x";
   const scale =
-    isObject(props.scale) && isFunction(props.scale[scaleAxis])
+    isObject(props.scale) && Helpers.isFunction(props.scale[scaleAxis])
       ? props.scale[scaleAxis]
       : undefined;
   if (!scale) {

--- a/packages/victory-core/src/victory-util/data.ts
+++ b/packages/victory-core/src/victory-util/data.ts
@@ -3,7 +3,6 @@ import React from "react";
 import {
   uniq,
   last,
-  isFunction,
   isPlainObject,
   property,
   orderBy,
@@ -97,7 +96,7 @@ function cleanData(dataset, props) {
 function getEventKey(key) {
   // creates a data accessor function
   // given a property key, path, array index, or null for identity.
-  if (isFunction(key)) {
+  if (Helpers.isFunction(key)) {
     return key;
   } else if (key === null || key === undefined) {
     return () => undefined;

--- a/packages/victory-core/src/victory-util/domain.ts
+++ b/packages/victory-core/src/victory-util/domain.ts
@@ -1,13 +1,6 @@
 /* eslint-disable no-use-before-define */
 import React from "react";
-import {
-  flatten,
-  isPlainObject,
-  sortedUniq,
-  isFunction,
-  includes,
-  isDate,
-} from "lodash";
+import { flatten, isPlainObject, sortedUniq, includes, isDate } from "lodash";
 import * as Data from "./data";
 import * as Scale from "./scale";
 import * as Helpers from "./helpers";
@@ -183,10 +176,10 @@ export function createDomainFunction(
   getDomainFromDataFunction?,
   formatDomainFunction?,
 ) {
-  const getDomainFromDataFn = isFunction(getDomainFromDataFunction)
+  const getDomainFromDataFn = Helpers.isFunction(getDomainFromDataFunction)
     ? getDomainFromDataFunction
     : getDomainFromData;
-  const formatDomainFn = isFunction(formatDomainFunction)
+  const formatDomainFn = Helpers.isFunction(formatDomainFunction)
     ? formatDomainFunction
     : formatDomain;
   return (props, axis) => {

--- a/packages/victory-core/src/victory-util/events.ts
+++ b/packages/victory-core/src/victory-util/events.ts
@@ -1,15 +1,7 @@
 /* eslint-disable no-use-before-define */
-import {
-  isEmpty,
-  isFunction,
-  without,
-  pickBy,
-  omitBy,
-  uniq,
-  includes,
-  keys,
-} from "lodash";
+import { isEmpty, without, pickBy, omitBy, uniq, includes, keys } from "lodash";
 import type { EventMixinCalculatedValues } from "./add-events";
+import { isFunction } from "./helpers";
 
 const GLOBAL_EVENT_REGEX = /^onGlobal(.*)$/;
 

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 import React, { isValidElement } from "react";
-import { defaults, isFunction, property, pick, keys } from "lodash";
+import { defaults, property, pick, keys } from "lodash";
 import { CallbackArgs } from "../types/callbacks";
 import { ValueOrAccessor } from "../types/prop-types";
 
@@ -192,6 +192,17 @@ export function getRange(props, axis) {
 export function isNil(value: any): boolean {
   // eslint-disable-next-line eqeqeq
   return value == null;
+}
+
+/**
+ * Checks if `value` is classified as a `Function` object.
+ *
+ * @since 0.1.0
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a function, else `false`.
+ */
+export function isFunction(value: any): value is (...args: any[]) => any {
+  return typeof value === "function";
 }
 
 export function createAccessor(key) {

--- a/packages/victory-core/src/victory-util/scale.ts
+++ b/packages/victory-core/src/victory-util/scale.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define */
-import { includes, isFunction, isPlainObject } from "lodash";
+import { includes, isPlainObject } from "lodash";
 import * as Helpers from "./helpers";
 import * as Collection from "./collection";
 import * as d3Scale from "victory-vendor/d3-scale";
@@ -25,9 +25,9 @@ export function validScale(
 ): scale is ScaleName | D3Scale {
   if (typeof scale === "function") {
     return (
-      isFunction(scale.copy) &&
-      isFunction(scale.domain) &&
-      isFunction(scale.range)
+      Helpers.isFunction(scale.copy) &&
+      Helpers.isFunction(scale.domain) &&
+      Helpers.isFunction(scale.range)
     );
   } else if (typeof scale === "string") {
     return includes(supportedScaleStrings, scale);
@@ -110,7 +110,7 @@ export function getScaleFromProps(props, axis): D3Scale | undefined {
   }
   const scale = props.scale[axis] || props.scale;
   if (validScale(scale)) {
-    return isFunction(scale) ? scale : getScaleFromName(scale);
+    return Helpers.isFunction(scale) ? scale : getScaleFromName(scale);
   }
   return undefined;
 }

--- a/packages/victory-core/src/victory-util/wrapper.tsx
+++ b/packages/victory-core/src/victory-util/wrapper.tsx
@@ -1,7 +1,6 @@
 import {
   defaults,
   flatten,
-  isFunction,
   uniq,
   groupBy,
   uniqBy,
@@ -104,7 +103,7 @@ export function getDataFromChildren(props, childComponents) {
     let childElement = child;
     if (!Data.isDataComponent(child)) {
       return null;
-    } else if (child.type && isFunction(child.type.getData)) {
+    } else if (child.type && Helpers.isFunction(child.type.getData)) {
       childElement = parent ? React.cloneElement(child, parent.props) : child;
       childData = childElement.type.getData(childProps);
     } else {
@@ -228,7 +227,7 @@ export function getDomainFromChildren(props, axis, childComponents) {
     const sharedProps = Object.assign({}, child.props, parentProps);
     if (!Domain.isDomainComponent(child)) {
       return null;
-    } else if (child.type && isFunction(child.type.getDomain)) {
+    } else if (child.type && Helpers.isFunction(child.type.getDomain)) {
       return child.props && child.type.getDomain(sharedProps, axis);
     }
     return Domain.getDomain(sharedProps, axis);
@@ -383,7 +382,7 @@ export function getStringsFromData(childComponents) {
     let data;
     if (!Data.isDataComponent(child)) {
       return null;
-    } else if (child.type && isFunction(child.type.getData)) {
+    } else if (child.type && Helpers.isFunction(child.type.getData)) {
       data = child.type.getData(childProps);
     } else {
       data = Data.getData(childProps);

--- a/packages/victory-create-container/src/create-container.ts
+++ b/packages/victory-create-container/src/create-container.ts
@@ -1,14 +1,6 @@
 import React from "react";
-import {
-  toPairs,
-  groupBy,
-  forOwn,
-  includes,
-  flow,
-  isEmpty,
-  isFunction,
-} from "lodash";
-import { VictoryContainer, Log } from "victory-core";
+import { toPairs, groupBy, forOwn, includes, flow, isEmpty } from "lodash";
+import { Helpers, VictoryContainer, Log } from "victory-core";
 import { voronoiContainerMixin } from "victory-voronoi-container";
 import { zoomContainerMixin } from "victory-zoom-container";
 import { selectionContainerMixin } from "victory-selection-container";
@@ -108,7 +100,7 @@ export const combineContainerMixins = (
     static defaultEvents = (props) => {
       return combineDefaultEvents(
         Classes.reduce((defaultEvents, Class) => {
-          const events = isFunction(Class.defaultEvents)
+          const events = Helpers.isFunction(Class.defaultEvents)
             ? Class.defaultEvents(props)
             : Class.defaultEvents;
           return [...defaultEvents, ...events];

--- a/packages/victory-cursor-container/src/cursor-helpers.tsx
+++ b/packages/victory-cursor-container/src/cursor-helpers.tsx
@@ -1,5 +1,5 @@
-import { Selection, SVGCoordinateType } from "victory-core";
-import { throttle, isFunction, mapValues } from "lodash";
+import { Helpers, Selection, SVGCoordinateType } from "victory-core";
+import { throttle, mapValues } from "lodash";
 
 const ON_MOUSE_MOVE_THROTTLE_MS = 16;
 
@@ -46,7 +46,7 @@ class CursorHelpersClass {
       cursorValue = null;
     }
 
-    if (isFunction(onCursorChange)) {
+    if (Helpers.isFunction(onCursorChange)) {
       if (cursorValue) {
         const value = cursorDimension
           ? cursorValue[cursorDimension]
@@ -76,7 +76,7 @@ class CursorHelpersClass {
   onTouchEnd = (evt, targetProps) => {
     const { onCursorChange } = targetProps;
 
-    if (isFunction(targetProps.onCursorChange)) {
+    if (Helpers.isFunction(targetProps.onCursorChange)) {
       onCursorChange(null, targetProps);
     }
 

--- a/packages/victory-native/src/helpers/native-zoom-helpers.ts
+++ b/packages/victory-native/src/helpers/native-zoom-helpers.ts
@@ -1,7 +1,7 @@
-import { throttle, isFunction, defaults } from "lodash";
+import { throttle, defaults } from "lodash";
 import { Dimensions } from "react-native";
 import isEqual from "react-fast-compare";
-import { Collection } from "victory-core";
+import { Collection, Helpers as CoreHelpers } from "victory-core";
 import { RawZoomHelpers } from "victory-zoom-container";
 
 const hypotenuse = (x, y) => Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
@@ -59,7 +59,7 @@ const Helpers = {
       // if zoomActive is already set AND user hasn't zoommed out all the way
       (targetProps.zoomActive && !isEqual(originalDomain, lastDomain));
 
-    if (isFunction(onZoomDomainChange)) {
+    if (CoreHelpers.isFunction(onZoomDomainChange)) {
       onZoomDomainChange(currentDomain);
     }
     return [

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -1,11 +1,11 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2, 45, 90, 135, 180, 225, 270, 315, 360] }]*/
-import { defaults, isFunction, isPlainObject } from "lodash";
+import { defaults, isPlainObject } from "lodash";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 import { Helpers, Data, Style } from "victory-core";
 
 const checkForValidText = (text) => {
-  if (text === undefined || text === null || isFunction(text)) {
+  if (text === undefined || text === null || Helpers.isFunction(text)) {
     return text;
   }
   return `${text}`;
@@ -46,7 +46,7 @@ const getOrigin = (props, padding) => {
 };
 
 const getSlices = (props, data) => {
-  const padAngle = isFunction(props.padAngle) ? 0 : props.padAngle;
+  const padAngle = Helpers.isFunction(props.padAngle) ? 0 : props.padAngle;
   const layoutFunction = d3Shape
     .pie()
     .sort(null)
@@ -95,7 +95,9 @@ const getLabelText = (props, datum, index) => {
   } else if (Array.isArray(props.labels)) {
     text = props.labels[index];
   } else {
-    text = isFunction(props.labels) ? props.labels : datum.xName || datum._x;
+    text = Helpers.isFunction(props.labels)
+      ? props.labels
+      : datum.xName || datum._x;
   }
   return checkForValidText(text);
 };

--- a/packages/victory-pie/src/slice.tsx
+++ b/packages/victory-pie/src/slice.tsx
@@ -8,7 +8,7 @@ import {
   VictoryCommonProps,
   VictoryStyleInterface,
 } from "victory-core";
-import { defaults, isFunction } from "lodash";
+import { defaults } from "lodash";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 export type VictorySliceLabelPositionType =
@@ -46,7 +46,7 @@ export interface SliceProps extends VictoryCommonProps {
 
 const getPath = (props) => {
   const { slice, radius, innerRadius, cornerRadius } = props;
-  if (isFunction(props.pathFunction)) {
+  if (Helpers.isFunction(props.pathFunction)) {
     return props.pathFunction(slice);
   }
   const padAngle = Helpers.degreesToRadians(props.padAngle);

--- a/packages/victory-selection-container/src/selection-helpers.tsx
+++ b/packages/victory-selection-container/src/selection-helpers.tsx
@@ -1,5 +1,5 @@
 import { Selection, Data, Helpers, Datum } from "victory-core";
-import { defaults, throttle, isFunction, includes } from "lodash";
+import { defaults, throttle, includes } from "lodash";
 import React from "react";
 
 const ON_MOUSE_MOVE_THROTTLE_MS = 16;
@@ -28,7 +28,7 @@ class SelectionHelpersClass {
       let childElement;
       if (!Data.isDataComponent(child) || includes(blacklist, childName)) {
         return null;
-      } else if (child.type && isFunction(child.type.getData)) {
+      } else if (child.type && Helpers.isFunction(child.type.getData)) {
         childElement = parent ? React.cloneElement(child, parent.props) : child;
         const childData =
           childElement.props && childElement.type.getData(childElement.props);
@@ -111,7 +111,7 @@ class SelectionHelpersClass {
         : Selection.getDomainCoordinates(targetProps).y[1];
 
     const mutatedProps = { x1, y1, select: true, x2, y2, parentSVG };
-    if (selectedData && isFunction(targetProps.onSelectionCleared)) {
+    if (selectedData && Helpers.isFunction(targetProps.onSelectionCleared)) {
       targetProps.onSelectionCleared(defaults({}, mutatedProps, targetProps));
     }
     const parentMutation = [{ target: "parent", mutation: () => mutatedProps }];
@@ -187,7 +187,7 @@ class SelectionHelpersClass {
       y2: null,
     };
     const callbackMutation =
-      selectedData && isFunction(targetProps.onSelection)
+      selectedData && Helpers.isFunction(targetProps.onSelection)
         ? targetProps.onSelection(
             selectedData,
             bounds,

--- a/packages/victory-shared-events/src/victory-shared-events.tsx
+++ b/packages/victory-shared-events/src/victory-shared-events.tsx
@@ -1,11 +1,4 @@
-import {
-  isFunction,
-  defaults,
-  isEmpty,
-  fromPairs,
-  keys,
-  difference,
-} from "lodash";
+import { defaults, isEmpty, fromPairs, keys, difference } from "lodash";
 import React from "react";
 import {
   EventCallbackInterface,
@@ -139,7 +132,9 @@ export class VictorySharedEvents extends React.Component<VictorySharedEventsProp
     if (!isEmpty(externalMutations)) {
       const callbacks = props.externalEventMutations.reduce(
         (memo, mutation) =>
-          isFunction(mutation.callback) ? memo.concat(mutation.callback) : memo,
+          Helpers.isFunction(mutation.callback)
+            ? memo.concat(mutation.callback)
+            : memo,
         [],
       );
       const compiledCallbacks = callbacks.length
@@ -186,7 +181,7 @@ export class VictorySharedEvents extends React.Component<VictorySharedEventsProp
 
   getBasePropsFromChildren(childComponents) {
     const iteratee = (child, childName) => {
-      if (child.type && isFunction(child.type.getBaseProps)) {
+      if (child.type && Helpers.isFunction(child.type.getBaseProps)) {
         const baseProps = child.props && child.type.getBaseProps(child.props);
         return baseProps ? [[childName, baseProps]] : null;
       }
@@ -214,7 +209,7 @@ export class VictorySharedEvents extends React.Component<VictorySharedEventsProp
         } else if (
           childNames[index] !== "parent" &&
           child.type &&
-          isFunction(child.type.getBaseProps)
+          Helpers.isFunction(child.type.getBaseProps)
         ) {
           const name = child.props.name || childNames[index];
           const childEvents =

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 import React from "react";
-import { defaults, isFunction, pick } from "lodash";
+import { defaults, pick } from "lodash";
 import { VictoryTooltip } from "victory-tooltip";
 import {
   VictoryContainer,
@@ -130,7 +130,9 @@ export function voronoiContainerMixin<
           datum,
           active: true,
         });
-        const text = isFunction(labels) ? labels(labelProps) : undefined;
+        const text = Helpers.isFunction(labels)
+          ? labels(labelProps)
+          : undefined;
         const textArray = text !== undefined ? `${text}`.split("\n") : [];
         const baseStyle = (datum.style && datum.style[type]) || {};
         const componentStyle = Array.isArray(componentStyleArray)
@@ -174,7 +176,7 @@ export function voronoiContainerMixin<
           datum,
           active: true,
         });
-        const t = isFunction(labels) ? labels(labelProps) : null;
+        const t = Helpers.isFunction(labels) ? labels(labelProps) : null;
         if (t === null || t === undefined) {
           return memo;
         }

--- a/packages/victory-voronoi-container/src/voronoi-helpers.ts
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.ts
@@ -1,12 +1,5 @@
 import { Collection, Selection, Data, Helpers } from "victory-core";
-import {
-  isFunction,
-  isEmpty,
-  includes,
-  isString,
-  isRegExp,
-  throttle,
-} from "lodash";
+import { isEmpty, includes, isString, isRegExp, throttle } from "lodash";
 import isEqual from "react-fast-compare";
 import Delaunay from "delaunay-find/lib/index.js";
 import React from "react";
@@ -84,7 +77,7 @@ class VoronoiHelpersClass {
         return null;
       }
       const getChildData =
-        child.type && isFunction(child.type.getData)
+        child.type && Helpers.isFunction(child.type.getData)
           ? child.type.getData
           : getData;
       const childData = getChildData(child.props);
@@ -195,13 +188,13 @@ class VoronoiHelpersClass {
   }
 
   onActivated(props, points) {
-    if (isFunction(props.onActivated)) {
+    if (Helpers.isFunction(props.onActivated)) {
       props.onActivated(points, props);
     }
   }
 
   onDeactivated(props, points) {
-    if (isFunction(props.onDeactivated)) {
+    if (Helpers.isFunction(props.onDeactivated)) {
       props.onDeactivated(points, props);
     }
   }

--- a/packages/victory-zoom-container/src/victory-zoom-container.tsx
+++ b/packages/victory-zoom-container/src/victory-zoom-container.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { defaults, isFunction } from "lodash";
+import { defaults } from "lodash";
 import { ZoomHelpers } from "./zoom-helpers";
 import {
+  Data,
+  DomainTuple,
+  Helpers,
   VictoryContainer,
   VictoryClipContainer,
-  Data,
   VictoryContainerProps,
-  DomainTuple,
 } from "victory-core";
 
 const DEFAULT_DOWNSAMPLE = 150;
@@ -146,7 +147,7 @@ export function zoomContainerMixin<
       const getData = (childProps) => {
         const { data, x, y } = childProps;
         const defaultGetData =
-          child.type && isFunction(child.type.getData)
+          child.type && Helpers.isFunction(child.type.getData)
             ? child.type.getData
             : () => undefined;
         // skip costly data formatting if x and y accessors are not present

--- a/packages/victory-zoom-container/src/zoom-helpers.ts
+++ b/packages/victory-zoom-container/src/zoom-helpers.ts
@@ -1,7 +1,7 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2, 1000] }]*/
 import { Children } from "react";
-import { Selection, Collection, Wrapper } from "victory-core";
-import { throttle, isFunction, defaults, delay } from "lodash";
+import { Helpers, Selection, Collection, Wrapper } from "victory-core";
+import { throttle, defaults, delay } from "lodash";
 
 export const RawZoomHelpers = {
   checkDomainEquality(a, b) {
@@ -291,7 +291,7 @@ export const RawZoomHelpers = {
         zoomActive,
       };
 
-      if (isFunction(onZoomDomainChange)) {
+      if (Helpers.isFunction(onZoomDomainChange)) {
         onZoomDomainChange(
           currentDomain,
           defaults({}, mutatedProps, targetProps),
@@ -344,7 +344,7 @@ export const RawZoomHelpers = {
       zoomActive,
     };
 
-    if (isFunction(onZoomDomainChange)) {
+    if (Helpers.isFunction(onZoomDomainChange)) {
       onZoomDomainChange(
         currentDomain,
         defaults({}, mutatedProps, targetProps),


### PR DESCRIPTION
Replaces lodash `isFunction` with a native code function that acts as a Typescript type guard.

This is a stacked PR and is based on #2800. It will be rebased against main after #2800 is merged.

