### PR TITLE
Fix the signature of class static fields as functions

### DIFF
--- a/.changeset/stale-shirts-grow.md
+++ b/.changeset/stale-shirts-grow.md
@@ -1,0 +1,25 @@
+---
+"victory-area": patch
+"victory-axis": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-brush-container": patch
+"victory-candlestick": patch
+"victory-create-container": patch
+"victory-cursor-container": patch
+"victory-errorbar": patch
+"victory-histogram": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-native": patch
+"victory-pie": patch
+"victory-polar-axis": patch
+"victory-scatter": patch
+"victory-selection-container": patch
+"victory-tooltip": patch
+"victory-voronoi": patch
+"victory-voronoi-container": patch
+"victory-zoom-container": patch
+---
+
+Fix the signature of class static functions in components

--- a/packages/victory-area/src/victory-area.tsx
+++ b/packages/victory-area/src/victory-area.tsx
@@ -88,7 +88,9 @@ class VictoryAreaBase extends React.Component<VictoryAreaProps> {
     DefaultTransitions.continuousPolarTransitions();
   static getDomain = Domain.getDomainWithZero;
   static getData = Data.getData;
-  static getBaseProps = (props) => getBaseProps(props, fallbackProps);
+  static getBaseProps(props) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents = [
     "dataComponent",
     "labelComponent",

--- a/packages/victory-axis/src/victory-axis.tsx
+++ b/packages/victory-axis/src/victory-axis.tsx
@@ -102,8 +102,12 @@ class VictoryAxisBase extends React.Component<VictoryAxisProps> {
 
   static getDomain = Axis.getDomain;
   static getAxis = Axis.getAxis;
-  static getStyles = (props) => getStyles(props);
-  static getBaseProps = (props) => getBaseProps(props, fallbackProps);
+  static getStyles(props) {
+    return getStyles(props);
+  }
+  static getBaseProps(props) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents: Array<keyof VictoryAxisProps> = [
     "axisComponent",
     "axisLabelComponent",

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -119,8 +119,9 @@ class VictoryBarBase extends React.Component<VictoryBarProps> {
 
   static getDomain = Domain.getDomainWithZero;
   static getData = Data.getData;
-  static getBaseProps = (props: VictoryBarProps) =>
-    getBaseProps(props, fallbackProps);
+  static getBaseProps(props: VictoryBarProps) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents: (keyof VictoryBarProps)[] = [
     "dataComponent",
     "labelComponent",

--- a/packages/victory-box-plot/src/victory-box-plot.tsx
+++ b/packages/victory-box-plot/src/victory-box-plot.tsx
@@ -163,7 +163,9 @@ class VictoryBoxPlotBase extends React.Component<VictoryBoxPlotProps> {
 
   static getDomain = getDomain;
   static getData = getData;
-  static getBaseProps = (props) => getBaseProps(props, fallbackProps);
+  static getBaseProps(props) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents: Array<keyof VictoryBoxPlotProps> = [
     "maxComponent",
     "maxLabelComponent",

--- a/packages/victory-box-plot/src/victory-box-plot.tsx
+++ b/packages/victory-box-plot/src/victory-box-plot.tsx
@@ -161,8 +161,12 @@ class VictoryBoxPlotBase extends React.Component<VictoryBoxPlotProps> {
     theme: VictoryTheme.grayscale,
   };
 
-  static getDomain = getDomain;
-  static getData = getData;
+  static getDomain(props, axis) {
+    return getDomain(props, axis);
+  }
+  static getData(props) {
+    return getData(props);
+  }
   static getBaseProps(props) {
     return getBaseProps(props, fallbackProps);
   }

--- a/packages/victory-brush-container/src/victory-brush-container.tsx
+++ b/packages/victory-brush-container/src/victory-brush-container.tsx
@@ -66,7 +66,7 @@ export function brushContainerMixin<
       mouseMoveThreshold: 0,
     };
 
-    static defaultEvents = (props) => {
+    static defaultEvents(props) {
       return [
         {
           target: "parent",
@@ -111,7 +111,7 @@ export function brushContainerMixin<
           },
         },
       ];
-    };
+    }
 
     getSelectBox(props, coordinates) {
       const { x, y } = coordinates;

--- a/packages/victory-candlestick/src/victory-candlestick.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.tsx
@@ -169,8 +169,12 @@ class VictoryCandlestickBase extends React.Component<VictoryCandlestickProps> {
     theme: VictoryTheme.grayscale,
   };
 
-  static getDomain = getDomain;
-  static getData = getData;
+  static getDomain(props, axis) {
+    return getDomain(props, axis);
+  }
+  static getData(props) {
+    return getData(props);
+  }
   static getBaseProps(props: VictoryCandlestickProps) {
     return getBaseProps(props, fallbackProps);
   }

--- a/packages/victory-candlestick/src/victory-candlestick.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.tsx
@@ -171,8 +171,9 @@ class VictoryCandlestickBase extends React.Component<VictoryCandlestickProps> {
 
   static getDomain = getDomain;
   static getData = getData;
-  static getBaseProps = (props: VictoryCandlestickProps) =>
-    getBaseProps(props, fallbackProps);
+  static getBaseProps(props: VictoryCandlestickProps) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents = [
     "openLabelComponent",
     "closeLabelComponent",

--- a/packages/victory-create-container/src/create-container.ts
+++ b/packages/victory-create-container/src/create-container.ts
@@ -97,7 +97,7 @@ export const combineContainerMixins = (
       {},
     );
 
-    static defaultEvents = (props) => {
+    static defaultEvents(props) {
       return combineDefaultEvents(
         Classes.reduce((defaultEvents, Class) => {
           const events = Helpers.isFunction(Class.defaultEvents)
@@ -106,7 +106,7 @@ export const combineContainerMixins = (
           return [...defaultEvents, ...events];
         }, []),
       );
-    };
+    }
 
     getChildren(props) {
       return instances.reduce(

--- a/packages/victory-cursor-container/src/victory-cursor-container.tsx
+++ b/packages/victory-cursor-container/src/victory-cursor-container.tsx
@@ -46,7 +46,7 @@ export function cursorContainerMixin<
       },
       cursorComponent: <LineSegment />,
     };
-    static defaultEvents = (props) => {
+    static defaultEvents(props) {
       return [
         {
           target: "parent",
@@ -72,7 +72,7 @@ export function cursorContainerMixin<
           },
         },
       ];
-    };
+    }
 
     getCursorPosition(props) {
       const { cursorValue, defaultCursorValue, domain, cursorDimension } =

--- a/packages/victory-errorbar/src/victory-errorbar.tsx
+++ b/packages/victory-errorbar/src/victory-errorbar.tsx
@@ -88,7 +88,9 @@ class VictoryErrorBarBase extends React.Component<VictoryErrorBarProps> {
 
   static getDomain = getDomain;
   static getData = getData;
-  static getBaseProps = (props) => getBaseProps(props, fallbackProps);
+  static getBaseProps(props) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents = [
     "dataComponent",
     "labelComponent",

--- a/packages/victory-errorbar/src/victory-errorbar.tsx
+++ b/packages/victory-errorbar/src/victory-errorbar.tsx
@@ -86,8 +86,12 @@ class VictoryErrorBarBase extends React.Component<VictoryErrorBarProps> {
     theme: VictoryTheme.grayscale,
   };
 
-  static getDomain = getDomain;
-  static getData = getData;
+  static getDomain(props, axis) {
+    return getDomain(props, axis);
+  }
+  static getData(props) {
+    return getData(props);
+  }
   static getBaseProps(props) {
     return getBaseProps(props, fallbackProps);
   }

--- a/packages/victory-histogram/src/victory-histogram.tsx
+++ b/packages/victory-histogram/src/victory-histogram.tsx
@@ -111,8 +111,12 @@ class VictoryHistogramBase extends React.Component<VictoryHistogramProps> {
     theme: VictoryTheme.grayscale,
   };
 
-  static getDomain = getDomain;
-  static getData = getData;
+  static getDomain(props, axis) {
+    return getDomain(props, axis);
+  }
+  static getData(props) {
+    return getData(props);
+  }
   static getBaseProps(props: VictoryHistogramProps) {
     return getBaseProps(props, fallbackProps);
   }

--- a/packages/victory-histogram/src/victory-histogram.tsx
+++ b/packages/victory-histogram/src/victory-histogram.tsx
@@ -113,8 +113,9 @@ class VictoryHistogramBase extends React.Component<VictoryHistogramProps> {
 
   static getDomain = getDomain;
   static getData = getData;
-  static getBaseProps = (props: VictoryHistogramProps) =>
-    getBaseProps(props, fallbackProps);
+  static getBaseProps(props: VictoryHistogramProps) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents: Partial<keyof VictoryHistogramProps>[] = [
     "dataComponent",
     "labelComponent",

--- a/packages/victory-histogram/src/victory-histogram.tsx
+++ b/packages/victory-histogram/src/victory-histogram.tsx
@@ -97,7 +97,9 @@ class VictoryHistogramBase extends React.Component<VictoryHistogramProps> {
     },
   };
 
-  static getFormattedData = getFormattedData;
+  static getFormattedData(...args: any) {
+    return getFormattedData(...args);
+  }
 
   static defaultProps: VictoryHistogramProps = {
     containerComponent: <VictoryContainer />,

--- a/packages/victory-legend/src/victory-legend.tsx
+++ b/packages/victory-legend/src/victory-legend.tsx
@@ -84,11 +84,13 @@ class VictoryLegendBase extends React.Component<VictoryLegendProps> {
     titleComponent: <VictoryLabel />,
   };
 
-  static getBaseProps = (props: VictoryLegendProps) =>
-    getBaseProps(props, fallbackProps);
+  static getBaseProps(props: VictoryLegendProps) {
+    return getBaseProps(props, fallbackProps);
+  }
 
-  static getDimensions = (props: VictoryLegendProps) =>
-    getDimensions(props, fallbackProps);
+  static getDimensions(props: VictoryLegendProps) {
+    return getDimensions(props, fallbackProps);
+  }
 
   static expectedComponents = [
     "borderComponent",

--- a/packages/victory-line/src/victory-line.tsx
+++ b/packages/victory-line/src/victory-line.tsx
@@ -77,7 +77,9 @@ class VictoryLineBase extends React.Component<VictoryLineProps> {
 
   static getDomain = Domain.getDomain;
   static getData = Data.getData;
-  static getBaseProps = (props) => getBaseProps(props, fallbackProps);
+  static getBaseProps(props) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents = [
     "dataComponent",
     "labelComponent",

--- a/packages/victory-native/src/components/victory-brush-container.tsx
+++ b/packages/victory-native/src/components/victory-brush-container.tsx
@@ -50,7 +50,7 @@ function nativeBrushMixin<
     };
 
     // overrides all web events with native specific events
-    static defaultEvents = (props: TProps) => {
+    static defaultEvents(props: TProps) {
       return [
         {
           target: "parent",
@@ -77,7 +77,7 @@ function nativeBrushMixin<
           },
         },
       ];
-    };
+    }
   };
 }
 

--- a/packages/victory-native/src/components/victory-cursor-container.tsx
+++ b/packages/victory-native/src/components/victory-cursor-container.tsx
@@ -42,7 +42,7 @@ function nativeCursorMixin<
     };
 
     // overrides all web events with native specific events
-    static defaultEvents = (props: TProps) => {
+    static defaultEvents(props: TProps) {
       return [
         {
           target: "parent",
@@ -65,7 +65,7 @@ function nativeCursorMixin<
           },
         },
       ];
-    };
+    }
   };
 }
 

--- a/packages/victory-native/src/components/victory-selection-container.tsx
+++ b/packages/victory-native/src/components/victory-selection-container.tsx
@@ -50,7 +50,7 @@ function nativeSelectionMixin<
     };
 
     // overrides all web events with native specific events
-    static defaultEvents = (props: TProps) => {
+    static defaultEvents(props: TProps) {
       return [
         {
           target: "parent",
@@ -77,7 +77,7 @@ function nativeSelectionMixin<
           },
         },
       ];
-    };
+    }
   };
 }
 

--- a/packages/victory-native/src/components/victory-tooltip.tsx
+++ b/packages/victory-native/src/components/victory-tooltip.tsx
@@ -13,40 +13,42 @@ export class VictoryTooltip extends VictoryTooltipBase {
     groupComponent: <G />,
   };
 
-  static defaultEvents = () => [
-    {
-      target: "data",
-      eventHandlers: {
-        onPressIn: (targetProps) => {
-          return [
-            {
-              target: "labels",
-              mutation: () => ({ active: true }),
-            },
-            {
-              target: "data",
-              mutation: () =>
-                targetProps.activateData
-                  ? { active: true }
-                  : { active: undefined },
-            },
-          ];
-        },
-        onPressOut: () => {
-          return [
-            {
-              target: "labels",
-              mutation: () => ({ active: undefined }),
-            },
-            {
-              target: "data",
-              mutation: () => ({ active: undefined }),
-            },
-          ];
+  static defaultEvents() {
+    return [
+      {
+        target: "data",
+        eventHandlers: {
+          onPressIn: (targetProps) => {
+            return [
+              {
+                target: "labels",
+                mutation: () => ({ active: true }),
+              },
+              {
+                target: "data",
+                mutation: () =>
+                  targetProps.activateData
+                    ? { active: true }
+                    : { active: undefined },
+              },
+            ];
+          },
+          onPressOut: () => {
+            return [
+              {
+                target: "labels",
+                mutation: () => ({ active: undefined }),
+              },
+              {
+                target: "data",
+                mutation: () => ({ active: undefined }),
+              },
+            ];
+          },
         },
       },
-    },
-  ];
+    ];
+  }
 
   renderTooltip(props) {
     const evaluatedProps = this.getEvaluatedProps(props);

--- a/packages/victory-native/src/components/victory-voronoi-container.tsx
+++ b/packages/victory-native/src/components/victory-voronoi-container.tsx
@@ -43,7 +43,7 @@ function nativeVoronoiMixin<
     };
 
     // overrides all web events with native specific events
-    static defaultEvents = (props: TProps) => {
+    static defaultEvents(props: TProps) {
       return [
         {
           target: "parent",
@@ -76,7 +76,7 @@ function nativeVoronoiMixin<
               },
         },
       ];
-    };
+    }
   };
 }
 

--- a/packages/victory-native/src/components/victory-zoom-container.tsx
+++ b/packages/victory-native/src/components/victory-zoom-container.tsx
@@ -39,7 +39,7 @@ function nativeZoomMixin<
     };
 
     // overrides all web events with native specific events
-    static defaultEvents = (props: TProps) => {
+    static defaultEvents(props: TProps) {
       const { disable } = props;
       return [
         {
@@ -80,7 +80,7 @@ function nativeZoomMixin<
           },
         },
       ];
-    };
+    }
   };
 }
 

--- a/packages/victory-pie/src/victory-pie.tsx
+++ b/packages/victory-pie/src/victory-pie.tsx
@@ -146,8 +146,9 @@ class VictoryPieBase extends React.Component<VictoryPieProps> {
     theme: VictoryTheme.grayscale,
   };
 
-  static getBaseProps = (props: VictoryPieProps) =>
-    getBaseProps(props, fallbackProps);
+  static getBaseProps(props: VictoryPieProps) {
+    return getBaseProps(props, fallbackProps);
+  }
   static getData = Data.getData;
   static expectedComponents: (keyof VictoryPieProps)[] = [
     "dataComponent",

--- a/packages/victory-polar-axis/src/victory-polar-axis.tsx
+++ b/packages/victory-polar-axis/src/victory-polar-axis.tsx
@@ -67,7 +67,9 @@ class VictoryPolarAxisBase extends React.Component<VictoryPolarAxisProps> {
 
   static getDomain = Axis.getDomain;
   static getAxis = Axis.getAxis;
-  static getScale = getScale;
+  static getScale(props) {
+    return getScale(props);
+  }
   static getStyles(props) {
     return getStyles(props, fallbackProps.style);
   }

--- a/packages/victory-polar-axis/src/victory-polar-axis.tsx
+++ b/packages/victory-polar-axis/src/victory-polar-axis.tsx
@@ -68,8 +68,12 @@ class VictoryPolarAxisBase extends React.Component<VictoryPolarAxisProps> {
   static getDomain = Axis.getDomain;
   static getAxis = Axis.getAxis;
   static getScale = getScale;
-  static getStyles = (props) => getStyles(props, fallbackProps.style);
-  static getBaseProps = (props) => getBaseProps(props, fallbackProps);
+  static getStyles(props) {
+    return getStyles(props, fallbackProps.style);
+  }
+  static getBaseProps(props) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents = [
     "axisComponent",
     "circularAxisComponent",

--- a/packages/victory-scatter/src/victory-scatter.tsx
+++ b/packages/victory-scatter/src/victory-scatter.tsx
@@ -86,7 +86,9 @@ class VictoryScatterBase extends React.Component<VictoryScatterProps> {
 
   static getDomain = Domain.getDomain;
   static getData = Data.getData;
-  static getBaseProps = (props) => getBaseProps(props, fallbackProps);
+  static getBaseProps(props) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents = [
     "dataComponent",
     "labelComponent",

--- a/packages/victory-selection-container/src/victory-selection-container.tsx
+++ b/packages/victory-selection-container/src/victory-selection-container.tsx
@@ -52,7 +52,7 @@ export function selectionContainerMixin<
       },
     };
 
-    static defaultEvents = (props: TProps) => {
+    static defaultEvents(props: TProps) {
       return [
         {
           target: "parent",
@@ -90,7 +90,7 @@ export function selectionContainerMixin<
           },
         },
       ];
-    };
+    }
 
     getRect(props) {
       const { x1, x2, y1, y2, selectionStyle, selectionComponent, name } =

--- a/packages/victory-tooltip/src/victory-tooltip.tsx
+++ b/packages/victory-tooltip/src/victory-tooltip.tsx
@@ -106,12 +106,10 @@ export class VictoryTooltip extends React.Component<VictoryTooltipProps> {
     groupComponent: <g />,
   };
 
-  static defaultEvents = (
-    props: VictoryTooltipProps,
-  ): {
+  static defaultEvents(props: VictoryTooltipProps): {
     target: string;
     eventHandlers: EventHandlers;
-  }[] => {
+  }[] {
     const activate = props.activateData
       ? [
           { target: "labels", mutation: () => ({ active: true }) },
@@ -137,7 +135,7 @@ export class VictoryTooltip extends React.Component<VictoryTooltipProps> {
         },
       },
     ];
-  };
+  }
 
   id: string | number;
 

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
@@ -43,7 +43,7 @@ export function voronoiContainerMixin<
       voronoiPadding: 5,
     };
 
-    static defaultEvents = (props: VictoryVoronoiContainerProps) => {
+    static defaultEvents(props: VictoryVoronoiContainerProps) {
       return [
         {
           target: "parent",
@@ -81,7 +81,7 @@ export function voronoiContainerMixin<
               },
         },
       ];
-    };
+    }
 
     getDimension(props) {
       const { horizontal, voronoiDimension } = props;

--- a/packages/victory-voronoi/src/victory-voronoi.tsx
+++ b/packages/victory-voronoi/src/victory-voronoi.tsx
@@ -75,8 +75,9 @@ class VictoryVoronoiBase extends React.Component<VictoryVoronoiProps> {
 
   static getDomain = Domain.getDomain;
   static getData = Data.getData;
-  static getBaseProps = (props: VictoryVoronoiProps) =>
-    getBaseProps(props, fallbackProps);
+  static getBaseProps(props: VictoryVoronoiProps) {
+    return getBaseProps(props, fallbackProps);
+  }
   static expectedComponents: (keyof VictoryVoronoiProps)[] = [
     "dataComponent",
     "labelComponent",

--- a/packages/victory-zoom-container/src/victory-zoom-container.tsx
+++ b/packages/victory-zoom-container/src/victory-zoom-container.tsx
@@ -47,7 +47,7 @@ export function zoomContainerMixin<
       zoomActive: false,
     };
 
-    static defaultEvents = (props: TProps) => {
+    static defaultEvents(props: TProps) {
       return [
         {
           target: "parent",
@@ -103,7 +103,7 @@ export function zoomContainerMixin<
           },
         },
       ];
-    };
+    }
 
     clipDataComponents(children: React.ReactElement[], props) {
       const { scale, clipContainerComponent, polar, origin, horizontal } =


### PR DESCRIPTION
Changes static fields that were defined as inline functions to avoid problems with some transpilers.

In components defined as classes, some static fields were defined as inline functions.

```
// source code
static getBaseProps = (props) => getBaseProps(props, fallbackProps);

// transpiled
static (0, $csb___helper_methods.getBaseProps) = props => (0, $csb___helper_methods.getBaseProps)(props, fallbackProps)
```

This PR changes those to plain functions in order to prevent a syntax error in transpilers that do not specify a default name for anonymous functions.

```
// source code
static getBaseProps(props){
  return getBaseProps(props, fallbackProps);
}

// transpiled
static getBaseProps = function (props) {
  return (0, $csb___helper_methods.getBaseProps)(props, fallbackProps);
};
```

Published `victory@37.0.1-next.2` pre release package

[Working Codesandbox](https://codesandbox.io/p/sandbox/victory-version-36-forked-3zyct5?file=%2Fpackage.json%3A10%2C30)

Fix for #2839 