### PR TITLE
Override VictoryGroup styles with VictoryBoxplot

### DIFF
--- a/.changeset/rare-spies-agree.md
+++ b/.changeset/rare-spies-agree.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+allow VictoryBoxPlot childStyles to override VictoryGroup parent styles

--- a/demo/ts/components/group-demo.tsx
+++ b/demo/ts/components/group-demo.tsx
@@ -9,6 +9,7 @@ import { VictoryScatter } from "victory-scatter";
 import { VictoryErrorBar } from "victory-errorbar";
 import { VictoryTooltip } from "victory-tooltip";
 import { VictoryVoronoi } from "victory-voronoi";
+import { VictoryBoxPlot } from "victory-box-plot";
 import { range, random } from "lodash";
 
 class App extends React.Component {
@@ -160,6 +161,27 @@ class App extends React.Component {
               />
             </VictoryGroup>
           </VictoryChart>
+          <VictoryGroup style={chartStyle}>
+              <VictoryBoxPlot
+                minLabels
+                maxLabels
+                data={[
+                  { x: 1, y: [1, 2, 3, 5] },
+                  { x: 2, y: [3, 2, 8, 10] },
+                  { x: 3, y: [2, 8, 6, 5] },
+                  { x: 4, y: [1, 3, 2, 9] },
+                ]}
+                style={{
+                  min: { stroke: "tomato" },
+                  max: { stroke: "orange" },
+                  q1: { fill: "tomato" },
+                  q3: { fill: "orange" },
+                  median: { stroke: "white", strokeWidth: 2 },
+                  minLabels: { fill: "tomato" },
+                  maxLabels: { fill: "orange" },
+                }}
+              />
+            </VictoryGroup>
         </div>
       </div>
     );

--- a/packages/victory-core/src/victory-util/wrapper.tsx
+++ b/packages/victory-core/src/victory-util/wrapper.tsx
@@ -345,6 +345,7 @@ export function getChildStyle(child, index, calculatedProps) {
   );
   const labelsStyle = defaults({}, childStyle.labels, style.labels);
   return {
+    ...childStyle,
     parent: style.parent,
     data: dataStyle,
     labels: labelsStyle,

--- a/packages/victory-group/src/helper-methods.tsx
+++ b/packages/victory-group/src/helper-methods.tsx
@@ -202,10 +202,7 @@ export function getChildren(initialProps, childComponents?, calculatedProps?) {
       ? getPolarX0(props, newCalculatedProps, index, role)
       : getX0(props, newCalculatedProps, index, role);
     const style =
-      role === "voronoi" ||
-      role === "tooltip" ||
-      role === "label" ||
-      role === "boxplot"
+      role === "voronoi" || role === "tooltip" || role === "label"
         ? child.props.style
         : Wrapper.getChildStyle(child, index, newCalculatedProps);
     const labels = props.labels

--- a/packages/victory-group/src/helper-methods.tsx
+++ b/packages/victory-group/src/helper-methods.tsx
@@ -202,7 +202,10 @@ export function getChildren(initialProps, childComponents?, calculatedProps?) {
       ? getPolarX0(props, newCalculatedProps, index, role)
       : getX0(props, newCalculatedProps, index, role);
     const style =
-      role === "voronoi" || role === "tooltip" || role === "label" || role === "boxplot"
+      role === "voronoi" ||
+      role === "tooltip" ||
+      role === "label" ||
+      role === "boxplot"
         ? child.props.style
         : Wrapper.getChildStyle(child, index, newCalculatedProps);
     const labels = props.labels

--- a/packages/victory-group/src/helper-methods.tsx
+++ b/packages/victory-group/src/helper-methods.tsx
@@ -202,7 +202,7 @@ export function getChildren(initialProps, childComponents?, calculatedProps?) {
       ? getPolarX0(props, newCalculatedProps, index, role)
       : getX0(props, newCalculatedProps, index, role);
     const style =
-      role === "voronoi" || role === "tooltip" || role === "label"
+      role === "voronoi" || role === "tooltip" || role === "label" || role === "boxplot"
         ? child.props.style
         : Wrapper.getChildStyle(child, index, newCalculatedProps);
     const labels = props.labels

--- a/stories/victory-box-plot.stories.tsx
+++ b/stories/victory-box-plot.stories.tsx
@@ -5,7 +5,6 @@ import { range } from "lodash";
 import seedrandom from "seedrandom";
 
 import { VictoryBoxPlot } from "../packages/victory-box-plot";
-import { VictoryBar } from "../packages/victory-bar";
 import { VictoryChart } from "../packages/victory-chart";
 import { VictoryTooltip } from "../packages/victory-tooltip";
 import { VictoryGroup } from "../packages/victory-group";

--- a/stories/victory-box-plot.stories.tsx
+++ b/stories/victory-box-plot.stories.tsx
@@ -5,8 +5,10 @@ import { range } from "lodash";
 import seedrandom from "seedrandom";
 
 import { VictoryBoxPlot } from "../packages/victory-box-plot";
+import { VictoryBar } from "../packages/victory-bar";
 import { VictoryChart } from "../packages/victory-chart";
 import { VictoryTooltip } from "../packages/victory-tooltip";
+import { VictoryGroup } from "../packages/victory-group";
 import {
   VictoryTheme,
   Box,
@@ -358,5 +360,31 @@ export const DisableInlineStyles = () => {
         />
       </VictoryChart>
     </>
+  );
+};
+
+export const VictoryGroupAsParent = () => {
+  return (
+    <VictoryGroup style={parentStyle}>
+      <VictoryBoxPlot
+        minLabels
+        maxLabels
+        data={[
+          { x: 1, y: [1, 2, 3, 5] },
+          { x: 2, y: [3, 2, 8, 10] },
+          { x: 3, y: [2, 8, 6, 5] },
+          { x: 4, y: [1, 3, 2, 9] },
+        ]}
+        style={{
+          min: { stroke: "tomato" },
+          max: { stroke: "orange" },
+          q1: { fill: "tomato" },
+          q3: { fill: "orange" },
+          median: { stroke: "white", strokeWidth: 2 },
+          minLabels: { fill: "tomato" },
+          maxLabels: { fill: "orange" },
+        }}
+      />
+    </VictoryGroup>
   );
 };

--- a/stories/victory-box-plot.stories.tsx
+++ b/stories/victory-box-plot.stories.tsx
@@ -6,6 +6,7 @@ import seedrandom from "seedrandom";
 
 import { VictoryBoxPlot } from "../packages/victory-box-plot";
 import { VictoryChart } from "../packages/victory-chart";
+import { VictoryGroup } from "../packages/victory-group";
 import { VictoryTooltip } from "../packages/victory-tooltip";
 import {
   VictoryTheme,
@@ -358,5 +359,31 @@ export const DisableInlineStyles = () => {
         />
       </VictoryChart>
     </>
+  );
+};
+
+export const VictoryGroupAsParent = () => {
+  return (
+    <VictoryGroup style={parentStyle}>
+      <VictoryBoxPlot
+        minLabels
+        maxLabels
+        data={[
+          { x: 1, y: [1, 2, 3, 5] },
+          { x: 2, y: [3, 2, 8, 10] },
+          { x: 3, y: [2, 8, 6, 5] },
+          { x: 4, y: [1, 3, 2, 9] },
+        ]}
+        style={{
+          min: { stroke: "tomato" },
+          max: { stroke: "orange" },
+          q1: { fill: "tomato" },
+          q3: { fill: "orange" },
+          median: { stroke: "white", strokeWidth: 2 },
+          minLabels: { fill: "tomato" },
+          maxLabels: { fill: "orange" },
+        }}
+      />
+    </VictoryGroup>
   );
 };

--- a/stories/victory-box-plot.stories.tsx
+++ b/stories/victory-box-plot.stories.tsx
@@ -7,7 +7,6 @@ import seedrandom from "seedrandom";
 import { VictoryBoxPlot } from "../packages/victory-box-plot";
 import { VictoryChart } from "../packages/victory-chart";
 import { VictoryTooltip } from "../packages/victory-tooltip";
-import { VictoryGroup } from "../packages/victory-group";
 import {
   VictoryTheme,
   Box,
@@ -359,31 +358,5 @@ export const DisableInlineStyles = () => {
         />
       </VictoryChart>
     </>
-  );
-};
-
-export const VictoryGroupAsParent = () => {
-  return (
-    <VictoryGroup style={parentStyle}>
-      <VictoryBoxPlot
-        minLabels
-        maxLabels
-        data={[
-          { x: 1, y: [1, 2, 3, 5] },
-          { x: 2, y: [3, 2, 8, 10] },
-          { x: 3, y: [2, 8, 6, 5] },
-          { x: 4, y: [1, 3, 2, 9] },
-        ]}
-        style={{
-          min: { stroke: "tomato" },
-          max: { stroke: "orange" },
-          q1: { fill: "tomato" },
-          q3: { fill: "orange" },
-          median: { stroke: "white", strokeWidth: 2 },
-          minLabels: { fill: "tomato" },
-          maxLabels: { fill: "orange" },
-        }}
-      />
-    </VictoryGroup>
   );
 };


### PR DESCRIPTION

<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

VictoryGroup was overriding the styles of the child Boxplot with its wrapper styles. To fix this , new role check for `boxplot 
is added.

Fixes #1261

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

I tested this against the given code example in the issue and the style is now getting reflected.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
