### PR TITLE
fix: dedup data for `<VictoryStack/>`

### DIFF
--- a/.changeset/lovely-ligers-pump.md
+++ b/.changeset/lovely-ligers-pump.md
@@ -1,0 +1,5 @@
+---
+"victory-stack": patch
+---
+
+addresses #2883 - fall back in case data duplicated when using stack mode

--- a/packages/victory-stack/src/helper-methods.test.tsx
+++ b/packages/victory-stack/src/helper-methods.test.tsx
@@ -1,0 +1,862 @@
+import * as Helpers from "./helper-methods";
+
+jest.mock("victory-core", () => {
+  const originalModule = jest.requireActual("victory-core");
+
+  const data = [
+    [
+      {
+        _stack: 1,
+        _group: 0,
+        _x: new Date("2023-11-18T08:10:00.050Z"),
+        _y: 0,
+        x: new Date("2023-11-18T08:10:00.050Z"),
+        y: 0,
+      },
+      {
+        _stack: 1,
+        _group: 1,
+        _x: new Date("2023-11-18T08:10:00.050Z"),
+        _y: 2,
+        x: new Date("2023-11-18T08:10:00.050Z"),
+        y: 2,
+      },
+      {
+        _stack: 1,
+        _group: 2,
+        _x: new Date("2023-11-18T08:12:00.050Z"),
+        _y: 3,
+        x: new Date("2023-11-18T08:12:00.050Z"),
+        y: 3,
+      },
+      {
+        _stack: 1,
+        _group: 3,
+        _x: new Date("2023-11-18T08:13:00.050Z"),
+        _y: 4,
+        x: new Date("2023-11-18T08:13:00.050Z"),
+        y: 4,
+      },
+      {
+        _stack: 1,
+        _group: 4,
+        _x: new Date("2023-11-18T08:14:00.050Z"),
+        _y: 7,
+        x: new Date("2023-11-18T08:14:00.050Z"),
+        y: 7,
+      },
+      {
+        _stack: 1,
+        _group: 5,
+        _x: new Date("2023-11-18T08:15:00.050Z"),
+        _y: 8,
+        x: new Date("2023-11-18T08:15:00.050Z"),
+        y: 8,
+      },
+    ],
+  ];
+
+  const modifyProps = {
+    children: [
+      {
+        key: ".0",
+        ref: null,
+        props: {
+          data: [
+            {
+              x: "2023-11-18T08:10:00.050Z",
+              y: 0,
+            },
+            {
+              x: "2023-11-18T08:10:00.050Z",
+              y: 2,
+            },
+            {
+              x: "2023-11-18T08:12:00.050Z",
+              y: 3,
+            },
+            {
+              x: "2023-11-18T08:13:00.050Z",
+              y: 4,
+            },
+            {
+              x: "2023-11-18T08:14:00.050Z",
+              y: 7,
+            },
+            {
+              x: "2023-11-18T08:15:00.050Z",
+              y: 8,
+            },
+          ],
+          containerComponent: {
+            key: null,
+            ref: null,
+            props: {},
+            _owner: null,
+            _store: {},
+          },
+          dataComponent: {
+            key: null,
+            ref: null,
+            props: {},
+            _owner: null,
+            _store: {},
+          },
+          groupComponent: {
+            key: null,
+            ref: null,
+            props: {
+              circleComponent: {
+                type: {},
+                key: null,
+                ref: null,
+                props: {},
+                _owner: null,
+                _store: {},
+              },
+              rectComponent: {
+                type: {},
+                key: null,
+                ref: null,
+                props: {},
+                _owner: null,
+                _store: {},
+              },
+              clipPathComponent: {
+                key: null,
+                ref: null,
+                props: {},
+                _owner: null,
+                _store: {},
+              },
+              groupComponent: {
+                type: "g",
+                key: null,
+                ref: null,
+                props: {},
+                _owner: null,
+                _store: {},
+              },
+            },
+            _owner: null,
+            _store: {},
+          },
+          labelComponent: {
+            key: null,
+            ref: null,
+            props: {
+              renderInPortal: true,
+            },
+            _owner: null,
+            _store: {},
+          },
+          samples: 50,
+          sortKey: "x",
+          sortOrder: "ascending",
+          standalone: true,
+          theme: {
+            area: {
+              style: {
+                data: {
+                  fill: "#252525",
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            axis: {
+              style: {
+                axis: {
+                  fill: "transparent",
+                  stroke: "#252525",
+                  strokeWidth: 1,
+                  strokeLinecap: "round",
+                  strokeLinejoin: "round",
+                },
+                axisLabel: {
+                  textAnchor: "middle",
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 25,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+                grid: {
+                  fill: "none",
+                  stroke: "none",
+                  pointerEvents: "painted",
+                },
+                ticks: {
+                  fill: "transparent",
+                  size: 1,
+                  stroke: "transparent",
+                },
+                tickLabels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            bar: {
+              style: {
+                data: {
+                  fill: "#252525",
+                  padding: 8,
+                  strokeWidth: 0,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            boxplot: {
+              style: {
+                max: {
+                  padding: 8,
+                  stroke: "#252525",
+                  strokeWidth: 1,
+                },
+                maxLabels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 3,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+                median: {
+                  padding: 8,
+                  stroke: "#252525",
+                  strokeWidth: 1,
+                },
+                medianLabels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 3,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+                min: {
+                  padding: 8,
+                  stroke: "#252525",
+                  strokeWidth: 1,
+                },
+                minLabels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 3,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+                q1: {
+                  padding: 8,
+                  fill: "#969696",
+                },
+                q1Labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 3,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+                q3: {
+                  padding: 8,
+                  fill: "#969696",
+                },
+                q3Labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 3,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              boxWidth: 20,
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            candlestick: {
+              style: {
+                data: {
+                  stroke: "#252525",
+                  strokeWidth: 1,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 5,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              candleColors: {
+                positive: "#ffffff",
+                negative: "#252525",
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            chart: {
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            errorbar: {
+              borderWidth: 8,
+              style: {
+                data: {
+                  fill: "transparent",
+                  stroke: "#252525",
+                  strokeWidth: 2,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            group: {
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+              width: 450,
+              height: 300,
+              padding: 50,
+            },
+            histogram: {
+              style: {
+                data: {
+                  fill: "#969696",
+                  stroke: "#252525",
+                  strokeWidth: 2,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            legend: {
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+              gutter: 10,
+              orientation: "vertical",
+              titleOrientation: "top",
+              style: {
+                data: {
+                  type: "circle",
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+                title: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 5,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+            },
+            line: {
+              style: {
+                data: {
+                  fill: "transparent",
+                  stroke: "#252525",
+                  strokeWidth: 2,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            pie: {
+              style: {
+                data: {
+                  padding: 10,
+                  stroke: "transparent",
+                  strokeWidth: 1,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 20,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+              width: 400,
+              height: 400,
+              padding: 50,
+            },
+            scatter: {
+              style: {
+                data: {
+                  fill: "#252525",
+                  stroke: "transparent",
+                  strokeWidth: 0,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 10,
+                  fill: "#252525",
+                  stroke: "transparent",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+            stack: {
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+              width: 450,
+              height: 300,
+              padding: 50,
+            },
+            tooltip: {
+              style: {
+                fontFamily:
+                  "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                fontSize: 14,
+                letterSpacing: "normal",
+                padding: 0,
+                fill: "#252525",
+                stroke: "transparent",
+                pointerEvents: "none",
+              },
+              flyoutStyle: {
+                stroke: "#252525",
+                strokeWidth: 1,
+                fill: "#f0f0f0",
+                pointerEvents: "none",
+              },
+              flyoutPadding: 5,
+              cornerRadius: 5,
+              pointerLength: 10,
+            },
+            voronoi: {
+              style: {
+                data: {
+                  fill: "transparent",
+                  stroke: "transparent",
+                  strokeWidth: 0,
+                },
+                labels: {
+                  fontFamily:
+                    "'Gill Sans', 'Seravek', 'Trebuchet MS', sans-serif",
+                  fontSize: 14,
+                  letterSpacing: "normal",
+                  padding: 5,
+                  fill: "#252525",
+                  stroke: "transparent",
+                  pointerEvents: "none",
+                },
+                flyout: {
+                  stroke: "#252525",
+                  strokeWidth: 1,
+                  fill: "#f0f0f0",
+                  pointerEvents: "none",
+                },
+              },
+              width: 450,
+              height: 300,
+              padding: 50,
+              colorScale: [
+                "#252525",
+                "#525252",
+                "#737373",
+                "#969696",
+                "#bdbdbd",
+                "#d9d9d9",
+                "#f0f0f0",
+              ],
+            },
+          },
+        },
+        _owner: null,
+        _store: {},
+      },
+    ],
+    containerComponent: {
+      key: null,
+      ref: null,
+      props: {},
+      _owner: null,
+      _store: {},
+    },
+    groupComponent: {
+      type: "g",
+      key: null,
+      ref: null,
+      props: {},
+      _owner: null,
+      _store: {},
+    },
+    standalone: true,
+    fillInMissingData: true,
+    colorScale: [
+      "#252525",
+      "#525252",
+      "#737373",
+      "#969696",
+      "#bdbdbd",
+      "#d9d9d9",
+      "#f0f0f0",
+    ],
+    width: 450,
+    height: 300,
+    padding: 50,
+  };
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    Wrapper: {
+      ...originalModule.Wrapper,
+      getDataFromChildren: jest.fn().mockReturnValue(data),
+      getStyle: jest.fn(),
+      getCategories: jest.fn(),
+      getScale: jest.fn().mockReturnValue({
+        domain: jest.fn().mockReturnValue({
+          range: jest.fn(),
+        }),
+      }),
+    },
+    Helpers: {
+      ...originalModule.Helpers,
+      modifyProps: jest.fn().mockReturnValue(modifyProps),
+    },
+  };
+});
+
+const childComponents = [
+  {
+    key: ".0",
+    ref: null,
+    props: {
+      data: [
+        {
+          x: "2023-11-18T08:10:00.050Z",
+          y: 0,
+        },
+        {
+          x: "2023-11-18T08:10:00.050Z",
+          y: 2,
+        },
+        {
+          x: "2023-11-18T08:12:00.050Z",
+          y: 3,
+        },
+        {
+          x: "2023-11-18T08:13:00.050Z",
+          y: 4,
+        },
+        {
+          x: "2023-11-18T08:14:00.050Z",
+          y: 7,
+        },
+        {
+          x: "2023-11-18T08:15:00.050Z",
+          y: 8,
+        },
+      ],
+      containerComponent: {
+        key: null,
+        ref: null,
+        props: {},
+        _owner: null,
+        _store: {},
+      },
+      dataComponent: {
+        key: null,
+        ref: null,
+        props: {},
+        _owner: null,
+        _store: {},
+      },
+      groupComponent: {
+        key: null,
+        ref: null,
+        props: {
+          circleComponent: {
+            type: {},
+            key: null,
+            ref: null,
+            props: {},
+            _owner: null,
+            _store: {},
+          },
+          rectComponent: {
+            type: {},
+            key: null,
+            ref: null,
+            props: {},
+            _owner: null,
+            _store: {},
+          },
+          clipPathComponent: {
+            key: null,
+            ref: null,
+            props: {},
+            _owner: null,
+            _store: {},
+          },
+          groupComponent: {
+            type: "g",
+            key: null,
+            ref: null,
+            props: {},
+            _owner: null,
+            _store: {},
+          },
+        },
+        _owner: null,
+        _store: {},
+      },
+      labelComponent: {
+        key: null,
+        ref: null,
+        props: {
+          renderInPortal: true,
+        },
+        _owner: null,
+        _store: {},
+      },
+      samples: 50,
+      sortKey: "x",
+      sortOrder: "ascending",
+      standalone: true,
+    },
+    _owner: null,
+    _store: {},
+  },
+];
+
+describe("victory-stack/helpers", () => {
+  describe("fillData", () => {
+    it("should dedupe data based on `x` and reduce array size from oirigal 6 to 5", () => {
+      const props = Helpers.getCalculatedProps({}, childComponents);
+
+      const { datasets } = props;
+
+      const firstDataStack = datasets[0];
+
+      expect(firstDataStack.length).toEqual(5);
+    });
+
+    it("should dedupe data based on `x` and only contain one item with Date('2023-11-18T08:10:00.050Z')", () => {
+      const props = Helpers.getCalculatedProps({}, childComponents);
+
+      const { datasets } = props;
+
+      const firstDataStack = datasets[0];
+
+      expect(
+        firstDataStack.filter(
+          (item) =>
+            item.x.getTime() === new Date("2023-11-18T08:10:00.050Z").getTime(),
+        ).length,
+      ).toEqual(1);
+    });
+  });
+});

--- a/packages/victory-stack/src/helper-methods.tsx
+++ b/packages/victory-stack/src/helper-methods.tsx
@@ -37,7 +37,7 @@ function fillData(props, datasets) {
   }
 
   return datasets.map((dataset) => {
-    const dedupedDataset = uniqBy(dataset, (el) => {
+    const dedupedDataset = uniqBy(dataset, (el: any) => {
       const isDate = el && el.x instanceof Date;
 
       const x1 = isDate ? el.x.getTime() : el.x;
@@ -142,13 +142,6 @@ function stackData(props, childComponents) {
   const filteredNullChild = filledDatasets.map((dataset) =>
     dataset.filter((datum) => datum._x !== null && datum._y !== null),
   );
-
-  console.log("stackData", {
-    props,
-    filledDatasets,
-    filteredNullChild,
-    dataFromChildren,
-  });
 
   return filteredNullChild.map((d, i) =>
     addLayoutData(props, filledDatasets, i),

--- a/packages/victory-stack/src/helper-methods.tsx
+++ b/packages/victory-stack/src/helper-methods.tsx
@@ -24,18 +24,6 @@ function fillData(props, datasets) {
 
   const xArr = orderBy(xKeys);
 
-  const dataSetLengths = new Set();
-
-  for (const dataset of datasets) {
-    dataSetLengths.add(dataset.length);
-  }
-
-  if (dataSetLengths.size > 1) {
-    console.warn(
-      "Your datasets have different length. That means some elements might not have a corresponding pair in other datasets.",
-    );
-  }
-
   return datasets.map((dataset) => {
     const dedupedDataset = uniqBy(dataset, (el: any) => {
       const isDate = el && el.x instanceof Date;
@@ -44,12 +32,6 @@ function fillData(props, datasets) {
 
       return x1;
     });
-
-    if (dataset.length !== dedupedDataset.length) {
-      console.warn(
-        "The data you provided has elements with duplicate keys (Same value for the x axis). This might not be what you wnat. Please check the data you provided.",
-      );
-    }
 
     let indexOffset = 0;
     const isDate = dedupedDataset[0] && dedupedDataset[0]._x instanceof Date;


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

That is a tricky issue. The problem is with AreaCharts (or LineCharts) when we use them in stacked mode.

We opt-in for stack mode by wrapping the Chart in the `<VictoryStack />` component.

VictoryStack modifies the underlying data which makes AreaChart behave a bit different (draws different area) compared to when it's used on it's own. Only when given invalid data.

What is invalid data? For LineCharts and AreaCharts we can assume data is invalid/bad/corrupt when to elements have identical `x` values.

Therefore the main responsibility and final call should be of the library user to provide clean data.

However, with a little change we can make the AreaChart provide the same fallback with or without the usage of Stack.

That is to dedup the data. One objection might be, we don't know the identity function for all given data, i.e. how do we know two elements are equal.

In Victory we already assume the identity of the data:

```
const x1 = isDate ? datum._x.getTime() : datum._x;
```

We can dedup the elements and removing duplicate instances from the stack.

Fixes #2883 or rather addresses it.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Manually and adding jest test for testing the dedup logic.

#### Manually

Before

![Screenshot 2024-09-13 at 14 21 57](https://github.com/user-attachments/assets/caa443d3-86e5-4b51-a8a3-c3381d1666d5)

After

![Screenshot 2024-09-13 at 14 22 43](https://github.com/user-attachments/assets/445825b8-3861-4f43-8c95-0dff129ffa21)

#### Jest

Created a new suite to mock almost all calls out, expect for the `fillData` function that has been modified.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
