### PR TITLE
Clean theme optimizations

### DIFF
--- a/.changeset/dry-books-invite.md
+++ b/.changeset/dry-books-invite.md
@@ -1,0 +1,5 @@
+---
+"victory-core": minor
+---
+
+Clean theme color updates and other minor adjustments

--- a/demo/ts/app.tsx
+++ b/demo/ts/app.tsx
@@ -32,6 +32,7 @@ import PrimitivesDemo from "./components/primitives-demo";
 import ScatterDemo from "./components/victory-scatter-demo";
 import SelectionDemo from "./components/selection-demo";
 import StackDemo from "./components/victory-stack-demo";
+import StackedThemeDemos from "./components/stacked-theme-demo";
 import TooltipDemo from "./components/victory-tooltip-demo";
 import VictoryDemo from "./components/victory-demo";
 import VictorySelectionContainerDemo from "./components/victory-selection-container-demo";
@@ -84,6 +85,7 @@ const MAP = {
   "/scatter": { component: ScatterDemo, name: "ScatterDemo" },
   "/selection": { component: SelectionDemo, name: "SelectionDemo" },
   "/stack": { component: StackDemo, name: "StackDemo" },
+  "/stacked-theme": { component: StackedThemeDemos, name: "StackedThemeDemos" },
   "/tooltip": { component: TooltipDemo, name: "TooltipDemo" },
   "/victory": { component: VictoryDemo, name: "VictoryDemo" },
   "/victory-selection-container": {

--- a/demo/ts/components/canvas-demo.tsx
+++ b/demo/ts/components/canvas-demo.tsx
@@ -13,7 +13,7 @@ import {
   CanvasGroup,
   CanvasPoint,
 } from "victory-canvas";
-import { VictoryTheme } from "victory-core/lib";
+import { VictoryTheme } from "victory-core";
 
 const populationData = [
   {

--- a/demo/ts/components/events-demo.tsx
+++ b/demo/ts/components/events-demo.tsx
@@ -77,7 +77,7 @@ class EventsDemo extends React.Component {
                           return {
                             style: {
                               ...props.style,
-                              fill: themeColors.pink,
+                              fill: themeColors.red,
                             },
                           };
                         },

--- a/demo/ts/components/group-demo.tsx
+++ b/demo/ts/components/group-demo.tsx
@@ -11,7 +11,7 @@ import { VictoryTooltip } from "victory-tooltip";
 import { VictoryVoronoi } from "victory-voronoi";
 import { VictoryBoxPlot } from "victory-box-plot";
 import { range, random } from "lodash";
-import { VictoryTheme } from "victory-core/lib";
+import { VictoryTheme } from "victory-core";
 
 const themeColors = VictoryTheme.clean.palette?.colors || {};
 class App extends React.Component {

--- a/demo/ts/components/horizontal-demo.tsx
+++ b/demo/ts/components/horizontal-demo.tsx
@@ -145,7 +145,7 @@ class App extends React.Component {
           <VictoryBar
             style={{
               data: {
-                fill: themeColors.pink,
+                fill: themeColors.red,
               },
             }}
             horizontal

--- a/demo/ts/components/immutable-demo.tsx
+++ b/demo/ts/components/immutable-demo.tsx
@@ -33,7 +33,7 @@ const themeColors = VictoryTheme.clean.palette?.colors || {};
 const scatterFillStyle: VictoryStyleInterface = {
   data: {
     fill: ({ active }) =>
-      active ? themeColors.pink || "pink" : themeColors.blue || "blue",
+      active ? themeColors.red || "pink" : themeColors.blue || "blue",
   },
 };
 interface WrapperProps {

--- a/demo/ts/components/primitives-demo.tsx
+++ b/demo/ts/components/primitives-demo.tsx
@@ -111,7 +111,7 @@ class App extends React.Component<any, PrimitivesDemoState> {
                   cy={0}
                   startAngle={180}
                   endAngle={360}
-                  style={{ fill: themeColors.pink }}
+                  style={{ fill: themeColors.red }}
                 />
               }
             />

--- a/demo/ts/components/stacked-theme-demo.tsx
+++ b/demo/ts/components/stacked-theme-demo.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { VictoryArea } from "victory-area";
+import { VictoryBar } from "victory-bar";
+import { VictoryChart } from "victory-chart";
+import { VictoryStack } from "victory-stack";
+import {
+  ColorScalePropType,
+  VictoryTheme,
+  VictoryThemeDefinition,
+} from "victory-core";
+import { VictoryAxis } from "victory-axis";
+
+const data = [
+  {
+    x: 1,
+    y: 2,
+  },
+  {
+    x: 2,
+    y: 3,
+  },
+  {
+    x: 3,
+    y: 5,
+  },
+  {
+    x: 4,
+    y: 4,
+  },
+  {
+    x: 5,
+    y: 7,
+  },
+];
+
+const StackedChart = ({
+  theme = VictoryTheme.clean,
+  colorScale,
+  chartType = "area",
+  domainPadding,
+}: {
+  theme?: VictoryThemeDefinition;
+  colorScale?: ColorScalePropType;
+  chartType?: "area" | "bar";
+  domainPadding?: number;
+}) => {
+  const chartStyle: { [key: string]: React.CSSProperties } = {
+    parent: {
+      border: "1px solid #ccc",
+      width: "100%",
+      height: 400,
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+    },
+  };
+  const ChartComponent = chartType === "area" ? VictoryArea : VictoryBar;
+  return (
+    <VictoryChart
+      theme={theme}
+      domainPadding={domainPadding}
+      style={chartStyle}
+    >
+      <VictoryAxis label="X Axis" />
+      <VictoryAxis dependentAxis label="Y Axis" />
+      <VictoryStack colorScale={colorScale} aria-label="Victory Stack Demo">
+        <ChartComponent data={data} />
+        <ChartComponent data={data} />
+        <ChartComponent data={data} />
+        <ChartComponent data={data} />
+        <ChartComponent data={data} />
+      </VictoryStack>
+    </VictoryChart>
+  );
+};
+
+const colorScales: ColorScalePropType[] = [
+  "qualitative",
+  "heatmap",
+  "warm",
+  "cool",
+  "red",
+  "green",
+];
+
+class StackedThemeDemos extends React.Component {
+  render() {
+    const containerStyle: React.CSSProperties = {
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: "20px",
+    };
+
+    const wrapperStyle: React.CSSProperties = {
+      ...containerStyle,
+      flexDirection: "column",
+    };
+
+    return (
+      <div className="demo" style={containerStyle}>
+        <div style={wrapperStyle}>
+          <h2>Clean Theme</h2>
+          {colorScales.map((colorScale, i) => (
+            <StackedChart key={i} colorScale={colorScale} />
+          ))}
+          {colorScales.map((colorScale, i) => (
+            <StackedChart
+              key={i}
+              colorScale={colorScale}
+              chartType="bar"
+              domainPadding={20}
+            />
+          ))}
+        </div>
+        <div style={wrapperStyle}>
+          <h2>Material Theme</h2>
+          {colorScales.map((colorScale, i) => (
+            <StackedChart
+              key={i}
+              theme={VictoryTheme.material}
+              colorScale={colorScale}
+            />
+          ))}
+          {colorScales.map((colorScale, i) => (
+            <StackedChart
+              key={i}
+              theme={VictoryTheme.material}
+              colorScale={colorScale}
+              chartType="bar"
+              domainPadding={20}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default StackedThemeDemos;

--- a/demo/ts/components/victory-area-demo.tsx
+++ b/demo/ts/components/victory-area-demo.tsx
@@ -183,7 +183,7 @@ export default class VictoryAreaDemo extends React.Component<
             data={this.state.data}
             style={{
               data: {
-                fill: VictoryTheme.clean.palette?.colors?.pink,
+                fill: VictoryTheme.clean.palette?.colors?.red,
               },
             }}
           />

--- a/demo/ts/components/victory-area-demo.tsx
+++ b/demo/ts/components/victory-area-demo.tsx
@@ -133,8 +133,6 @@ export default class VictoryAreaDemo extends React.Component<
       justifyContent: "center",
     };
 
-    const dataStyle = { strokeWidth: 2, fillOpacity: 0.4 };
-
     return (
       <div className="demo" style={containerStyle}>
         <VictoryChart theme={VictoryTheme.clean} style={style}>

--- a/demo/ts/components/victory-bar-demo.tsx
+++ b/demo/ts/components/victory-bar-demo.tsx
@@ -153,7 +153,7 @@ export default class VictoryBarDemo extends React.Component<
           <VictoryBar
             theme={VictoryTheme.clean}
             style={{
-              data: { fill: VictoryTheme.clean.palette?.colors?.pink },
+              data: { fill: VictoryTheme.clean.palette?.colors?.red },
             }}
             scale={{ y: "log", x: "linear" }}
             horizontal
@@ -509,7 +509,7 @@ export default class VictoryBarDemo extends React.Component<
           style={{
             parent: parentStyle,
             data: {
-              fill: VictoryTheme.clean.palette?.colors?.pink,
+              fill: VictoryTheme.clean.palette?.colors?.red,
             },
           }}
           labels={["a", "b", "c", "d", "e"]}

--- a/demo/ts/components/victory-box-plot-demo.tsx
+++ b/demo/ts/components/victory-box-plot-demo.tsx
@@ -145,7 +145,7 @@ export default class VictoryBoxPlotDemo extends React.Component<
             ]}
             style={{
               q1: { fill: VictoryTheme.clean.palette?.colors?.yellow },
-              q3: { fill: VictoryTheme.clean.palette?.colors?.pink },
+              q3: { fill: VictoryTheme.clean.palette?.colors?.red },
             }}
           />
         </VictoryChart>
@@ -244,7 +244,7 @@ export default class VictoryBoxPlotDemo extends React.Component<
               median: "bottom",
             }}
             style={{
-              q1: { fill: VictoryTheme.clean.palette?.colors?.pink },
+              q1: { fill: VictoryTheme.clean.palette?.colors?.red },
               q3: { fill: VictoryTheme.clean.palette?.colors?.purple },
             }}
           />

--- a/demo/ts/components/victory-brush-container-demo.tsx
+++ b/demo/ts/components/victory-brush-container-demo.tsx
@@ -322,7 +322,7 @@ export default class VictoryBrushContainerDemo extends React.Component<
             <VictoryBar
               style={{
                 data: {
-                  fill: themeColors.pink,
+                  fill: themeColors.red,
                 },
               }}
               data={[

--- a/demo/ts/components/victory-chart-demo.tsx
+++ b/demo/ts/components/victory-chart-demo.tsx
@@ -261,7 +261,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
           </VictoryChart>
 
           <VictoryChart style={chartStyle} theme={VictoryTheme.clean}>
-            <VictoryScatter style={{ data: { fill: themeColors.pink } }} />
+            <VictoryScatter style={{ data: { fill: themeColors.red } }} />
           </VictoryChart>
 
           <VictoryChart
@@ -509,7 +509,7 @@ class VictoryChartDemo extends React.Component<any, VictoryChartDemoState> {
             theme={VictoryTheme.clean}
           >
             <VictoryLine
-              style={{ data: { stroke: themeColors.pink } }}
+              style={{ data: { stroke: themeColors.red } }}
               y={(data) => Math.sin(2 * Math.PI * data.x)}
             />
 

--- a/demo/ts/components/victory-cursor-container-demo.tsx
+++ b/demo/ts/components/victory-cursor-container-demo.tsx
@@ -178,7 +178,7 @@ class App extends React.Component<any, VictoryCursorContainerStateInterface> {
             <VictoryGroup style={chartStyle}>
               <VictoryScatter
                 style={{
-                  data: { fill: themeColors.pink },
+                  data: { fill: themeColors.red },
                 }}
                 size={({ active }) => (active ? 5 : 3)}
                 labels={({ datum }) => datum.y}

--- a/demo/ts/components/victory-demo.tsx
+++ b/demo/ts/components/victory-demo.tsx
@@ -10,7 +10,7 @@ import { VictoryScatter } from "victory-scatter";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
 import { VictorySelectionContainer } from "victory-selection-container";
-import { VictoryTheme } from "victory-core/lib";
+import { VictoryTheme } from "victory-core";
 
 export default class App extends React.Component {
   render() {

--- a/demo/ts/components/victory-histogram-demo.tsx
+++ b/demo/ts/components/victory-histogram-demo.tsx
@@ -327,7 +327,7 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
           style={{
             parent: parentStyle,
             data: {
-              fill: VictoryTheme.clean.palette?.colors?.pink,
+              fill: VictoryTheme.clean.palette?.colors?.red,
             },
           }}
           events={[
@@ -465,7 +465,7 @@ export default class App extends React.Component<{}, VictoryBarDemoState> {
           <VictoryHistogram
             horizontal
             style={{
-              data: { fill: VictoryTheme.clean.palette?.colors?.pink },
+              data: { fill: VictoryTheme.clean.palette?.colors?.red },
             }}
             data={this.dateData}
           />

--- a/demo/ts/components/victory-label-demo.tsx
+++ b/demo/ts/components/victory-label-demo.tsx
@@ -160,7 +160,7 @@ export default class App extends React.Component<any, {}> {
           theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: themeColors.pink, opacity: 0.3 }}
+              backgroundStyle={{ fill: themeColors.red, opacity: 0.3 }}
               textAnchor="start"
               verticalAnchor="end"
               text={
@@ -175,7 +175,7 @@ export default class App extends React.Component<any, {}> {
           theme={VictoryTheme.clean}
           labelComponent={
             <VictoryLabel
-              backgroundStyle={{ fill: themeColors.pink, opacity: 0.3 }}
+              backgroundStyle={{ fill: themeColors.red, opacity: 0.3 }}
               textAnchor="end"
               verticalAnchor="middle"
               text={
@@ -278,7 +278,7 @@ export default class App extends React.Component<any, {}> {
           labelComponent={
             <VictoryLabel
               backgroundStyle={[
-                { fill: themeColors.pink },
+                { fill: themeColors.red },
                 { fill: themeColors.blue },
                 { fill: themeColors.purple },
                 { fill: themeColors.red },
@@ -303,7 +303,7 @@ export default class App extends React.Component<any, {}> {
             <VictoryLabel
               angle={20}
               backgroundStyle={[
-                { fill: themeColors.pink },
+                { fill: themeColors.red },
                 { fill: themeColors.blue },
               ]}
               text={[

--- a/demo/ts/components/victory-line-demo.tsx
+++ b/demo/ts/components/victory-line-demo.tsx
@@ -205,7 +205,7 @@ export default class VictoryLineDemo extends React.Component<
           theme={VictoryTheme.clean}
           style={{
             parent: parentStyle,
-            data: { stroke: VictoryTheme.clean.palette?.colors?.pink },
+            data: { stroke: VictoryTheme.clean.palette?.colors?.red },
           }}
           data={this.state.arrayData}
           x={0}

--- a/demo/ts/components/victory-tooltip-demo.tsx
+++ b/demo/ts/components/victory-tooltip-demo.tsx
@@ -8,7 +8,7 @@ import { VictoryScatter } from "victory-scatter";
 import { VictoryTooltip } from "victory-tooltip";
 import { VictoryCandlestick } from "victory-candlestick";
 import { VictoryErrorBar } from "victory-errorbar";
-import { VictoryTheme } from "victory-core/lib";
+import { VictoryTheme } from "victory-core";
 
 class App extends React.Component {
   render() {

--- a/demo/ts/components/victory-voronoi-demo.tsx
+++ b/demo/ts/components/victory-voronoi-demo.tsx
@@ -69,7 +69,7 @@ class VoronoiDemo extends React.Component<any, VoronoiDemoStateProps> {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryVoronoi
-            theme={VictoryTheme.clean}
+            theme={VictoryTheme.material}
             style={{ parent: parentStyle }}
           />
 

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -38,12 +38,6 @@ const red = {
   "700": "#D31A3D",
   "900": "#BA1E45",
 };
-const pink = {
-  "100": "#FFDAF6",
-  "300": "#F99DE2",
-  "500": "#FF08C2",
-  "900": "#B2158B",
-};
 const purple = {
   "100": "#EDE3FE",
   "300": "#CDB0FF",
@@ -86,7 +80,6 @@ const colors = {
   red: red["500"],
   purple: purple["500"],
   teal: teal["500"],
-  pink: pink["500"],
 };
 
 const colorScale = Object.values(colors);

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -131,7 +131,7 @@ const padding = 8;
 const baseProps = {
   width: 450,
   height: 300,
-  padding: 50,
+  padding: 60,
   colorScale,
 };
 // *
@@ -198,7 +198,7 @@ export const clean: VictoryThemeDefinition = {
           strokeLinejoin,
         },
         axisLabel: Object.assign({}, centeredLabelStyles, {
-          padding,
+          padding: 35,
           stroke: "transparent",
         }),
         grid: {

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -75,12 +75,11 @@ const green = {
 
 const colors = {
   blue: blue["500"],
-  pink: pink["500"],
-  teal: teal["500"],
+  cyan: cyan["500"],
   purple: purple["500"],
   green: green["500"],
   orange: orange["500"],
-  cyan: cyan["500"],
+  teal: teal["500"],
   red: red["500"],
   yellow: yellow["500"],
 };
@@ -265,9 +264,9 @@ export const clean: VictoryThemeDefinition = {
         medianLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
         min: { padding, stroke: gray["400"], strokeWidth: 2 },
         minLabels: Object.assign({}, baseLabelStyles, { padding: 3 }),
-        q1: { padding, fill: teal["500"], rx: borderRadius, strokeWidth: 2 },
+        q1: { padding, fill: colorScale[0], rx: borderRadius, strokeWidth: 2 },
         q1Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
-        q3: { padding, fill: cyan["500"], rx: borderRadius },
+        q3: { padding, fill: colorScale[1], rx: borderRadius },
         q3Labels: Object.assign({}, baseLabelStyles, { padding: 3 }),
       },
       boxWidth: 20,

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -94,6 +94,8 @@ const redPalette = [red["500"], red["300"], red["100"]];
 const greenPalette = [green["500"], green["300"], green["100"]];
 const bluePalette = [blue["500"], blue["300"], blue["100"]];
 
+const defaultColor = blue["500"];
+
 // *
 // * Typography
 // *
@@ -155,7 +157,7 @@ export const clean: VictoryThemeDefinition = {
     {
       style: {
         data: {
-          fill: blue["500"],
+          fill: defaultColor,
           strokeWidth: 2,
           fillOpacity: 0.5,
         },
@@ -243,7 +245,7 @@ export const clean: VictoryThemeDefinition = {
     {
       style: {
         data: {
-          fill: blue["500"],
+          fill: defaultColor,
           padding,
           strokeWidth: 1,
           fillOpacity: 0.5,
@@ -350,7 +352,7 @@ export const clean: VictoryThemeDefinition = {
         data: {
           fill: "transparent",
           opacity: 1,
-          stroke: blue["500"],
+          stroke: defaultColor,
           strokeWidth: 2,
           strokeLinecap,
           strokeLinejoin,
@@ -387,7 +389,7 @@ export const clean: VictoryThemeDefinition = {
     {
       style: {
         data: {
-          fill: purple["500"],
+          fill: defaultColor,
           opacity: 1,
           stroke: "transparent",
           strokeWidth: 0,
@@ -426,9 +428,8 @@ export const clean: VictoryThemeDefinition = {
       style: {
         data: {
           fill: blue["100"],
-          stroke: blue["500"],
+          stroke: defaultColor,
           strokeWidth: 2,
-          opacity: 0.4,
         },
         labels: Object.assign({}, baseLabelStyles, {
           padding: 5,

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -28,12 +28,14 @@ const orange = {
   "100": "#FEE2D5",
   "300": "#FFA981",
   "500": "#FF6F2C",
+  "700": "#FF4E1B",
   "900": "#D74D26",
 };
 const red = {
   "100": "#FFDCE5",
   "300": "#FF9EB7",
   "500": "#F82B60",
+  "700": "#D31A3D",
   "900": "#BA1E45",
 };
 const pink = {
@@ -52,6 +54,7 @@ const blue = {
   "100": "#CFDFFF",
   "300": "#9CC7FF",
   "500": "#2D7FF9",
+  "700": "#0056B3",
   "900": "#2750AE",
 };
 const cyan = {
@@ -70,28 +73,54 @@ const green = {
   "100": "#D1F7C4",
   "300": "#93E088",
   "500": "#20C933",
+  "700": "#1B9B2A",
   "900": "#338A17",
 };
 
 const colors = {
   blue: blue["500"],
   cyan: cyan["500"],
-  purple: purple["500"],
   green: green["500"],
-  orange: orange["500"],
-  teal: teal["500"],
-  red: red["500"],
   yellow: yellow["500"],
+  orange: orange["500"],
+  red: red["500"],
+  purple: purple["500"],
+  teal: teal["500"],
+  pink: pink["500"],
 };
 
 const colorScale = Object.values(colors);
-const grayscale = [gray["200"], gray["400"], gray["600"], gray["900"]];
-const warm = [yellow["500"], orange["500"], red["500"], pink["500"]];
-const cool = [cyan["500"], teal["500"], blue["500"], purple["500"]];
-const heatmap = [green["500"], yellow["500"], red["500"]];
-const redPalette = [red["500"], red["300"], red["100"]];
-const greenPalette = [green["500"], green["300"], green["100"]];
-const bluePalette = [blue["500"], blue["300"], blue["100"]];
+const grayscale = [
+  gray["100"],
+  gray["300"],
+  gray["500"],
+  gray["700"],
+  gray["900"],
+];
+const warm = [
+  yellow["300"],
+  yellow["500"],
+  orange["500"],
+  orange["900"],
+  red["500"],
+];
+const cool = [
+  purple["500"],
+  blue["500"],
+  cyan["500"],
+  teal["500"],
+  green["500"],
+];
+const heatmap = [
+  green["900"],
+  green["500"],
+  yellow["500"],
+  orange["500"],
+  red["500"],
+];
+const redPalette = Object.values(red);
+const greenPalette = Object.values(green);
+const bluePalette = Object.values(blue);
 
 const defaultColor = blue["500"];
 

--- a/packages/victory-core/src/victory-theme/clean.tsx
+++ b/packages/victory-core/src/victory-theme/clean.tsx
@@ -285,8 +285,8 @@ export const clean: VictoryThemeDefinition = {
         labels: Object.assign({}, baseLabelStyles, { padding: 5 }),
       },
       candleColors: {
-        positive: teal["500"],
-        negative: orange["500"],
+        positive: green["500"],
+        negative: red["500"],
       },
       wickStrokeWidth: 2,
     },

--- a/packages/victory-core/src/victory-theme/material.tsx
+++ b/packages/victory-core/src/victory-theme/material.tsx
@@ -67,7 +67,7 @@ const padding = 8;
 const baseProps = {
   width: 350,
   height: 350,
-  padding: 60,
+  padding: 50,
 };
 // *
 // * Labels
@@ -127,7 +127,7 @@ export const material: VictoryThemeDefinition = {
           strokeLinejoin,
         },
         axisLabel: Object.assign({}, centeredLabelStyles, {
-          padding: 35,
+          padding,
           stroke: "transparent",
         }),
         grid: {

--- a/packages/victory-core/src/victory-theme/material.tsx
+++ b/packages/victory-core/src/victory-theme/material.tsx
@@ -67,7 +67,7 @@ const padding = 8;
 const baseProps = {
   width: 350,
   height: 350,
-  padding: 50,
+  padding: 60,
 };
 // *
 // * Labels
@@ -127,7 +127,7 @@ export const material: VictoryThemeDefinition = {
           strokeLinejoin,
         },
         axisLabel: Object.assign({}, centeredLabelStyles, {
-          padding,
+          padding: 35,
           stroke: "transparent",
         }),
         grid: {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a stack bar/area theme demo:
![2024-10-15 14 32 13](https://github.com/user-attachments/assets/6de4d8da-ac69-4c0b-b7db-66b7470e5371)


And also updates the following for the clean theme:
- [x] Default color should always be the same between all charts
- [x] Remove pink color
- [x] Candlestick colors positive and neg should be green and red by default
- [x] Box plot should use the first two qualitative color scale colors
- [x] Adjust axis padding
- [x] Fix broken translucent PadAngle demo

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

These demos have been manually checked on Chrome and Safari on MacOS.
