### PR TITLE
Fix zoom out of chart with cursor outside chart container

### DIFF
--- a/.changeset/honest-bananas-suffer.md
+++ b/.changeset/honest-bananas-suffer.md
@@ -1,0 +1,5 @@
+---
+"victory-zoom-container": patch
+---
+
+Fix: #2761 zoom out zooming in if cursor outside chart container

--- a/packages/victory-zoom-container/src/zoom-helpers.test.ts
+++ b/packages/victory-zoom-container/src/zoom-helpers.test.ts
@@ -1,0 +1,88 @@
+import { RawZoomHelpers } from "./zoom-helpers";
+
+describe("RawZoomHelpers.getMinimumDomain", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  it("should be calculating the minimum domain", () => {
+    jest.spyOn(RawZoomHelpers, "getDomain").mockImplementation(() => ({
+      x: [0, 100],
+    }));
+    expect(
+      RawZoomHelpers.getMinimumDomain(30, { minimumZoom: true }, "x"),
+    ).toStrictEqual([29.95, 30.05]);
+  });
+});
+
+describe("RawZoomHelpers.getScaledDomain", () => {
+  it("should scale the domain correctly with a zoom in factor", () => {
+    expectToBeCloseToArray(
+      RawZoomHelpers.getScaledDomain([0, 100], 0.9, 0.5),
+      [5, 95],
+    );
+  });
+  it("should scale the domain correctly with a zoom out factor", () => {
+    expectToBeCloseToArray(
+      RawZoomHelpers.getScaledDomain([0, 100], 1.1, 0.5),
+      [-5, 105],
+    );
+  });
+});
+
+describe("RawZoomHelpers.scale", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should get the correct domain", () => {
+    jest.spyOn(RawZoomHelpers, "getDomain").mockImplementation(() => ({
+      x: [0, 100],
+    }));
+    jest.spyOn(RawZoomHelpers, "getScalePercent").mockImplementation(() => 0.5);
+    jest
+      .spyOn(RawZoomHelpers, "getMinimumDomain")
+      .mockImplementation(() => [29.955, 30.045]);
+
+    expectToBeCloseToArray(
+      RawZoomHelpers.scale([0, 100], { deltaY: -1 }, {}, "x"),
+      [0.166, 99.833],
+    );
+  });
+
+  it("should't change the domain when zooming out with max zoom out", () => {
+    jest.spyOn(RawZoomHelpers, "getDomain").mockImplementation(() => ({
+      x: [0, 100],
+    }));
+    jest.spyOn(RawZoomHelpers, "getScalePercent").mockImplementation(() => 0.1);
+    jest
+      .spyOn(RawZoomHelpers, "getMinimumDomain")
+      .mockImplementation(() => [29.955, 30.045]);
+
+    expectToBeCloseToArray(
+      RawZoomHelpers.scale([0, 100], { deltaY: 1 }, {}, "x"),
+      [0, 100],
+    );
+  });
+
+  it("should't change the domain when zooming out with max zoom out with the cursor outside the container boundary", () => {
+    jest.spyOn(RawZoomHelpers, "getDomain").mockImplementation(() => ({
+      x: [0, 100],
+    }));
+    jest
+      .spyOn(RawZoomHelpers, "getScalePercent")
+      .mockImplementation(() => -0.1);
+    jest
+      .spyOn(RawZoomHelpers, "getMinimumDomain")
+      .mockImplementation(() => [29.955, 30.045]);
+
+    expectToBeCloseToArray(
+      RawZoomHelpers.scale([0, 100], { deltaY: 1 }, {}, "x"),
+      [0, 100],
+    );
+  });
+});
+
+function expectToBeCloseToArray(actual, expected) {
+  expect(actual.length).toBe(expected.length);
+  actual.forEach((x, i) => expect(x).toBeCloseTo(expected[i]));
+}

--- a/packages/victory-zoom-container/src/zoom-helpers.ts
+++ b/packages/victory-zoom-container/src/zoom-helpers.ts
@@ -64,8 +64,8 @@ export const RawZoomHelpers = {
     const [from, to] = currentDomain;
     const range = Math.abs(to - from);
     const diff = range - range * factor;
-    const newMin = Number(from) + diff * percent;
-    const newMax = Number(to) - diff * (1 - percent);
+    const newMin = Number(from) + diff * Math.max(percent, 0);
+    const newMax = Number(to) - diff * Math.max(1 - percent, 0);
     return [Math.min(newMin, newMax), Math.max(newMin, newMax)];
   },
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2761

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

Bug fix

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Verified manually and added unit tests with previously failing example (`"should't change the domain when zooming out with max zoom out with the cursor outside the container boundary"`).

With this simple solution if the cursor is outside the chart container it will be considered as if it is at the container edge.

Steps to reproduce the reproduce the unwanted behavior are reported in #2761.

The new behavior can be tested on the local ZoomContainerDemo example.
