### PR TITLE
Feat/clean theme demos pt 2

### DIFF
--- a/.changeset/spicy-kings-wave.md
+++ b/.changeset/spicy-kings-wave.md
@@ -1,0 +1,5 @@
+---
+"victory-core": minor
+---
+
+more minor updates to clean theme

--- a/demo/ts/components/create-container-demo.tsx
+++ b/demo/ts/components/create-container-demo.tsx
@@ -11,7 +11,9 @@ import { VictoryLine } from "victory-line";
 import { VictoryScatter } from "victory-scatter";
 import { VictoryTooltip } from "victory-tooltip";
 import { VictoryLegend } from "victory-legend";
-import { VictoryTheme } from "victory-core/lib";
+import { VictoryTheme } from "victory-core";
+
+const themeColors = VictoryTheme.clean.palette?.colors || {};
 
 const Charts = ({ behaviors }) => {
   const containerStyle: React.CSSProperties = {
@@ -34,6 +36,7 @@ const Charts = ({ behaviors }) => {
         {/* A */}
         <VictoryChart
           style={chartStyle}
+          theme={VictoryTheme.clean}
           height={400}
           padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
           domainPadding={{ y: 2 }}
@@ -58,11 +61,10 @@ const Charts = ({ behaviors }) => {
             centerTitle
             orientation="horizontal"
             gutter={20}
-            style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
             data={[
-              { name: "One", symbol: { fill: "tomato" } },
-              { name: "Two", symbol: { fill: "orange" } },
-              { name: "Three", symbol: { fill: "gold" } },
+              { name: "One", symbol: { fill: themeColors.red } },
+              { name: "Two", symbol: { fill: themeColors.orange } },
+              { name: "Three", symbol: { fill: themeColors.yellow } },
             ]}
           />
           <VictoryLine
@@ -74,10 +76,10 @@ const Charts = ({ behaviors }) => {
             ]}
             style={{
               data: {
-                stroke: "tomato",
+                stroke: themeColors.red,
                 strokeWidth: ({ active }) => (active ? 4 : 2),
               },
-              labels: { fill: "tomato" },
+              labels: { fill: themeColors.red },
             }}
           />
 
@@ -89,10 +91,10 @@ const Charts = ({ behaviors }) => {
             ]}
             style={{
               data: {
-                stroke: "blue",
+                stroke: themeColors.orange,
                 strokeWidth: ({ active }) => (active ? 4 : 2),
               },
-              labels: { fill: "blue" },
+              labels: { fill: themeColors.orange },
             }}
           />
 
@@ -104,10 +106,10 @@ const Charts = ({ behaviors }) => {
             ]}
             style={{
               data: {
-                stroke: "black",
+                stroke: themeColors.yellow,
                 strokeWidth: ({ active }) => (active ? 4 : 2),
               },
-              labels: { fill: "black" },
+              labels: { fill: themeColors.yellow },
             }}
           />
         </VictoryChart>
@@ -120,9 +122,9 @@ const Charts = ({ behaviors }) => {
               labels={({ datum }) => round(datum.x, 2)}
               cursorLabel={({ datum }) => round(datum.x, 2)}
               selectionStyle={{
-                stroke: "tomato",
+                stroke: themeColors.red,
                 strokeWidth: 2,
-                fill: "tomato",
+                fill: themeColors.red,
                 fillOpacity: 0.1,
               }}
               selectedDomain={{ x: [0.4, 0.95], y: [0.5, 0.8] }}
@@ -133,7 +135,10 @@ const Charts = ({ behaviors }) => {
           <VictoryScatter
             style={{
               data: {
-                fill: ({ active }) => (active ? "tomato" : "black"),
+                fill: ({ active }) =>
+                  active
+                    ? themeColors.red || "tomato"
+                    : themeColors.yellow || "yellow",
               },
             }}
             size={({ active }) => (active ? 5 : 3)}
@@ -151,7 +156,7 @@ const Charts = ({ behaviors }) => {
           <VictoryGroup style={chartStyle}>
             <VictoryScatter
               style={{
-                data: { fill: "tomato" },
+                data: { fill: themeColors.blue },
               }}
               size={({ active }) => (active ? 5 : 3)}
               labels={({ datum }) => datum.y}
@@ -160,11 +165,6 @@ const Charts = ({ behaviors }) => {
                   pointerLength={4}
                   flyoutPadding={{ top: 8, bottom: 8, left: 16, right: 16 }}
                   cornerRadius={1}
-                  flyoutStyle={{
-                    stroke: "#757575",
-                    strokeWidth: 2,
-                    fill: "white",
-                  }}
                 />
               }
               data={[
@@ -179,7 +179,7 @@ const Charts = ({ behaviors }) => {
             />
             <VictoryScatter
               style={{
-                data: { fill: "blue" },
+                data: { fill: themeColors.purple },
               }}
               size={({ active }) => (active ? 5 : 3)}
               labels={({ datum }) => datum.y}
@@ -188,11 +188,6 @@ const Charts = ({ behaviors }) => {
                   pointerLength={4}
                   flyoutPadding={{ top: 8, bottom: 8, left: 16, right: 16 }}
                   cornerRadius={1}
-                  flyoutStyle={{
-                    stroke: "#757575",
-                    strokeWidth: 2,
-                    fill: "white",
-                  }}
                 />
               }
               data={[
@@ -206,6 +201,9 @@ const Charts = ({ behaviors }) => {
               ]}
             />
             <VictoryScatter
+              style={{
+                data: { fill: themeColors.green },
+              }}
               data={[
                 { x: 1, y: 5 },
                 { x: 2, y: -4 },
@@ -221,11 +219,6 @@ const Charts = ({ behaviors }) => {
                   pointerLength={4}
                   flyoutPadding={{ top: 8, bottom: 8, left: 16, right: 16 }}
                   cornerRadius={1}
-                  flyoutStyle={{
-                    stroke: "#757575",
-                    strokeWidth: 2,
-                    fill: "white",
-                  }}
                 />
               }
               size={({ active }) => (active ? 5 : 3)}
@@ -234,20 +227,14 @@ const Charts = ({ behaviors }) => {
         </VictoryChart>
         {/* D */}
         <VictoryStack
+          theme={VictoryTheme.clean}
           style={chartStyle}
           containerComponent={
             <CustomContainer selectedDomain={{ x: [1.5, 2.5], y: [-3, 4] }} />
           }
         >
           <VictoryBar
-            style={{
-              data: {
-                fill: "tomato",
-                stroke: ({ active }) => (active ? "black" : "none"),
-                strokeWidth: 2,
-              },
-            }}
-            barWidth={({ active }) => (active ? 5 : 3)}
+            barWidth={({ active }) => (active ? 10 : 8)}
             data={[
               { x: 1, y: -5 },
               { x: 2, y: 4 },
@@ -259,14 +246,7 @@ const Charts = ({ behaviors }) => {
             ]}
           />
           <VictoryBar
-            style={{
-              data: {
-                fill: "orange",
-                stroke: ({ active }) => (active ? "black" : "none"),
-                strokeWidth: 2,
-              },
-            }}
-            barWidth={({ active }) => (active ? 5 : 3)}
+            barWidth={({ active }) => (active ? 10 : 8)}
             data={[
               { x: 1, y: -3 },
               { x: 2, y: 5 },
@@ -278,13 +258,7 @@ const Charts = ({ behaviors }) => {
             ]}
           />
           <VictoryBar
-            style={{
-              data: {
-                fill: "gold",
-                stroke: ({ active }) => (active ? "black" : "none"),
-                strokeWidth: 2,
-              },
-            }}
+            barWidth={({ active }) => (active ? 10 : 8)}
             data={[
               { x: 1, y: 5 },
               { x: 2, y: -4 },

--- a/demo/ts/components/draggable-demo.tsx
+++ b/demo/ts/components/draggable-demo.tsx
@@ -200,7 +200,7 @@ class App extends React.Component<any, DraggableDemoInterface> {
                   brushDomain={bar.range}
                   onBrushDomainChange={this.onDomainChange.bind(this)}
                   brushStyle={{
-                    fill: "skyBlue",
+                    fill: VictoryTheme.clean.palette?.colors?.cyan,
                     opacity: ({ active }) => (active ? 1 : 0.5),
                   }}
                 />
@@ -219,7 +219,7 @@ class App extends React.Component<any, DraggableDemoInterface> {
             }
             style={{
               data: {
-                fill: "skyBlue",
+                fill: VictoryTheme.clean.palette?.colors?.cyan,
                 opacity: ({ active }) => (active ? 1 : 0.5),
                 cursor: "move",
               },
@@ -264,14 +264,14 @@ class App extends React.Component<any, DraggableDemoInterface> {
             data={this.state.points}
             size={5}
             style={{
-              data: { fill: "skyBlue" },
+              data: { fill: VictoryTheme.clean.palette?.colors?.cyan },
             }}
             x="name"
             y="date"
           />
           <VictoryBar
             style={{
-              data: { fill: "skyBlue" },
+              data: { fill: VictoryTheme.clean.palette?.colors?.cyan },
             }}
             data={this.state.bars}
             x="name"

--- a/demo/ts/components/ouia-demo.tsx
+++ b/demo/ts/components/ouia-demo.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { VictoryChart } from "victory-chart";
 import { VictoryLine } from "victory-line";
-import { VictoryContainer } from "victory-core";
+import { VictoryContainer, VictoryTheme } from "victory-core";
 
 class OuiaDemo extends React.Component<any> {
   constructor(props: any) {
@@ -25,6 +25,7 @@ class OuiaDemo extends React.Component<any> {
         <h1>Open UI Automation (OUIA)</h1>
         <div style={containerStyle}>
           <VictoryChart
+            theme={VictoryTheme.clean}
             containerComponent={
               <VictoryContainer
                 ouiaId="victory-container-ouia"

--- a/demo/ts/components/primitives-demo.tsx
+++ b/demo/ts/components/primitives-demo.tsx
@@ -8,6 +8,8 @@ import { VictoryPolarAxis } from "victory-polar-axis";
 import { Arc, LineSegment, VictoryTheme, Whisker } from "victory-core";
 import { range, random } from "lodash";
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+
 interface PrimitivesDemoState {
   axisBackgroundColor: string;
   whiskersActive: boolean;
@@ -20,7 +22,7 @@ class App extends React.Component<any, PrimitivesDemoState> {
   constructor(props: any) {
     super(props);
     this.state = {
-      axisBackgroundColor: "mediumseagreen",
+      axisBackgroundColor: themeColors.green || "mediumseagreen",
       whiskersActive: true,
     };
   }
@@ -44,9 +46,10 @@ class App extends React.Component<any, PrimitivesDemoState> {
 
   handleClick() {
     const newBackgroundColor =
-      this.state.axisBackgroundColor === "mediumseagreen"
-        ? "paleturquoise"
-        : "mediumseagreen";
+      this.state.axisBackgroundColor === "mediumseagreen" ||
+      this.state.axisBackgroundColor === themeColors.green
+        ? themeColors.cyan || "paleturquoise"
+        : themeColors.green || "mediumseagreen";
 
     this.setState({ axisBackgroundColor: newBackgroundColor });
   }
@@ -86,7 +89,7 @@ class App extends React.Component<any, PrimitivesDemoState> {
     return (
       <div className="demo">
         <div style={containerStyle}>
-          <VictoryChart polar style={chartStyle}>
+          <VictoryChart polar style={chartStyle} theme={VictoryTheme.clean}>
             <VictoryPolarAxis
               circularAxisComponent={
                 <Arc
@@ -95,7 +98,7 @@ class App extends React.Component<any, PrimitivesDemoState> {
                   cy={0}
                   startAngle={0}
                   endAngle={180}
-                  style={{ fill: "tomato", stroke: "none" }}
+                  style={{ fill: themeColors.red }}
                 />
               }
             />
@@ -108,13 +111,13 @@ class App extends React.Component<any, PrimitivesDemoState> {
                   cy={0}
                   startAngle={180}
                   endAngle={360}
-                  style={{ fill: "salmon", stroke: "none" }}
+                  style={{ fill: themeColors.pink }}
                 />
               }
             />
           </VictoryChart>
 
-          <VictoryChart style={axisChartStyle}>
+          <VictoryChart style={axisChartStyle} theme={VictoryTheme.clean}>
             <VictoryAxis
               crossAxis
               axisComponent={
@@ -123,8 +126,6 @@ class App extends React.Component<any, PrimitivesDemoState> {
                   style={lineSegmentStyle}
                 />
               }
-              width={400}
-              height={400}
               domain={[-10, 10]}
               offsetY={200}
               standalone={false}
@@ -138,17 +139,18 @@ class App extends React.Component<any, PrimitivesDemoState> {
                   style={lineSegmentStyle}
                 />
               }
-              width={400}
-              height={400}
               domain={[-10, 10]}
               offsetX={200}
               standalone={false}
             />
           </VictoryChart>
 
-          <VictoryChart domainPadding={20} theme={VictoryTheme.clean}>
+          <VictoryChart
+            domainPadding={20}
+            theme={VictoryTheme.clean}
+            style={chartStyle}
+          >
             <VictoryBoxPlot
-              boxWidth={20}
               data={this.state.boxPlotData}
               maxComponent={<Whisker active={this.state.whiskersActive} />}
               minComponent={<Whisker active={this.state.whiskersActive} />}

--- a/demo/ts/components/selection-demo.tsx
+++ b/demo/ts/components/selection-demo.tsx
@@ -9,8 +9,26 @@ import { VictoryScatter } from "victory-scatter";
 import { VictorySelectionContainer } from "victory-selection-container";
 import { VictoryLegend } from "victory-legend";
 import { VictoryTooltip } from "victory-tooltip";
-import { VictoryTheme } from "victory-core/lib";
+import { VictoryStyleInterface, VictoryTheme } from "victory-core";
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+const {
+  red = "red",
+  green = "green",
+  blue = "blue",
+  pink = "pink",
+  cyan = "cyan",
+  purple = "purple",
+  orange = "orange",
+  yellow = "gold",
+} = themeColors;
+
+const activeStrokeStyle: VictoryStyleInterface = {
+  data: {
+    stroke: ({ active }) => (active ? purple : "none"),
+    strokeWidth: 2,
+  },
+};
 interface SelectionDemoState {
   points: { x: number; y: number }[];
 }
@@ -83,9 +101,9 @@ export default class SelectionDemo extends React.Component<
               <VictorySelectionContainer
                 selectionDimension="x"
                 selectionStyle={{
-                  stroke: "tomato",
+                  stroke: red,
                   strokeWidth: 2,
-                  fill: "tomato",
+                  fill: red,
                   fillOpacity: 0.1,
                 }}
                 onSelection={this.handleSelection.bind(this)}
@@ -97,19 +115,15 @@ export default class SelectionDemo extends React.Component<
               x={120}
               y={20}
               title="Legend"
-              centerTitle
-              orientation="horizontal"
-              gutter={20}
-              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
               data={[
-                { name: "One", symbol: { fill: "tomato" } },
-                { name: "Two", symbol: { fill: "orange" } },
-                { name: "Three", symbol: { fill: "gold" } },
+                { name: "One", symbol: { fill: red } },
+                { name: "Two", symbol: { fill: orange } },
+                { name: "Three", symbol: { fill: yellow } },
               ]}
             />
             <VictoryLine
               style={{
-                data: { stroke: "tomato" },
+                data: { stroke: red },
               }}
               data={[
                 { x: 1, y: -5 },
@@ -123,7 +137,7 @@ export default class SelectionDemo extends React.Component<
             />
             <VictoryLine
               style={{
-                data: { stroke: "blue" },
+                data: { stroke: orange },
               }}
               data={[
                 { x: 1, y: -3 },
@@ -136,6 +150,9 @@ export default class SelectionDemo extends React.Component<
               ]}
             />
             <VictoryLine
+              style={{
+                data: { stroke: yellow },
+              }}
               data={[
                 { x: 1, y: 5 },
                 { x: 2, y: -4 },
@@ -159,10 +176,10 @@ export default class SelectionDemo extends React.Component<
                 { x: 3, y: -2 },
               ]}
             >
-              <VictoryLine style={{ data: { stroke: "tomato" } }} />
+              <VictoryLine style={{ data: { stroke: cyan } }} />
               <VictoryScatter
                 style={{
-                  data: { fill: ({ active }) => (active ? "tomato" : "gray") },
+                  data: { fill: ({ active }) => (active ? cyan : yellow) },
                 }}
                 labels={({ datum }) => datum.y}
                 labelComponent={<VictoryTooltip />}
@@ -176,10 +193,10 @@ export default class SelectionDemo extends React.Component<
                 { x: 3, y: 3 },
               ]}
             >
-              <VictoryLine style={{ data: { stroke: "blue" } }} />
+              <VictoryLine style={{ data: { stroke: green } }} />
               <VictoryScatter
                 style={{
-                  data: { fill: ({ active }) => (active ? "blue" : "gray") },
+                  data: { fill: ({ active }) => (active ? green : yellow) },
                 }}
                 labels={({ datum }) => datum.y}
                 labelComponent={<VictoryTooltip />}
@@ -193,10 +210,10 @@ export default class SelectionDemo extends React.Component<
                 { x: 3, y: -2 },
               ]}
             >
-              <VictoryLine style={{ data: { stroke: "black" } }} />
+              <VictoryLine style={{ data: { stroke: pink } }} />
               <VictoryScatter
                 style={{
-                  data: { fill: ({ active }) => (active ? "black" : "gray") },
+                  data: { fill: ({ active }) => (active ? pink : yellow) },
                 }}
                 labels={({ datum }) => datum.y}
                 labelComponent={<VictoryTooltip />}
@@ -208,15 +225,15 @@ export default class SelectionDemo extends React.Component<
             style={{
               parent: chartStyle.parent,
               data: {
-                fill: ({ active }) => (active ? "tomato" : "black"),
+                fill: ({ active }) => (active ? red : yellow),
               },
             }}
             containerComponent={
               <VictorySelectionContainer
                 selectionStyle={{
-                  stroke: "tomato",
+                  stroke: red,
                   strokeWidth: 2,
-                  fill: "tomato",
+                  fill: red,
                   fillOpacity: 0.1,
                 }}
               />
@@ -237,20 +254,19 @@ export default class SelectionDemo extends React.Component<
             style={{
               parent: chartStyle.parent,
               data: {
-                fill: ({ active }) => (active ? "tomato" : "black"),
+                fill: ({ active }) => (active ? pink : purple),
               },
             }}
             containerComponent={
               <VictorySelectionContainer
                 selectionStyle={{
-                  stroke: "tomato",
+                  stroke: pink,
                   strokeWidth: 2,
-                  fill: "tomato",
+                  fill: pink,
                   fillOpacity: 0.1,
                 }}
               />
             }
-            size={({ active }) => (active ? 5 : 3)}
             y={(d) => d.x * d.x}
           />
 
@@ -259,9 +275,9 @@ export default class SelectionDemo extends React.Component<
             containerComponent={
               <VictorySelectionContainer
                 selectionStyle={{
-                  stroke: "tomato",
+                  stroke: red,
                   strokeWidth: 2,
-                  fill: "tomato",
+                  fill: red,
                   fillOpacity: 0.1,
                 }}
               />
@@ -269,7 +285,7 @@ export default class SelectionDemo extends React.Component<
           >
             <VictoryScatter
               style={{
-                data: { fill: "tomato" },
+                data: { fill: blue },
               }}
               size={({ active }) => (active ? 5 : 3)}
               data={[
@@ -284,7 +300,7 @@ export default class SelectionDemo extends React.Component<
             />
             <VictoryScatter
               style={{
-                data: { fill: "blue" },
+                data: { fill: green },
               }}
               size={({ active }) => (active ? 5 : 3)}
               data={[
@@ -298,6 +314,9 @@ export default class SelectionDemo extends React.Component<
               ]}
             />
             <VictoryScatter
+              style={{
+                data: { fill: purple },
+              }}
               data={[
                 { x: 1, y: 5 },
                 { x: 2, y: -4 },
@@ -319,9 +338,9 @@ export default class SelectionDemo extends React.Component<
               <VictorySelectionContainer
                 selectionDimension="x"
                 selectionStyle={{
-                  stroke: "tomato",
+                  stroke: blue,
                   strokeWidth: 2,
-                  fill: "tomato",
+                  fill: blue,
                   fillOpacity: 0.1,
                 }}
               />
@@ -329,13 +348,7 @@ export default class SelectionDemo extends React.Component<
           >
             <VictoryStack>
               <VictoryBar
-                style={{
-                  data: {
-                    fill: "tomato",
-                    stroke: ({ active }) => (active ? "#292929" : "none"),
-                    strokeWidth: 2,
-                  },
-                }}
+                style={activeStrokeStyle}
                 data={[
                   { x: 1, y: -5 },
                   { x: 2, y: 4 },
@@ -347,13 +360,7 @@ export default class SelectionDemo extends React.Component<
                 ]}
               />
               <VictoryBar
-                style={{
-                  data: {
-                    fill: "orange",
-                    stroke: ({ active }) => (active ? "#292929" : "none"),
-                    strokeWidth: 2,
-                  },
-                }}
+                style={activeStrokeStyle}
                 data={[
                   { x: 1, y: -3 },
                   { x: 2, y: 5 },
@@ -365,13 +372,7 @@ export default class SelectionDemo extends React.Component<
                 ]}
               />
               <VictoryBar
-                style={{
-                  data: {
-                    fill: "gold",
-                    stroke: ({ active }) => (active ? "#292929" : "none"),
-                    strokeWidth: 2,
-                  },
-                }}
+                style={activeStrokeStyle}
                 data={[
                   { x: 1, y: 5 },
                   { x: 2, y: -4 },

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -12,6 +12,8 @@ import { VictoryZoomContainer } from "victory-zoom-container";
 import { VictoryBrushContainer } from "victory-brush-container";
 import { DomainTuple, VictoryTheme } from "victory-core";
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+
 interface VictoryBrushContainerDemoState {
   zoomDomain: {
     x?: DomainTuple;
@@ -62,9 +64,6 @@ export default class VictoryBrushContainerDemo extends React.Component<
             }
           >
             <VictoryLine
-              style={{
-                data: { stroke: "tomato" },
-              }}
               data={[
                 { x: new Date(1982, 1, 1), y: 125 },
                 { x: new Date(1987, 1, 1), y: 257 },
@@ -78,6 +77,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
             />
           </VictoryChart>
           <VictoryChart
+            theme={VictoryTheme.clean}
             padding={{ top: 0, left: 50, right: 50, bottom: 30 }}
             width={800}
             height={100}
@@ -103,9 +103,6 @@ export default class VictoryBrushContainerDemo extends React.Component<
               tickFormat={(x) => new Date(x).getFullYear()}
             />
             <VictoryLine
-              style={{
-                data: { stroke: "tomato" },
-              }}
               data={[
                 { x: new Date(1982, 1, 1), y: 125 },
                 { x: new Date(1987, 1, 1), y: 257 },
@@ -138,17 +135,15 @@ export default class VictoryBrushContainerDemo extends React.Component<
               title="Legend"
               centerTitle
               orientation="horizontal"
-              gutter={20}
-              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
               data={[
-                { name: "One", symbol: { fill: "tomato" } },
-                { name: "Two", symbol: { fill: "orange" } },
-                { name: "Three", symbol: { fill: "gold" } },
+                { name: "One", symbol: { fill: themeColors.red } },
+                { name: "Two", symbol: { fill: themeColors.orange } },
+                { name: "Three", symbol: { fill: themeColors.yellow } },
               ]}
             />
             <VictoryLine
               style={{
-                data: { stroke: "tomato" },
+                data: { stroke: themeColors.red },
               }}
               data={[
                 { x: 1, y: -5 },
@@ -162,7 +157,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
             />
             <VictoryLine
               style={{
-                data: { stroke: "blue" },
+                data: { stroke: themeColors.orange },
               }}
               data={[
                 { x: 1, y: -3 },
@@ -175,6 +170,9 @@ export default class VictoryBrushContainerDemo extends React.Component<
               ]}
             />
             <VictoryLine
+              style={{
+                data: { stroke: themeColors.yellow },
+              }}
               data={[
                 { x: 1, y: 5 },
                 { x: 2, y: -4 },
@@ -188,10 +186,14 @@ export default class VictoryBrushContainerDemo extends React.Component<
           </VictoryChart>
 
           <VictoryScatter
+            theme={VictoryTheme.clean}
             style={{
               parent: chartStyle.parent,
               data: {
-                fill: ({ active }) => (active ? "tomato" : "black"),
+                fill: ({ active }) =>
+                  active
+                    ? themeColors.blue || "blue"
+                    : themeColors.orange || "orange",
               },
             }}
             domain={{ x: [0, 10], y: [-5, 5] }}
@@ -217,7 +219,10 @@ export default class VictoryBrushContainerDemo extends React.Component<
             style={{
               parent: chartStyle.parent,
               data: {
-                fill: ({ active }) => (active ? "tomato" : "black"),
+                fill: ({ active }) =>
+                  active
+                    ? themeColors.blue || "blue"
+                    : themeColors.orange || "orange",
               },
             }}
             containerComponent={
@@ -235,7 +240,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
           >
             <VictoryScatter
               style={{
-                data: { fill: "tomato" },
+                data: { fill: themeColors.red },
               }}
               size={({ active }) => (active ? 5 : 3)}
               data={[
@@ -250,7 +255,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
             />
             <VictoryScatter
               style={{
-                data: { fill: "blue" },
+                data: { fill: themeColors.orange },
               }}
               size={({ active }) => (active ? 5 : 3)}
               data={[
@@ -264,6 +269,9 @@ export default class VictoryBrushContainerDemo extends React.Component<
               ]}
             />
             <VictoryScatter
+              style={{
+                data: { fill: themeColors.yellow },
+              }}
               data={[
                 { x: 1, y: 5 },
                 { x: 2, y: -4 },
@@ -278,17 +286,11 @@ export default class VictoryBrushContainerDemo extends React.Component<
           </VictoryGroup>
 
           <VictoryStack
+            theme={VictoryTheme.clean}
             style={chartStyle}
             containerComponent={<VictoryBrushContainer />}
           >
             <VictoryBar
-              style={{
-                data: {
-                  fill: "tomato",
-                  stroke: ({ active }) => (active ? "black" : "none"),
-                  strokeWidth: 2,
-                },
-              }}
               barWidth={({ active }) => (active ? 5 : 3)}
               data={[
                 { x: 1, y: -5 },
@@ -303,9 +305,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
             <VictoryBar
               style={{
                 data: {
-                  fill: "orange",
-                  stroke: ({ active }) => (active ? "black" : "none"),
-                  strokeWidth: 2,
+                  fill: themeColors.purple,
                 },
               }}
               barWidth={({ active }) => (active ? 5 : 3)}
@@ -322,9 +322,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
             <VictoryBar
               style={{
                 data: {
-                  fill: "gold",
-                  stroke: ({ active }) => (active ? "black" : "none"),
-                  strokeWidth: 2,
+                  fill: themeColors.pink,
                 },
               }}
               data={[
@@ -340,13 +338,19 @@ export default class VictoryBrushContainerDemo extends React.Component<
           </VictoryStack>
 
           <VictoryLine
-            style={{ parent: chartStyle.parent, data: { stroke: "teal" } }}
+            theme={VictoryTheme.clean}
+            style={{
+              parent: chartStyle.parent,
+              data: { stroke: themeColors.teal },
+            }}
             containerComponent={
               <VictoryBrushContainer
                 brushDomain={{ y: [-3, 3] }}
-                brushComponent={<rect style={{ fill: "teal" }} />}
+                brushComponent={<rect style={{ fill: themeColors.blue }} />}
                 handleWidth={1}
-                handleStyle={{ stroke: "black", fill: "black" }}
+                handleStyle={{
+                  stroke: themeColors.cyan,
+                }}
               />
             }
             data={[

--- a/demo/ts/components/victory-brush-line-demo.tsx
+++ b/demo/ts/components/victory-brush-line-demo.tsx
@@ -34,6 +34,8 @@ const data: DataType = [
   { name: "Francis", strength: 2, intelligence: 40, speed: 200, luck: 2 },
 ];
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+
 interface BrushLineDemoState {
   maximumValues: number[];
   datasets: DataSet[];
@@ -191,6 +193,7 @@ class App extends React.Component<any, BrushLineDemoState> {
         <div style={containerStyle}>
           <button onClick={this.clearMutation.bind(this)}>reset domain</button>
           <VictoryChart
+            theme={VictoryTheme.clean}
             style={{ parent: { maxWidth: "50%" } }}
             domain={{ y: [0, 1.1] }}
             height={height}
@@ -198,10 +201,6 @@ class App extends React.Component<any, BrushLineDemoState> {
             padding={padding}
           >
             <VictoryAxis
-              style={{
-                tickLabels: { fontSize: 20 },
-                axis: { stroke: "none" },
-              }}
               tickLabelComponent={<VictoryLabel y={padding.top - 40} />}
             />
             {this.state.datasets.map((dataset: DataSet) => (
@@ -210,12 +209,6 @@ class App extends React.Component<any, BrushLineDemoState> {
                 name={dataset.name}
                 data={dataset.data}
                 groupComponent={<g />}
-                style={{
-                  data: {
-                    stroke: "tomato",
-                    opacity: this.isActive(dataset) ? 1 : 0.2,
-                  },
-                }}
               />
             ))}
             {attributes.map((attribute, index) => (
@@ -232,13 +225,6 @@ class App extends React.Component<any, BrushLineDemoState> {
                   />
                 }
                 offsetX={this.getAxisOffset(index)}
-                style={{
-                  tickLabels: {
-                    fontSize: 15,
-                    padding: 15,
-                    pointerEvents: "none",
-                  },
-                }}
                 tickValues={[0.2, 0.4, 0.6, 0.8, 1]}
                 tickFormat={(tick) => Math.round(tick * max[index])}
               />
@@ -260,8 +246,17 @@ class App extends React.Component<any, BrushLineDemoState> {
             />
           </VictoryChart>
 
-          <VictoryChart style={chartStyle} domainPadding={{ x: 50 }}>
+          <VictoryChart
+            style={chartStyle}
+            theme={VictoryTheme.clean}
+            domainPadding={{ x: 50 }}
+          >
             <VictoryBar
+              style={{
+                data: {
+                  fill: themeColors.purple,
+                },
+              }}
               data={[
                 { x: "one", y: 4 },
                 { x: "two", y: 5 },
@@ -275,7 +270,7 @@ class App extends React.Component<any, BrushLineDemoState> {
               }
             />
           </VictoryChart>
-          <VictoryChart style={chartStyle}>
+          <VictoryChart style={chartStyle} theme={VictoryTheme.clean}>
             <VictoryScatter
               data={[
                 { x: "one", y: 0 },
@@ -285,7 +280,7 @@ class App extends React.Component<any, BrushLineDemoState> {
             />
             <VictoryAxis gridComponent={<VictoryBrushLine brushWidth={20} />} />
           </VictoryChart>
-          <VictoryChart style={chartStyle}>
+          <VictoryChart style={chartStyle} theme={VictoryTheme.clean}>
             <VictoryScatter
               data={[
                 { x: "one", y: 0 },
@@ -302,6 +297,7 @@ class App extends React.Component<any, BrushLineDemoState> {
 
           <VictoryAxis
             style={chartStyle}
+            theme={VictoryTheme.clean}
             gridComponent={
               <VictoryBrushLine brushWidth={20} brushDomain={[0, 10]} />
             }

--- a/demo/ts/components/victory-cursor-container-demo.tsx
+++ b/demo/ts/components/victory-cursor-container-demo.tsx
@@ -9,8 +9,9 @@ import { VictoryLine } from "victory-line";
 import { VictoryScatter } from "victory-scatter";
 import { VictoryCursorContainer } from "victory-cursor-container";
 import { VictoryTooltip } from "victory-tooltip";
-import { VictoryLegend } from "victory-legend";
 import { VictoryTheme, CoordinatesPropType } from "victory-core";
+
+const themeColors = VictoryTheme.clean.palette?.colors || {};
 
 interface VictoryCursorContainerStateInterface {
   data: { a: number; b: number }[];
@@ -74,29 +75,13 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
         <div style={containerStyle}>
           <VictoryChart
             style={chartStyle}
-            theme={VictoryTheme.material}
-            height={400}
-            padding={{ top: 100, bottom: 40, left: 50, right: 50 }}
+            theme={VictoryTheme.clean}
             containerComponent={
               <VictoryCursorContainer
                 cursorLabel={({ datum }) => round(datum.x, 2)}
               />
             }
           >
-            <VictoryLegend
-              x={90}
-              y={10}
-              title="Legend"
-              centerTitle
-              orientation="horizontal"
-              gutter={20}
-              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
-              data={[
-                { name: "One", symbol: { fill: "tomato" } },
-                { name: "Two", symbol: { fill: "orange" } },
-                { name: "Three", symbol: { fill: "gold" } },
-              ]}
-            />
             <VictoryLine data={this.state.bigData} />
           </VictoryChart>
 
@@ -120,9 +105,6 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
                   { x: 2, y: 4, l: "two" },
                   { x: 3, y: -2, l: "three" },
                 ]}
-                style={{
-                  labels: { fill: "tomato" },
-                }}
               />
 
               <VictoryBar
@@ -131,9 +113,6 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
                   { x: 2, y: 5, l: "green" },
                   { x: 3, y: 3, l: "blue" },
                 ]}
-                style={{
-                  labels: { fill: "blue" },
-                }}
               />
 
               <VictoryBar
@@ -142,9 +121,6 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
                   { x: 2, y: -4, l: "dog" },
                   { x: 3, y: -2, l: "bird" },
                 ]}
-                style={{
-                  labels: { fill: "black" },
-                }}
               />
             </VictoryGroup>
           </VictoryChart>
@@ -155,7 +131,10 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
             style={{
               parent: chartStyle.parent,
               data: {
-                fill: ({ active }) => (active ? "tomato" : "black"),
+                fill: ({ active }) =>
+                  active
+                    ? themeColors.teal || "teal"
+                    : themeColors.purple || "purple",
               },
             }}
             containerComponent={
@@ -172,8 +151,12 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
           />
 
           <VictoryScatter
+            theme={VictoryTheme.clean}
             style={{
               parent: chartStyle.parent,
+              data: {
+                fill: themeColors.green,
+              },
             }}
             containerComponent={<VictoryCursorContainer />}
             size={({ active }) => (active ? 5 : 3)}
@@ -181,6 +164,7 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
           />
 
           <VictoryChart
+            theme={VictoryTheme.clean}
             style={chartStyle}
             containerComponent={
               <VictoryCursorContainer
@@ -194,7 +178,7 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
             <VictoryGroup style={chartStyle}>
               <VictoryScatter
                 style={{
-                  data: { fill: "tomato" },
+                  data: { fill: themeColors.pink },
                 }}
                 size={({ active }) => (active ? 5 : 3)}
                 labels={({ datum }) => datum.y}
@@ -211,7 +195,7 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
               />
               <VictoryScatter
                 style={{
-                  data: { fill: "blue" },
+                  data: { fill: themeColors.yellow },
                 }}
                 size={({ active }) => (active ? 5 : 3)}
                 labels={({ datum }) => datum.y}
@@ -244,17 +228,12 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
           </VictoryChart>
 
           <VictoryStack
+            theme={VictoryTheme.clean}
+            colorScale="warm"
             style={chartStyle}
             containerComponent={<VictoryCursorContainer />}
           >
             <VictoryBar
-              style={{
-                data: {
-                  fill: "tomato",
-                  stroke: ({ active }) => (active ? "black" : "none"),
-                  strokeWidth: 2,
-                },
-              }}
               data={[
                 { x: 1, y: -5 },
                 { x: 2, y: 4 },
@@ -266,13 +245,6 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
               ]}
             />
             <VictoryBar
-              style={{
-                data: {
-                  fill: "orange",
-                  stroke: ({ active }) => (active ? "black" : "none"),
-                  strokeWidth: 2,
-                },
-              }}
               data={[
                 { x: 1, y: -3 },
                 { x: 2, y: 5 },
@@ -284,13 +256,6 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
               ]}
             />
             <VictoryBar
-              style={{
-                data: {
-                  fill: "gold",
-                  stroke: ({ active }) => (active ? "black" : "none"),
-                  strokeWidth: 2,
-                },
-              }}
               data={[
                 { x: 1, y: 5 },
                 { x: 2, y: -4 },

--- a/demo/ts/components/victory-errorbar-demo.tsx
+++ b/demo/ts/components/victory-errorbar-demo.tsx
@@ -17,6 +17,8 @@ const style = {
   parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
 };
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+
 type dataType = {
   x?: string | number;
   y?: string | number;
@@ -40,7 +42,7 @@ export default class VictoryErrorBarDemo extends React.Component<
 
     this.state = {
       data: this.getData(),
-      hoverStyle: { stroke: "gold " },
+      hoverStyle: { stroke: themeColors.green || "green" },
     };
   }
 
@@ -85,13 +87,14 @@ export default class VictoryErrorBarDemo extends React.Component<
           <VictoryScatter data={basicData} />
         </VictoryChart>
 
-        <VictoryChart horizontal style={style}>
+        <VictoryChart horizontal style={style} theme={VictoryTheme.clean}>
           <VictoryErrorBar data={basicData} />
           <VictoryScatter data={basicData} />
         </VictoryChart>
 
         <VictoryErrorBar
           style={style}
+          theme={VictoryTheme.clean}
           width={500}
           height={500}
           animate={{ duration: 2000 }}
@@ -100,46 +103,57 @@ export default class VictoryErrorBarDemo extends React.Component<
             <VictoryContainer
               title="ErrorBar Chart"
               desc="This is a errorbar chart with data points!"
-              style={{ border: "1px solid red", margin: "2%", maxWidth: "40%" }}
+              style={{ ...style.parent }}
             />
           }
         />
 
         <VictoryErrorBar
+          theme={VictoryTheme.clean}
           horizontal
           style={style}
           width={500}
           height={500}
           animate={{ duration: 2000 }}
-          borderWidth={30}
           data={this.state.data}
         />
 
         <VictoryErrorBar
+          theme={VictoryTheme.clean}
+          animate={{ duration: 2000 }}
           style={{
             parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
-            data: { fill: ({ datum }) => (datum.y > 0 ? "red" : "blue") },
+            data: {
+              stroke: ({ datum }) =>
+                datum.y > 0
+                  ? themeColors.red || "red"
+                  : themeColors.blue || "blue",
+            },
           }}
           width={500}
           height={500}
         />
 
         <VictoryErrorBar
+          theme={VictoryTheme.clean}
           style={{
             parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
-            data: { stroke: "blue", opacity: 0.7, strokeWidth: 3 },
+            data: {
+              stroke: themeColors.purple,
+            },
           }}
           width={500}
           height={500}
           data={this.state.data}
         />
 
-        <VictoryChart>
+        <VictoryChart style={style} theme={VictoryTheme.clean}>
           <VictoryErrorBar style={style} standalone={false} />
         </VictoryChart>
 
         <VictoryErrorBar
-          style={{ parent: style.parent, data: this.state.hoverStyle }}
+          theme={VictoryTheme.clean}
+          style={{ ...style, data: this.state.hoverStyle }}
           data={this.state.data}
           events={[
             {
@@ -151,7 +165,7 @@ export default class VictoryErrorBarDemo extends React.Component<
                       mutation: (props: any) => {
                         return {
                           style: Object.assign({}, props.style, {
-                            stroke: "orange",
+                            stroke: themeColors.orange || "orange",
                           }),
                         };
                       },
@@ -163,11 +177,11 @@ export default class VictoryErrorBarDemo extends React.Component<
           ]}
         />
 
-        <VictoryChart style={style} theme={VictoryTheme.material}>
+        <VictoryChart style={style} theme={VictoryTheme.clean}>
           <VictoryErrorBar style={style} data={this.state.data} />
         </VictoryChart>
 
-        <VictoryChart style={style} theme={VictoryTheme.material}>
+        <VictoryChart style={style} theme={VictoryTheme.clean}>
           <VictoryErrorBar style={style} data={[]} />
         </VictoryChart>
       </div>

--- a/demo/ts/components/victory-label-demo.tsx
+++ b/demo/ts/components/victory-label-demo.tsx
@@ -13,9 +13,9 @@ const containerStyle: React.CSSProperties = {
 
 const style = {
   parent: { border: "1px solid #ccc", margin: "1%", maxWidth: "25%" },
-  labels: { padding: 0 },
-  data: { fill: "gold" },
 };
+
+const themeColors = VictoryTheme.clean.palette?.colors || {};
 
 const defaultScatterProps: VictoryScatterProps = {
   style,
@@ -31,13 +31,14 @@ export default class App extends React.Component<any, {}> {
     return (
       <div style={containerStyle}>
         <VictoryScatter
-          theme={VictoryTheme.clean}
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={<VictoryLabel />}
         />
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
               transform="translate(50)"
@@ -48,6 +49,7 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
               title={"Victory is awesome. This is a title."}
@@ -59,6 +61,7 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel angle={65} text={"Now with angles!!"} />
           }
@@ -66,11 +69,11 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
               direction="rtl"
               verticalAnchor="start"
-              style={[{ fill: "red", fontSize: 20 }]}
               text={"سلام world"}
             />
           }
@@ -78,11 +81,11 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
               textAnchor="middle"
               verticalAnchor="start"
-              style={{ padding: 15 }}
               text={
                 "Victory is awesome.\nThis is (middle, start) anchoring.\nGot it?"
               }
@@ -92,11 +95,12 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
               dx={30}
               dy={30}
-              backgroundStyle={{ fill: "cyan" }}
+              backgroundStyle={{ fill: themeColors.yellow, opacity: 0.4 }}
               text={"such text, wow"}
             />
           }
@@ -104,10 +108,14 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: "pink" }}
-              style={[{ fontSize: 20, fill: "green" }, { fontSize: 10 }]}
+              backgroundStyle={{ fill: themeColors.cyan, opacity: 0.4 }}
+              style={[
+                { fontSize: 20, fill: themeColors.purple },
+                { fontSize: 10 },
+              ]}
               lineHeight={[1, 3, 1]}
               textAnchor="start"
               verticalAnchor="start"
@@ -120,9 +128,10 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: "pink" }}
+              backgroundStyle={{ fill: themeColors.yellow, opacity: 0.4 }}
               textAnchor="end"
               verticalAnchor="end"
               text={"Victory is awesome.\nThis is (end, end) anchoring.\nOK?"}
@@ -132,9 +141,10 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: "pink" }}
+              backgroundStyle={{ fill: themeColors.green, opacity: 0.4 }}
               lineHeight={2}
               textAnchor="middle"
               verticalAnchor="end"
@@ -147,9 +157,10 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: "pink" }}
+              backgroundStyle={{ fill: themeColors.pink, opacity: 0.3 }}
               textAnchor="start"
               verticalAnchor="end"
               text={
@@ -161,9 +172,10 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: "pink" }}
+              backgroundStyle={{ fill: themeColors.pink, opacity: 0.3 }}
               textAnchor="end"
               verticalAnchor="middle"
               text={
@@ -175,12 +187,13 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
               lineHeight={2}
               textAnchor="middle"
               verticalAnchor="middle"
-              backgroundStyle={{ fill: "cyan", opacity: 0.4 }}
+              backgroundStyle={{ fill: themeColors.cyan, opacity: 0.4 }}
               text={
                 "Victory is awesome.\nThis is (middle, middle) anchoring.\nGot it?"
               }
@@ -190,8 +203,10 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
+              backgroundStyle={{ fill: themeColors.cyan, opacity: 0.4 }}
               textAnchor="start"
               verticalAnchor="middle"
               text={
@@ -204,9 +219,10 @@ export default class App extends React.Component<any, {}> {
         {/* examples for inlining VictoryLabel with mutlitple labels */}
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: "lavender" }}
+              backgroundStyle={{ fill: themeColors.purple, opacity: 0.4 }}
               verticalAnchor="middle"
               text={[
                 "Victory is awesome.",
@@ -219,13 +235,17 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: "lavender" }}
+              backgroundStyle={{ fill: themeColors.purple, opacity: 0.4 }}
               textAnchor="start"
               verticalAnchor="middle"
               text={["This is varying styles", "inline."]}
-              style={[{ fill: "#000" }, { fill: "#6128ff", fontSize: 20 }]}
+              style={[
+                { fill: "#FFF" },
+                { fill: themeColors.purple, fontSize: 20 },
+              ]}
               inline
               dx={10}
             />
@@ -234,12 +254,13 @@ export default class App extends React.Component<any, {}> {
 
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           data={[{ x: -10, y: 5 }]}
           labelComponent={
             <VictoryLabel
               textAnchor="start"
               verticalAnchor="start"
-              backgroundStyle={{ fill: "lavender" }}
+              backgroundStyle={{ fill: themeColors.purple, opacity: 0.4 }}
               text={["Use", "dx", "attribute", "to", "shift", "labels"]}
               inline
               dx={10}
@@ -253,13 +274,14 @@ export default class App extends React.Component<any, {}> {
          */}
         <VictoryScatter
           {...defaultScatterProps}
+          theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
               backgroundStyle={[
-                { fill: "pink" },
-                { fill: "blue" },
-                { fill: "purple" },
-                { fill: "red" },
+                { fill: themeColors.pink },
+                { fill: themeColors.blue },
+                { fill: themeColors.purple },
+                { fill: themeColors.red },
               ]}
               text={[
                 "Victory is awesome.",
@@ -267,7 +289,7 @@ export default class App extends React.Component<any, {}> {
                 "lineHeight",
                 "as an array.",
               ]}
-              style={[{ fontSize: 20, fill: "green" }, { fontSize: 30 }]}
+              style={[{ fontSize: 20, fill: "#FFF" }, { fontSize: 30 }]}
               lineHeight={[2, 2, 3, 1]}
               verticalAnchor="start"
             />
@@ -280,7 +302,10 @@ export default class App extends React.Component<any, {}> {
           labelComponent={
             <VictoryLabel
               angle={20}
-              backgroundStyle={[{ fill: "pink" }, { fill: "blue" }]}
+              backgroundStyle={[
+                { fill: themeColors.pink },
+                { fill: themeColors.blue },
+              ]}
               text={[
                 "Victory is awesome.",
                 "Even if we leave blank arrays",

--- a/demo/ts/components/victory-legend-demo.tsx
+++ b/demo/ts/components/victory-legend-demo.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from "react";
 import { VictoryLabel, Border, VictoryTheme } from "victory-core";
 import { VictoryLegend } from "victory-legend";
-import { FaMoon, FaSun, FaStar } from 'react-icons/fa'
-
-const legendStyle = {
-  labels: { fontSize: 14, fontFamily: "Palatino" },
-  border: { stroke: "black", strokeWidth: 2 },
-  title: { padding: 5, fill: "red" },
-};
+import { FaMoon, FaSun, FaStar } from "react-icons/fa";
 
 const symbolSize = 5;
 const symbolSpacer = 10;
@@ -95,7 +89,8 @@ const customIconData = [
       size: symbolSize,
       fill: "pink",
     },
-  }]
+  },
+];
 
 const CustomSun = (props) => {
   return <FaSun {...props} x={props.x - 7} y={props.y - 7} size={15} />;
@@ -132,11 +127,10 @@ const CustomMoon = (props) => {
   );
 };
 
-
 const LegendDemo = () => (
   <div className="demo">
     <div>
-      <svg height={200} width={1000}>
+      <svg height={200} width={1500}>
         <VictoryLegend
           theme={VictoryTheme.clean}
           standalone={false}
@@ -146,9 +140,7 @@ const LegendDemo = () => (
           title={["My Legend title", "with some explanatory substitle"]}
           data={data}
           symbolSpacer={symbolSpacer}
-          titleComponent={
-            <VictoryLabel style={[{ fontSize: 20 }, { fontSize: 14 }]} />
-          }
+          titleComponent={<VictoryLabel />}
           events={[
             {
               target: "data",
@@ -169,92 +161,65 @@ const LegendDemo = () => (
     <div>
       <svg height={200} width={1000}>
         <VictoryLegend
-          standalone={false}
-          titleOrientation="right"
-          centerTitle
           title={["TITLE"]}
+          data={data}
+          theme={VictoryTheme.clean}
+          standalone={false}
           x={25}
           y={20}
-          gutter={30}
           symbolSpacer={symbolSpacer}
           itemsPerRow={3}
-          data={data}
-          style={legendStyle}
         />
       </svg>
     </div>
-    <svg height={200} width={1000}>
-      <VictoryLegend
-        orientation="horizontal"
-        titleOrientation="left"
-        title={["TITLE"]}
-        standalone={false}
-        x={25}
-        y={20}
-        symbolSpacer={symbolSpacer}
-        gutter={30}
-        itemsPerRow={3}
-        data={data}
-        style={legendStyle}
-      />
-    </svg>
     <svg height={300} width={1000}>
       <VictoryLegend
+        title={["TITLE", "subtitle", "more"]}
+        data={data}
+        theme={VictoryTheme.clean}
         standalone={false}
         x={25}
         y={20}
-        titleOrientation="bottom"
-        title={["TITLE", "subtitle", "more"]}
         symbolSpacer={symbolSpacer}
-        gutter={30}
-        data={data}
-        style={legendStyle}
       />
     </svg>
-    <svg height={200} width={1000}>
+    <svg height={100} width={1000}>
       <VictoryLegend
+        data={data}
+        theme={VictoryTheme.clean}
         orientation="horizontal"
         standalone={false}
         x={25}
         y={20}
-        gutter={30}
-        data={data}
-        style={legendStyle}
       />
     </svg>
     <svg height={200} width={1000}>
       <VictoryLegend
-        x={25}
-        y={20}
-        standalone={false}
-        orientation="vertical"
-        gutter={{ left: 20, right: 50 }}
-        rowGutter={{ top: 5, bottom: 8 }}
-        style={{ border: { stroke: "black" } }}
         data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
+        theme={VictoryTheme.clean}
+        x={25}
+        y={0}
+        standalone={false}
       />
     </svg>
     <svg height={200} width={1000}>
       <VictoryLegend
-        borderComponent={<Border width={630} height={110} />}
-        centerTitle
+        theme={VictoryTheme.clean}
+        borderComponent={<Border />}
         x={25}
         y={20}
         standalone={false}
         title={["TITLE"]}
-        gutter={30}
         symbolSpacer={symbolSpacer}
         itemsPerRow={3}
         data={data}
-        style={legendStyle}
       />
     </svg>
     {/* CustomIcon */}
     <svg height={200} width={1000}>
       <VictoryLegend
-        centerTitle
+        theme={VictoryTheme.clean}
         title={["TITLE"]}
-        gutter={30}
         x={25}
         y={20}
         standalone={false}
@@ -262,7 +227,6 @@ const LegendDemo = () => (
         itemsPerRow={3}
         dataComponent={<CustomSun />}
         data={customIconData}
-        style={legendStyle}
       />
     </svg>
     {/* CustomIcon with events*/}

--- a/demo/ts/components/victory-selection-container-demo.tsx
+++ b/demo/ts/components/victory-selection-container-demo.tsx
@@ -27,6 +27,17 @@ const multiAxisData: multiAxisDataListType = [
   { strength: 5, intelligence: 225, stealth: 60 },
 ];
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+const {
+  red = "red",
+  green = "green",
+  blue = "blue",
+  cyan = "cyan",
+  purple = "purple",
+  orange = "orange",
+  yellow = "yellow",
+} = themeColors;
+
 class VictorySelectionContainerDemo extends React.Component<any, any> {
   setStateInterval?: number = undefined;
 
@@ -129,14 +140,13 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             <VictoryPolarAxis
               dependentAxis
               labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
               tickFormat={() => ""}
             />
             <VictoryPolarAxis labelPlacement="parallel" />
             <VictoryArea
               interpolation="catmullRom"
               style={{
-                data: { fill: "tomato" },
+                data: { fill: red },
               }}
               data={this.state.data}
             />
@@ -155,7 +165,6 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             <VictoryPolarAxis
               dependentAxis
               labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
               tickFormat={() => ""}
             />
             <VictoryPolarAxis labelPlacement="parallel" />
@@ -164,7 +173,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
               labels={({ datum }: any) => `y: ${Math.round(datum.y)}`}
               interpolation="linear"
               style={{
-                data: { stroke: "tomato", strokeWidth: 2 },
+                data: { stroke: red, strokeWidth: 2 },
               }}
               data={this.state.data}
             />
@@ -173,23 +182,22 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
           <VictoryChart
             polar
             animate={{ duration: 2000 }}
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             style={chartStyle}
           >
             <VictoryPolarAxis
               dependentAxis
               labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
               tickFormat={() => ""}
             />
             <VictoryPolarAxis labelPlacement="parallel" />
             <VictoryBar
               style={{
                 data: {
-                  fill: "tomato",
+                  fill: red,
                   width: 10,
                   fillOpacity: 0.4,
-                  stroke: "tomato",
+                  stroke: red,
                   strokeWidth: 2,
                 },
               }}
@@ -200,22 +208,21 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
           <VictoryChart
             polar
             animate={{ duration: 2000 }}
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             style={chartStyle}
           >
             <VictoryPolarAxis
               dependentAxis
               labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
               tickFormat={() => ""}
             />
             <VictoryPolarAxis labelPlacement="parallel" />
             <VictoryBar
               style={{
                 data: {
-                  fill: "tomato",
+                  fill: red,
                   fillOpacity: 0.4,
-                  stroke: "tomato",
+                  stroke: red,
                   strokeWidth: 2,
                 },
               }}
@@ -225,7 +232,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
 
           <VictoryChart
             polar
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             domain={{ x: [0, 360], y: [0, 80] }}
             style={chartStyle}
             containerComponent={<VictoryZoomContainer />}
@@ -233,7 +240,6 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             <VictoryPolarAxis
               dependentAxis
               labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
               axisAngle={270}
               tickFormat={() => ""}
             />
@@ -247,16 +253,16 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
                 data: { fill: ({ datum }) => datum.fill, opacity: 0.5 },
               }}
               data={[
-                { x: 45, y: 20, label: 1, fill: "red" },
-                { x: 90, y: 30, label: 2, fill: "orange" },
-                { x: 135, y: 65, label: 3, fill: "gold" },
-                { x: 250, y: 50, label: 4, fill: "blue" },
-                { x: 270, y: 40, label: 5, fill: "cyan" },
-                { x: 295, y: 30, label: 6, fill: "green" },
+                { x: 45, y: 20, label: 1, fill: red },
+                { x: 90, y: 30, label: 2, fill: orange },
+                { x: 135, y: 65, label: 3, fill: yellow },
+                { x: 250, y: 50, label: 4, fill: blue },
+                { x: 270, y: 40, label: 5, fill: cyan },
+                { x: 295, y: 30, label: 6, fill: green },
               ]}
             />
             <VictoryScatter
-              style={{ data: { fill: "black" } }}
+              style={{ data: { fill: purple } }}
               data={[
                 { x: 45, y: 20 },
                 { x: 90, y: 30 },
@@ -268,23 +274,23 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             />
           </VictoryChart>
 
-          <VictoryChart polar theme={VictoryTheme.material} style={chartStyle}>
+          <VictoryChart polar theme={VictoryTheme.clean} style={chartStyle}>
             <VictoryBar
               alignment="start"
               style={{
                 data: { fill: ({ datum }) => datum.fill, opacity: 0.5 },
               }}
               data={[
-                { x: 15, y: 20, label: 1, fill: "red" },
-                { x: 25, y: 30, label: 2, fill: "orange" },
-                { x: 35, y: 65, label: 3, fill: "gold" },
-                { x: 40, y: 50, label: 4, fill: "blue" },
-                { x: 45, y: 40, label: 5, fill: "cyan" },
-                { x: 50, y: 30, label: 6, fill: "green" },
+                { x: 15, y: 20, label: 1, fill: red },
+                { x: 25, y: 30, label: 2, fill: orange },
+                { x: 35, y: 65, label: 3, fill: yellow },
+                { x: 40, y: 50, label: 4, fill: blue },
+                { x: 45, y: 40, label: 5, fill: cyan },
+                { x: 50, y: 30, label: 6, fill: green },
               ]}
             />
             <VictoryScatter
-              style={{ data: { fill: "black" } }}
+              style={{ data: { fill: purple } }}
               data={[
                 { x: 15, y: 20 },
                 { x: 25, y: 30 },
@@ -296,20 +302,20 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             />
           </VictoryChart>
 
-          <VictoryChart polar theme={VictoryTheme.material} style={chartStyle}>
+          <VictoryChart polar theme={VictoryTheme.clean} style={chartStyle}>
             <VictoryBar
               style={{ data: { fill: ({ datum }) => datum.fill, width: 10 } }}
               data={[
-                { x: 1, y: 2, label: 1, fill: "red" },
-                { x: 2, y: 3, label: 2, fill: "orange" },
-                { x: 3, y: 6, label: 3, fill: "gold" },
-                { x: 4, y: 5, label: 4, fill: "blue" },
-                { x: 5, y: 4, label: 5, fill: "cyan" },
-                { x: 6, y: 3, label: 6, fill: "green" },
+                { x: 1, y: 2, label: 1, fill: red },
+                { x: 2, y: 3, label: 2, fill: orange },
+                { x: 3, y: 6, label: 3, fill: yellow },
+                { x: 4, y: 5, label: 4, fill: blue },
+                { x: 5, y: 4, label: 5, fill: cyan },
+                { x: 6, y: 3, label: 6, fill: green },
               ]}
             />
             <VictoryScatter
-              style={{ data: { fill: "black" } }}
+              style={{ data: { fill: purple } }}
               data={[
                 { x: 1, y: 2 },
                 { x: 2, y: 3 },
@@ -321,11 +327,10 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             />
           </VictoryChart>
 
-          <VictoryChart polar theme={VictoryTheme.material} style={chartStyle}>
+          <VictoryChart polar theme={VictoryTheme.clean} style={chartStyle}>
             <VictoryPolarAxis
               dependentAxis
               labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
               axisAngle={270}
               tickValues={[25, 50, 75]}
             />
@@ -334,7 +339,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
               tickValues={[0, 45, 90, 135, 180, 225, 315]}
             />
             <VictoryScatter
-              style={{ data: { fill: "tomato" } }}
+              style={{ data: { fill: red } }}
               size={5}
               data={[
                 { x: 45, y: 20, label: 1 },
@@ -346,7 +351,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             />
 
             <VictoryArea
-              style={{ data: { fill: "tomato", opacity: 0.6 } }}
+              style={{ data: { fill: red, opacity: 0.6 } }}
               data={[
                 { x: 45, y: 20 },
                 { x: 90, y: 30 },
@@ -357,7 +362,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             />
 
             <VictoryLine
-              style={{ data: { stroke: "tomato" } }}
+              style={{ data: { stroke: red } }}
               data={[
                 { x: 45, y: 20 },
                 { x: 90, y: 30 },
@@ -368,11 +373,10 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
             />
           </VictoryChart>
 
-          <VictoryChart polar theme={VictoryTheme.material} style={chartStyle}>
+          <VictoryChart polar theme={VictoryTheme.clean} style={chartStyle}>
             <VictoryPolarAxis
               dependentAxis
               labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
               axisAngle={90}
               tickValues={[25, 50, 75]}
             />
@@ -387,7 +391,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
               ]}
             />
             <VictoryScatter
-              style={{ data: { fill: "tomato" } }}
+              style={{ data: { fill: red } }}
               size={5}
               data={[
                 { x: 1, y: 10 },
@@ -398,7 +402,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
               ]}
             />
             <VictoryArea
-              style={{ data: { fill: "tomato", opacity: 0.6 } }}
+              style={{ data: { fill: red, opacity: 0.6 } }}
               data={[
                 { x: 1, y: 10 },
                 { x: 2, y: 25 },
@@ -410,7 +414,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
           </VictoryChart>
 
           <VictoryPolarAxis
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             style={chartStyle}
             labelPlacement="vertical"
             startAngle={20}
@@ -424,7 +428,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
           <VictoryPolarAxis
             startAngle={0}
             endAngle={180}
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             style={chartStyle}
             labelPlacement="perpendicular"
             tickValues={[0, 45, 90, 135, 180]}
@@ -433,14 +437,14 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
           <VictoryPolarAxis
             startAngle={0}
             endAngle={180}
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             style={chartStyle}
             labelPlacement="perpendicular"
             tickValues={["Cat", "Dog", "Bird", "Snake"]}
           />
 
           <VictoryPolarAxis
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             style={chartStyle}
             domain={[0, 10]}
             labelPlacement="vertical"
@@ -450,7 +454,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
           <VictoryPolarAxis
             dependentAxis
             axisAngle={200}
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
             style={chartStyle}
             domain={[0, 10]}
             tickValues={[2, 4, 6, 8, 10]}
@@ -459,7 +463,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
           <svg width={350} height={350}>
             <VictoryPolarAxis
               standalone={false}
-              theme={VictoryTheme.material}
+              theme={VictoryTheme.clean}
               style={chartStyle}
               domain={[0, 360]}
               tickValues={[0, 45, 90, 135, 180, 225, 270, 315]}
@@ -469,7 +473,7 @@ class VictorySelectionContainerDemo extends React.Component<any, any> {
               dependentAxis
               standalone={false}
               axisAngle={200}
-              theme={VictoryTheme.material}
+              theme={VictoryTheme.clean}
               style={chartStyle}
               tickValues={[2, 4, 6, 8, 10]}
             />

--- a/demo/ts/components/victory-shared-events-demo.tsx
+++ b/demo/ts/components/victory-shared-events-demo.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { VictoryBar } from "victory-bar";
+import { VictoryTheme } from "victory-core";
 import { VictorySharedEvents } from "victory-shared-events";
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
 export default class VictorySharedEventsDemo extends React.Component<any, {}> {
   render() {
     const containerStyle: React.CSSProperties = {
@@ -14,7 +16,7 @@ export default class VictorySharedEventsDemo extends React.Component<any, {}> {
 
     return (
       <div className="demo" style={containerStyle}>
-        <svg width={500} height={300}>
+        <svg width={800} height={500}>
           <VictorySharedEvents
             events={[
               {
@@ -27,7 +29,9 @@ export default class VictorySharedEventsDemo extends React.Component<any, {}> {
                       childName: "secondBar",
                       mutation: (props) => {
                         return {
-                          style: Object.assign({}, props.style, { fill: "blue" }),
+                          style: Object.assign({}, props.style, {
+                            fill: themeColors.blue,
+                          }),
                         };
                       },
                     };
@@ -44,17 +48,21 @@ export default class VictorySharedEventsDemo extends React.Component<any, {}> {
                       {
                         childName: "firstBar",
                         mutation: (props) => {
-                          return props.style.fill === "cyan"
+                          return props.style.fill === themeColors.cyan
                             ? null
                             : {
-                                style: Object.assign({}, props.style, { fill: "cyan" }),
+                                style: Object.assign({}, props.style, {
+                                  fill: themeColors.cyan,
+                                }),
                               };
                         },
                       },
                       {
                         mutation: (props) => {
                           return {
-                            style: Object.assign({}, props.style, { fill: "orange" }),
+                            style: Object.assign({}, props.style, {
+                              fill: themeColors.orange,
+                            }),
                           };
                         },
                       },
@@ -72,9 +80,11 @@ export default class VictorySharedEventsDemo extends React.Component<any, {}> {
             ]}
           >
             <VictoryBar
+              theme={VictoryTheme.clean}
               name="firstBar"
+              standalone={false}
               style={{
-                data: { width: 25, fill: "gold" },
+                data: { width: 25, fill: themeColors.yellow },
               }}
               data={[
                 { x: "a", y: 2 },
@@ -83,7 +93,10 @@ export default class VictorySharedEventsDemo extends React.Component<any, {}> {
               ]}
             />
             <VictoryBar
+              theme={VictoryTheme.clean}
               name={"secondBar"}
+              standalone={false}
+              labels={({ datum }) => datum.y}
               data={[
                 { x: "a", y: 2 },
                 { x: "b", y: 3 },

--- a/demo/ts/components/victory-tooltip-demo.tsx
+++ b/demo/ts/components/victory-tooltip-demo.tsx
@@ -30,15 +30,9 @@ class App extends React.Component {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryBar
+            theme={VictoryTheme.clean}
             style={{ parent: parentStyle }}
-            labelComponent={
-              <VictoryTooltip
-                constrainToVisibleArea
-                flyoutStyle={{ stroke: "red" }}
-                cornerRadius={0}
-                pointerLength={20}
-              />
-            }
+            labelComponent={<VictoryTooltip constrainToVisibleArea />}
             labels={({ datum }) => `hello0000000000 #${datum.x}`}
             data={[
               { x: 1, y: 1 },
@@ -50,6 +44,7 @@ class App extends React.Component {
           />
 
           <VictoryScatter
+            theme={VictoryTheme.clean}
             style={{ parent: parentStyle }}
             labelComponent={
               <VictoryTooltip
@@ -73,11 +68,7 @@ class App extends React.Component {
             theme={VictoryTheme.clean}
             horizontal
             style={{ parent: parentStyle }}
-            highLabelComponent={
-              <VictoryTooltip
-                active dy={-3}
-              />
-            }
+            highLabelComponent={<VictoryTooltip active dy={-3} />}
             highLabels={({ datum }) => `hello #${datum.x}`}
             data={[
               { x: 1, open: 5, close: 10, high: 15, low: 0 },
@@ -102,7 +93,10 @@ class App extends React.Component {
             ]}
           />
 
-          <VictoryChart style={{ parent: parentStyle }}>
+          <VictoryChart
+            style={{ parent: parentStyle }}
+            theme={VictoryTheme.clean}
+          >
             <VictoryGroup
               labels={["a", "b", "c"]}
               labelComponent={<VictoryTooltip />}

--- a/demo/ts/components/victory-voronoi-container-demo.tsx
+++ b/demo/ts/components/victory-voronoi-container-demo.tsx
@@ -31,6 +31,16 @@ const chartStyle: { [key: string]: React.CSSProperties } = {
   parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
 };
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+const {
+  red = "red",
+  green = "green",
+  blue = "blue",
+  purple = "purple",
+  orange = "orange",
+  yellow = "yellow",
+} = themeColors;
+
 export default class VictoryVoronoiContainerDemo extends React.Component<
   any,
   VictoryVoronoiContainerDemoState
@@ -111,7 +121,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
             }
           >
             <VictoryScatter
-              style={{ data: { fill: "red" }, labels: { fill: "red" } }}
+              style={{ data: { fill: red }, labels: { fill: red } }}
               data={[
                 { x: 0, y: 2500 },
                 { x: 2, y: 3300 },
@@ -144,9 +154,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               <VictoryVoronoiContainer
                 labels={({ datum }) => `I'm kind of a long label ${datum.y}`}
                 mouseFollowTooltips
-                labelComponent={
-                  <VictoryTooltip constrainToVisibleArea />
-                }
+                labelComponent={<VictoryTooltip constrainToVisibleArea />}
               />
             }
           >
@@ -161,7 +169,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
                 { x: 7, y: 0 },
               ]}
               style={{
-                data: { fill: "blue" },
+                data: { fill: blue },
               }}
               size={({ active }) => (active ? 8 : 3)}
             />
@@ -176,13 +184,14 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
                 { x: 7, y: 0 },
               ]}
               style={{
-                data: { fill: "red" },
+                data: { fill: red },
               }}
               size={({ active }) => (active ? 5 : 3)}
             />
           </VictoryChart>
 
           <VictoryChart
+            theme={VictoryTheme.clean}
             height={450}
             domain={{ y: [0, 1] }}
             style={chartStyle}
@@ -201,7 +210,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
                 { x: 7, y: 0 },
               ]}
               style={{
-                data: { fill: "blue" },
+                data: { fill: blue },
               }}
               size={({ active }) => (active ? 5 : 3)}
             />
@@ -220,7 +229,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
                   <VictoryTooltip
                     y={150}
                     flyoutStyle={{ fill: "white" }}
-                    style={[{ fill: "green" }, { fill: "magenta" }]}
+                    style={[{ fill: green }, { fill: purple }]}
                   />
                 }
               />
@@ -236,10 +245,10 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               ]}
               style={{
                 data: {
-                  stroke: "tomato",
+                  stroke: red,
                   strokeWidth: ({ active }) => (active ? 4 : 2),
                 },
-                labels: { fill: "tomato" },
+                labels: { fill: red },
               }}
             />
 
@@ -252,10 +261,10 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               ]}
               style={{
                 data: {
-                  stroke: "blue",
+                  stroke: blue,
                   strokeWidth: ({ active }) => (active ? 4 : 2),
                 },
-                labels: { fill: "blue" },
+                labels: { fill: blue },
               }}
             />
 
@@ -268,20 +277,21 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               ]}
               style={{
                 data: {
-                  stroke: "black",
+                  stroke: yellow,
                   strokeWidth: ({ active }) => (active ? 4 : 2),
                 },
-                labels: { fill: "black" },
+                labels: { fill: yellow },
               }}
             />
           </VictoryChart>
 
           <VictoryScatter
+            theme={VictoryTheme.clean}
             animate={{ duration: 1000 }}
             style={{
               parent: chartStyle.parent,
               data: {
-                fill: ({ active }) => (active ? "tomato" : "black"),
+                fill: ({ active }) => (active ? red : yellow),
               },
             }}
             containerComponent={
@@ -297,6 +307,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
           />
 
           <VictoryChart
+            theme={VictoryTheme.clean}
             style={chartStyle}
             containerComponent={
               <VictoryVoronoiContainer
@@ -305,21 +316,11 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               />
             }
           >
-            <VictoryScatter
-              name="ignore"
-              style={{
-                data: {
-                  fill: "gray",
-                  opacity: 0.2,
-                },
-              }}
-              size={20}
-              y={(d) => d.x * d.x}
-            />
+            <VictoryScatter name="ignore" size={7} y={(d) => d.x * d.x} />
             <VictoryScatter
               style={{
                 data: {
-                  fill: ({ active }) => (active ? "tomato" : "black"),
+                  fill: ({ active }) => (active ? red : yellow),
                 },
               }}
               size={({ active }) => (active ? 5 : 3)}
@@ -328,6 +329,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
           </VictoryChart>
 
           <VictoryChart
+            theme={VictoryTheme.clean}
             height={450}
             padding={{ top: 100, bottom: 20, left: 50, right: 50 }}
             style={chartStyle}
@@ -353,14 +355,11 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
             >
               <VictoryScatter
                 style={{
-                  data: { fill: "tomato" },
+                  data: { fill: red },
                 }}
                 size={({ active }) => (active ? 8 : 3)}
               />
-              <VictoryLine
-                name="ignore"
-                style={{ data: { stroke: "tomato" } }}
-              />
+              <VictoryLine name="ignore" style={{ data: { stroke: yellow } }} />
             </VictoryGroup>
             <VictoryGroup
               data={[
@@ -375,11 +374,11 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
             >
               <VictoryScatter
                 style={{
-                  data: { fill: "blue" },
+                  data: { fill: blue },
                 }}
                 size={({ active }) => (active ? 5 : 3)}
               />
-              <VictoryLine name="ignore" style={{ data: { stroke: "blue" } }} />
+              <VictoryLine name="ignore" style={{ data: { stroke: blue } }} />
             </VictoryGroup>
             <VictoryGroup
               data={[
@@ -398,32 +397,30 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
           </VictoryChart>
 
           <VictoryChart
+            theme={VictoryTheme.clean}
             height={450}
             padding={{ top: 100, bottom: 20, left: 50, right: 50 }}
             style={chartStyle}
             containerComponent={
-              <VictoryVoronoiContainer voronoiBlacklist={["red"]} />
+              <VictoryVoronoiContainer voronoiBlacklist={[red]} />
             }
           >
             <VictoryLegend
               x={140}
               y={10}
               title="Legend"
-              centerTitle
               orientation="horizontal"
-              gutter={20}
-              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
               data={[
-                { name: "One", symbol: { fill: "tomato" } },
-                { name: "Two", symbol: { fill: "orange" } },
-                { name: "Three", symbol: { fill: "gold" } },
+                { name: "One", symbol: { fill: red } },
+                { name: "Two", symbol: { fill: orange } },
+                { name: "Three", symbol: { fill: yellow } },
               ]}
             />
             <VictoryGroup style={chartStyle}>
               <VictoryScatter
                 name="red"
                 style={{
-                  data: { fill: "tomato" },
+                  data: { fill: red },
                 }}
                 size={({ active }) => (active ? 5 : 3)}
                 labels={({ datum }) => datum.y}
@@ -440,7 +437,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               />
               <VictoryScatter
                 style={{
-                  data: { fill: "blue" },
+                  data: { fill: yellow },
                 }}
                 size={({ active }) => (active ? 5 : 3)}
                 labels={({ datum }) => datum.y}
@@ -456,6 +453,9 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
                 ]}
               />
               <VictoryScatter
+                style={{
+                  data: { fill: orange },
+                }}
                 data={[
                   { x: 1, y: 5 },
                   { x: 2, y: -4 },
@@ -473,9 +473,10 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
           </VictoryChart>
 
           <VictoryChart
+            theme={VictoryTheme.clean}
             style={chartStyle}
             containerComponent={
-              <VictoryVoronoiContainer voronoiBlacklist={["red"]} />
+              <VictoryVoronoiContainer voronoiBlacklist={[red]} />
             }
           >
             <VictoryStack>
@@ -483,8 +484,8 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
                 name="red"
                 style={{
                   data: {
-                    fill: "tomato",
-                    stroke: ({ active }) => (active ? "black" : "none"),
+                    fill: red,
+                    stroke: ({ active }) => (active ? yellow : "none"),
                     strokeWidth: 2,
                   },
                 }}
@@ -501,8 +502,8 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               <VictoryBar
                 style={{
                   data: {
-                    fill: "orange",
-                    stroke: ({ active }) => (active ? "black" : "none"),
+                    fill: orange,
+                    stroke: ({ active }) => (active ? yellow : "none"),
                     strokeWidth: 2,
                   },
                 }}
@@ -519,8 +520,8 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               <VictoryBar
                 style={{
                   data: {
-                    fill: "gold",
-                    stroke: ({ active }) => (active ? "black" : "none"),
+                    fill: yellow,
+                    stroke: ({ active }) => (active ? yellow : "none"),
                     strokeWidth: 2,
                   },
                 }}
@@ -538,14 +539,15 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
           </VictoryChart>
 
           <VictoryStack
+            theme={VictoryTheme.clean}
             style={chartStyle}
             containerComponent={<VictoryVoronoiContainer />}
           >
             <VictoryBar
               style={{
                 data: {
-                  fill: "tomato",
-                  stroke: ({ active }) => (active ? "black" : "none"),
+                  fill: red,
+                  stroke: ({ active }) => (active ? yellow : "none"),
                   strokeWidth: 2,
                 },
               }}
@@ -562,8 +564,8 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
             <VictoryBar
               style={{
                 data: {
-                  fill: "orange",
-                  stroke: ({ active }) => (active ? "black" : "none"),
+                  fill: orange,
+                  stroke: ({ active }) => (active ? yellow : "none"),
                   strokeWidth: 2,
                 },
               }}
@@ -580,8 +582,8 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
             <VictoryBar
               style={{
                 data: {
-                  fill: "gold",
-                  stroke: ({ active }) => (active ? "black" : "none"),
+                  fill: yellow,
+                  stroke: ({ active }) => (active ? yellow : "none"),
                   strokeWidth: 2,
                 },
               }}
@@ -599,7 +601,8 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
 
           <VictoryChart
             style={chartStyle}
-            theme={VictoryTheme.material}
+            theme={VictoryTheme.clean}
+            height={450}
             domainPadding={{ y: 2 }}
             containerComponent={
               <VictoryVoronoiContainer
@@ -623,7 +626,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               ]}
               style={{
                 data: {
-                  stroke: "red",
+                  stroke: red,
                   strokeWidth: ({ active }) => (active ? 4 : 2),
                 },
               }}
@@ -638,7 +641,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               ]}
               style={{
                 data: {
-                  stroke: "green",
+                  stroke: green,
                   strokeWidth: ({ active }) => (active ? 4 : 2),
                 },
               }}
@@ -646,6 +649,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
           </VictoryChart>
 
           <VictoryChart
+            theme={VictoryTheme.clean}
             height={450}
             padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
             style={chartStyle}
@@ -668,17 +672,14 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               x={165}
               y={10}
               title="Voronoi padding"
-              centerTitle
               orientation="horizontal"
-              gutter={20}
-              style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
               data={[
-                { name: "One", symbol: { fill: "tomato" } },
-                { name: "Two", symbol: { fill: "orange" } },
+                { name: "One", symbol: { fill: red } },
+                { name: "Two", symbol: { fill: orange } },
               ]}
             />
             <VictoryScatter
-              style={{ data: { fill: "tomato" }, labels: { fill: "tomato" } }}
+              style={{ data: { fill: red }, labels: { fill: red } }}
               data={[
                 { x: 0, y: 2 },
                 { x: 2, y: 3 },
@@ -687,7 +688,7 @@ export default class VictoryVoronoiContainerDemo extends React.Component<
               ]}
             />
             <VictoryScatter
-              style={{ data: { fill: "orange" }, labels: { fill: "orange" } }}
+              style={{ data: { fill: orange }, labels: { fill: orange } }}
               data={[
                 { x: 2, y: 2 },
                 { x: 4, y: 3 },

--- a/demo/ts/components/victory-voronoi-demo.tsx
+++ b/demo/ts/components/victory-voronoi-demo.tsx
@@ -5,7 +5,7 @@ import { VictoryTooltip } from "victory-tooltip";
 import { VictoryChart } from "victory-chart";
 import { VictoryScatter } from "victory-scatter";
 import { range, random } from "lodash";
-import { VictoryTheme } from "victory-core/lib";
+import { VictoryTheme } from "victory-core";
 
 type dataType = {
   x: number;
@@ -65,21 +65,17 @@ class VoronoiDemo extends React.Component<any, VoronoiDemoStateProps> {
       maxWidth: "40%",
     };
 
-    const visible: React.CSSProperties = {
-      fill: "gray",
-      opacity: 0.1,
-      stroke: "black",
-      strokeWidth: 2,
-    };
-
     return (
       <div className="demo">
         <div style={containerStyle}>
-          <VictoryVoronoi theme={VictoryTheme.clean} style={{ parent: parentStyle, data: visible }} />
+          <VictoryVoronoi
+            theme={VictoryTheme.clean}
+            style={{ parent: parentStyle }}
+          />
 
           <VictoryVoronoi
             theme={VictoryTheme.clean}
-            style={{ parent: parentStyle, data: visible }}
+            style={{ parent: parentStyle }}
             data={[
               { x: 1, y: 1 },
               { x: 2, y: 2 },
@@ -95,7 +91,11 @@ class VoronoiDemo extends React.Component<any, VoronoiDemoStateProps> {
                     return [
                       {
                         mutation: () => {
-                          return { style: { fill: "orange" } };
+                          return {
+                            style: {
+                              fill: VictoryTheme.clean.palette?.colors?.orange,
+                            },
+                          };
                         },
                       },
                     ];
@@ -106,7 +106,8 @@ class VoronoiDemo extends React.Component<any, VoronoiDemoStateProps> {
           />
 
           <VictoryVoronoi
-            style={{ parent: parentStyle, data: visible }}
+            theme={VictoryTheme.clean}
+            style={{ parent: parentStyle }}
             size={40}
             data={[
               { x: 1, y: 1 },
@@ -118,30 +119,39 @@ class VoronoiDemo extends React.Component<any, VoronoiDemoStateProps> {
           />
 
           <VictoryVoronoi
+            theme={VictoryTheme.clean}
             labels={({ datum }) => `#${datum.i}`}
             labelComponent={<VictoryTooltip />}
             animate={{ duration: 2000 }}
-            style={{ parent: parentStyle, data: visible }}
+            style={{ parent: parentStyle }}
             size={20}
             data={this.state.data}
           />
 
-          <VictoryChart horizontal style={{ parent: parentStyle }}  theme={VictoryTheme.clean} >
+          <VictoryChart
+            horizontal
+            style={{ parent: parentStyle }}
+            theme={VictoryTheme.clean}
+          >
             <VictoryVoronoi
               labels={({ datum }) => `#${datum.i}`}
               labelComponent={<VictoryTooltip />}
               size={20}
-              style={{ parent: parentStyle, data: visible }}
+              style={{ parent: parentStyle }}
               data={this.state.data}
             />
             <VictoryScatter data={this.state.data} />
           </VictoryChart>
 
-          <VictoryChart horizontal style={{ parent: parentStyle }}>
+          <VictoryChart
+            horizontal
+            style={{ parent: parentStyle }}
+            theme={VictoryTheme.clean}
+          >
             <VictoryVoronoi
               labels={({ datum }) => `#${datum.i}`}
               labelComponent={<VictoryTooltip />}
-              style={{ parent: parentStyle, data: visible }}
+              style={{ parent: parentStyle }}
               data={this.state.data}
             />
             <VictoryScatter data={this.state.data} />

--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -25,6 +25,18 @@ const allData = range(0, 10, 0.001).map((x) => ({
   y: (Math.sin((Math.PI * x) / 2) * x) / 10,
 }));
 
+const themeColors = VictoryTheme.clean.palette?.colors || {};
+const {
+  red = "red",
+  orange = "orange",
+  yellow = "yellow",
+  blue = "blue",
+  teal = "teal",
+  pink = "pink",
+  purple = "purple",
+  green = "green",
+} = themeColors;
+
 interface CustomChartState {
   zoomedXDomain: DomainTuple;
 }
@@ -87,6 +99,7 @@ class CustomChart extends React.Component<any, CustomChartState> {
     const renderedData = this.getData();
     return (
       <VictoryChart
+        theme={VictoryTheme.clean}
         style={this.props.style}
         domain={this.entireDomain}
         containerComponent={
@@ -113,7 +126,6 @@ interface VictoryZoomContainerDemoState {
     a: number;
     b: number;
   }[];
-  style: React.CSSProperties;
   transitionData: {
     x: number;
     y: number;
@@ -153,10 +165,6 @@ export default class VictoryZoomContainerDemo extends React.Component<
       data: this.getData(),
       transitionData: this.getTransitionData(),
       arrayData: this.getArrayData(),
-      style: {
-        stroke: "blue",
-        strokeWidth: 2,
-      },
       zoomDomain: this.getZoomDomain(),
     };
   }
@@ -167,7 +175,6 @@ export default class VictoryZoomContainerDemo extends React.Component<
       this.setState({
         data: this.getData(),
         transitionData: this.getTransitionData(),
-        style: this.getStyles(),
       });
     }, 3000);
   }
@@ -225,13 +232,11 @@ export default class VictoryZoomContainerDemo extends React.Component<
           style={{ parent: parentStyle }}
           data={this.state.transitionData}
         >
-          <VictoryLine
-            animate={{ duration: 1500 }}
-            style={{ data: this.state.style }}
-          />
+          <VictoryLine animate={{ duration: 1500 }} />
         </VictoryGroup>
 
         <VictoryChart
+          theme={VictoryTheme.clean}
           style={{ parent: parentStyle }}
           containerComponent={
             <VictoryZoomContainer
@@ -247,7 +252,9 @@ export default class VictoryZoomContainerDemo extends React.Component<
           <VictoryAxis tickFormat={(x) => new Date(x).getFullYear()} />
           <VictoryLine
             style={{
-              data: { stroke: "red", strokeWidth: 5 },
+              data: {
+                stroke: yellow,
+              },
             }}
             data={[
               { x: new Date(1982, 1, 1), y: 125 },
@@ -280,8 +287,13 @@ export default class VictoryZoomContainerDemo extends React.Component<
         >
           <VictoryPortal>
             <VictoryScatter
-              style={{ parent: parentStyle, data: { fill: "orange" } }}
-              size={15}
+              theme={VictoryTheme.clean}
+              style={{
+                parent: parentStyle,
+                data: {
+                  fill: green,
+                },
+              }}
               data={this.state.data}
               x="a"
               y="b"
@@ -290,6 +302,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
         </VictoryChart>
 
         <VictoryChart
+          theme={VictoryTheme.clean}
           style={{ parent: parentStyle }}
           animate={{ duration: 1500 }}
           domainPadding={{ x: 20, y: 0 }}
@@ -305,8 +318,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
           }
         >
           <VictoryScatter
-            style={{ parent: parentStyle, data: { fill: "orange" } }}
-            size={15}
+            style={{ parent: parentStyle }}
             data={this.state.data}
             x="a"
             y="b"
@@ -316,13 +328,13 @@ export default class VictoryZoomContainerDemo extends React.Component<
         </VictoryChart>
 
         <VictoryChart
+          theme={VictoryTheme.clean}
           style={{ parent: parentStyle }}
           containerComponent={<VictoryZoomContainer />}
         >
           <VictoryLine
             style={{
               parent: parentStyle,
-              data: { stroke: "red", strokeWidth: 6 },
             }}
             events={[
               {
@@ -333,7 +345,9 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       {
                         mutation: (props) => {
                           return {
-                            style: Object.assign({}, props.style, { stroke: "orange" }),
+                            style: Object.assign({}, props.style, {
+                              stroke: "orange",
+                            }),
                           };
                         },
                       },
@@ -354,13 +368,16 @@ export default class VictoryZoomContainerDemo extends React.Component<
         </VictoryChart>
 
         <VictoryChart
+          theme={VictoryTheme.clean}
           style={{ parent: parentStyle }}
           containerComponent={<VictoryZoomContainer />}
         >
           <VictoryArea
             style={{
               parent: parentStyle,
-              data: { stroke: "#333", fill: "#888", opacity: 0.4 },
+              data: {
+                fill: pink,
+              },
             }}
             data={this.state.data}
             x="a"
@@ -369,6 +386,12 @@ export default class VictoryZoomContainerDemo extends React.Component<
           />
           <VictoryAxis />
           <VictoryLine
+            style={{
+              parent: parentStyle,
+              data: {
+                stroke: pink,
+              },
+            }}
             data={this.state.data}
             x="a"
             y="b"
@@ -384,6 +407,8 @@ export default class VictoryZoomContainerDemo extends React.Component<
         </button>
 
         <VictoryChart
+          theme={VictoryTheme.clean}
+          height={400}
           containerComponent={
             <VictoryZoomContainer
               zoomDimension="x"
@@ -395,18 +420,18 @@ export default class VictoryZoomContainerDemo extends React.Component<
         >
           <VictoryLine
             name="line"
-            style={{ parent: parentStyle, data: { stroke: "blue" } }}
+            style={{ parent: parentStyle }}
             y={(d) => Math.sin(2 * Math.PI * d.x)}
             samples={25}
           />
         </VictoryChart>
 
         <VictoryChart
+          theme={VictoryTheme.clean}
           style={{ parent: parentStyle }}
           height={400}
           padding={{ top: 80, bottom: 50, left: 50, right: 50 }}
           containerComponent={<VictoryZoomContainer />}
-          theme={VictoryTheme.material}
           events={[
             {
               childName: "area-1",
@@ -419,7 +444,9 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: Object.assign({}, props.style, { fill: "gold" }),
+                          style: Object.assign({}, props.style, {
+                            fill: yellow,
+                          }),
                         };
                       },
                     },
@@ -428,7 +455,9 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: Object.assign({}, props.style, { fill: "orange" }),
+                          style: Object.assign({}, props.style, {
+                            fill: orange,
+                          }),
                         };
                       },
                     },
@@ -437,7 +466,7 @@ export default class VictoryZoomContainerDemo extends React.Component<
                       target: "data",
                       mutation: (props) => {
                         return {
-                          style: Object.assign({}, props.style, { fill: "red" }),
+                          style: Object.assign({}, props.style, { fill: red }),
                         };
                       },
                     },
@@ -451,14 +480,12 @@ export default class VictoryZoomContainerDemo extends React.Component<
             x={83}
             y={10}
             title="Legend"
-            centerTitle
             orientation="horizontal"
-            gutter={20}
-            style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
             data={[
-              { name: "One", symbol: { fill: "tomato" } },
-              { name: "Two", symbol: { fill: "orange" } },
-              { name: "Three", symbol: { fill: "gold" } },
+              { name: "One", symbol: { fill: teal } },
+              { name: "Two", symbol: { fill: pink } },
+              { name: "Three", symbol: { fill: purple } },
+              { name: "Four", symbol: { fill: blue } },
             ]}
           />
           <VictoryAxis />
@@ -507,15 +534,20 @@ export default class VictoryZoomContainerDemo extends React.Component<
           <VictoryAxis dependentAxis />
         </VictoryChart>
         <VictoryChart
+          theme={VictoryTheme.clean}
           horizontal
           style={{ parent: parentStyle }}
           containerComponent={<VictoryZoomContainer zoomDimension="x" />}
         >
           <VictoryBar
-            style={{ data: { stroke: "#333", fill: "#888", opacity: 0.4 } }}
             data={this.state.data}
             x="a"
             y="b"
+            style={{
+              data: {
+                fill: orange,
+              },
+            }}
           />
           <VictoryAxis />
           <VictoryAxis dependentAxis />

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -424,9 +424,10 @@ export const clean: VictoryThemeDefinition = {
     {
       style: {
         data: {
-          fill: red["100"],
-          stroke: red["500"],
+          fill: blue["100"],
+          stroke: blue["500"],
           strokeWidth: 2,
+          opacity: 0.4,
         },
         labels: Object.assign({}, baseLabelStyles, {
           padding: 5,

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -332,8 +332,9 @@ export const clean: VictoryThemeDefinition = {
     colorScale,
     gutter: 24,
     borderPadding: 10,
-    orientation: "vertical",
+    orientation: "horizontal",
     titleOrientation: "top",
+    centerTitle: true,
     style: {
       data: {
         type: "circle",

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -330,15 +330,16 @@ export const clean: VictoryThemeDefinition = {
   label: baseLabelStyles,
   legend: {
     colorScale,
-    gutter: 10,
+    gutter: 24,
+    borderPadding: 10,
     orientation: "vertical",
     titleOrientation: "top",
     style: {
       data: {
         type: "circle",
       },
-      labels: { ...baseLabelStyles, fontSize: 14 },
-      title: Object.assign({}, baseLabelStyles, { padding, fontSize: 20 }),
+      labels: { ...baseLabelStyles, fontSize: 12 },
+      title: Object.assign({}, baseLabelStyles, { padding, fontSize: 16 }),
       border: { stroke: gray["200"], strokeWidth: 2, padding: 16 },
     },
   },


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR updates the following victory demos to use the new clean theme:
| Demo Name | Screenshot |
| --- | --- |
| legend demo | ![Screenshot 2024-10-14 at 10 59 18 AM](https://github.com/user-attachments/assets/61d67d02-59c2-4c92-ba30-7c77537fe138) |
| ouia demo | ![Screenshot 2024-10-14 at 10 59 31 AM](https://github.com/user-attachments/assets/95552b53-2396-435c-a319-ca321f33cc02) |
| error bar demo | ![Screenshot 2024-10-14 at 10 59 53 AM](https://github.com/user-attachments/assets/02475c7b-8818-4ec4-a250-74f96408a037) |
| voronoi demo | ![Screenshot 2024-10-14 at 11 00 15 AM](https://github.com/user-attachments/assets/b446f474-2a8e-4a4a-8443-e4fc9f833363) |
| shared events demo | ![Screenshot 2024-10-14 at 11 00 23 AM](https://github.com/user-attachments/assets/50acbf80-6115-4a59-af75-bbef8cfaf205) |
| brush container demo | ![Screenshot 2024-10-14 at 11 00 35 AM](https://github.com/user-attachments/assets/fb7e85db-d081-427e-8f94-1bc547ec93b8) |
| brush line demo | ![Screenshot 2024-10-14 at 11 00 46 AM](https://github.com/user-attachments/assets/303adff5-0d9b-42c2-b750-eefdbb71b092) |
| create container demo | ![Screenshot 2024-10-14 at 11 01 06 AM](https://github.com/user-attachments/assets/6c4c10c5-942a-4e93-a10e-23aeaf2f3d2d) |
| cursor container demo | ![Screenshot 2024-10-14 at 11 01 20 AM](https://github.com/user-attachments/assets/894939bd-928f-48b8-b139-07cba0c43a93) |
| draggable demo | ![Screenshot 2024-10-14 at 11 03 14 AM](https://github.com/user-attachments/assets/cfc6636d-df49-441a-b5e7-de6d97dc3799) |
| label demo | ![Screenshot 2024-10-14 at 11 03 34 AM](https://github.com/user-attachments/assets/f6bcd50b-3eb1-421a-bc0e-eae61a1a3ad5) |
| selection demo | ![Screenshot 2024-10-14 at 11 04 02 AM](https://github.com/user-attachments/assets/994febf0-4245-452e-8e77-7af9959ec87a) |
| tooltip demo | ![Screenshot 2024-10-14 at 11 04 18 AM](https://github.com/user-attachments/assets/490f3eb8-7171-4d53-b58b-4392274735c7) |
| primitive demo | ![Screenshot 2024-10-14 at 11 00 02 AM](https://github.com/user-attachments/assets/598483d9-84d8-49d7-9e87-149ace60302c) |
| selection container demo | ![Screenshot 2024-10-14 at 11 04 45 AM](https://github.com/user-attachments/assets/c1f078eb-a76e-43dd-91c1-c3b597bd90c5) |
| voronoi container demo | ![Screenshot 2024-10-14 at 11 05 34 AM](https://github.com/user-attachments/assets/e04efa00-dad9-4921-ad70-ef1a23fd0e74) |
| zoom container demo | ![2024-10-14 11 06 02](https://github.com/user-attachments/assets/529028a9-979a-4769-b0c4-ffb1d6aa2a27) |

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

These demos have been manually checked on Chrome and Safari on MacOS.
