### PR TITLE
Add workflows to help automate issue triage

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -1,0 +1,28 @@
+name: Close inactive issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v4
+        with:
+          ascending: false
+          operations-per-run: 100
+          days-before-issue-stale: 90
+          days-before-issue-close: 7
+          stale-issue-label: 'Issue: Stale'
+          exempt-issue-labels: 'Issue: Accepted'
+          stale-issue-message: 'This issue is stale because it has been open for 90 days with no activity. If there is no activity in the next 7 days, the issue will be closed.'
+          close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked as stale. Please open a new issue if you believe you are encountering a related problem.'
+          days-before-pr-stale: -1
+          days-before-pr-close: -14
+          enable-statistics: true

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -24,5 +24,5 @@ jobs:
           stale-issue-message: 'This issue is stale because it has been open for 90 days with no activity. If there is no activity in the next 7 days, the issue will be closed.'
           close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked as stale. Please open a new issue if you believe you are encountering a related problem.'
           days-before-pr-stale: -1
-          days-before-pr-close: -14
+          days-before-pr-close: -1
           enable-statistics: true

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,39 @@
+name: Issue Triage
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  needs-repro:
+    runs-on: ubuntu-22.04
+    if: "${{ contains(github.event.label.name, 'Status: Needs More Info :hand:') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hi there! It looks like your issue requires a minimal reproducible example, but it is invalid or absent. Please prepare such an example and share it with us.
+
+              **The best way to get attention to your issue is to provide a clean and easy way for a developer to reproduce the issue on their own machine.** Please do not provide your entire project, or a project with more code than is necessary to reproduce the issue.
+
+              A side benefit of going through the process of narrowing down the minimal amount of code needed to reproduce the issue is that you may get lucky and discover that the bug is due to a mistake in your application code that you can quickly fix on your own.
+
+              ### Resources
+
+              - ["How to create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example)
+              - ["Codesandbox Starterkit for Victory"](https://codesandbox.io/p/sandbox/victory-starter-dj4f7t)
+
+              ### Common concerns
+
+              #### "I didn't have time to create one"
+
+              That's understandable, it can take some time to prepare. We ask that you hold off on filing an issue until you are able to fully complete the required fields in the issue template.
+
+              #### "You can reproduce it by yourself by creating a project and following these steps"
+
+              This is useful knowledge, but it's still valuable to have the resulting project that is produced from running the steps, where you have verified you can reproduce the issue.
+            `})


### PR DESCRIPTION
Add new workflows to help automate issue triage. Inspired by the Expo repository.

### Stale Issues

Any issues open longer than 90 days without activity will be labeled as "Stale". Any issue labeled "Stale" more than 7 days will be automatically closed with a message.

### Triage bot

This bot automates the reply message to issues. When an issue does not contain enough information or sample code, simply label the issue as `Status: Needs More Info` and the bot will automatically post a message containing links and information for the issue author.