### PR TITLE
Compatible unique id gen

### DIFF
--- a/.changeset/soft-balloons-wink.md
+++ b/.changeset/soft-balloons-wink.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+replace useId for backwards compatibility

--- a/packages/victory-core/src/victory-portal/victory-portal.tsx
+++ b/packages/victory-core/src/victory-portal/victory-portal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import { defaults, uniqueId } from "lodash";
 import * as Log from "../victory-util/log";
 import * as Helpers from "../victory-util/helpers";
 import { usePortalContext } from "./portal-context";
@@ -15,7 +15,7 @@ const defaultProps: Partial<VictoryPortalProps> = {
 
 export const VictoryPortal = (initialProps: VictoryPortalProps) => {
   const props = { ...defaultProps, ...initialProps };
-  const id = React.useId();
+  const id = uniqueId();
   const portalContext = usePortalContext();
 
   if (!portalContext) {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removes the use of `useId` to remain compatible with older versions of react

Fixes # https://github.com/FormidableLabs/victory/issues/2914

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

I tested this in a simple create-vite app with react 16. I also tested in a next app to make sure the ID generated doesn't break anything with SSR. It seems safe due to the component needing to be client rendered. I don't think any other randomness-related issues should be present.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
