### PR TITLE
Sorted numerical values

### DIFF
--- a/packages/victory-core/src/victory-util/data.ts
+++ b/packages/victory-core/src/victory-util/data.ts
@@ -311,7 +311,14 @@ export function formatData(
         return dataArr;
       }, []);
 
-  const sortedData = sortData(data, props.sortKey, props.sortOrder);
+  const sortedData = sortData(data, props.sortKey, props.sortOrder).map(
+    (datum, indexz) => {
+      return {
+        ...datum,
+        _x: indexz + 1,
+      };
+    },
+  );
   const cleanedData = cleanData(sortedData, props);
   return addEventKeys(props, cleanedData);
 }

--- a/packages/victory-core/src/victory-util/data.ts
+++ b/packages/victory-core/src/victory-util/data.ts
@@ -282,43 +282,43 @@ export function formatData(
 
   const data = preformattedData
     ? dataset
-    : dataset.reduce((dataArr, datum, index) => {
-        // eslint-disable-line complexity
-        const parsedDatum = parseDatum(datum);
-        const fallbackValues = { x: index, y: parsedDatum };
-        const processedValues = expectedKeys!.reduce((memo, type) => {
-          const processedValue = accessor[type](parsedDatum);
-          const value =
-            processedValue !== undefined
-              ? processedValue
-              : fallbackValues[type];
-          if (value !== undefined) {
-            if (typeof value === "string" && stringMap[type]) {
-              memo[`${type}Name`] = value;
-              memo[`_${type}`] = stringMap[type][value];
-            } else {
-              memo[`_${type}`] = value;
+    : sortData(dataset, props.sortKey, props.sortOrder).reduce(
+        (dataArr, datum, index) => {
+          // eslint-disable-line complexity
+          const parsedDatum = parseDatum(datum);
+          const fallbackValues = { x: index, y: parsedDatum };
+          const processedValues = expectedKeys!.reduce((memo, type) => {
+            const processedValue = accessor[type](parsedDatum);
+            const value =
+              processedValue !== undefined
+                ? processedValue
+                : fallbackValues[type];
+            if (value !== undefined) {
+              if (typeof value === "string" && stringMap[type]) {
+                memo[`${type}Name`] = value;
+                memo[`_${type}`] = stringMap[type][value];
+              } else {
+                memo[`_${type}`] = type === "x" ? index + 1 : value;
+              }
             }
+            return memo;
+          }, {});
+
+          const formattedDatum = Object.assign(
+            {},
+            processedValues,
+            parsedDatum,
+          );
+          if (!isEmpty(formattedDatum)) {
+            dataArr.push(formattedDatum);
           }
-          return memo;
-        }, {});
 
-        const formattedDatum = Object.assign({}, processedValues, parsedDatum);
-        if (!isEmpty(formattedDatum)) {
-          dataArr.push(formattedDatum);
-        }
+          return dataArr;
+        },
+        [],
+      );
 
-        return dataArr;
-      }, []);
-
-  const sortedData = sortData(data, props.sortKey, props.sortOrder).map(
-    (datum, indexz) => {
-      return {
-        ...datum,
-        _x: indexz + 1,
-      };
-    },
-  );
+  const sortedData = sortData(data, props.sortKey, props.sortOrder);
   const cleanedData = cleanData(sortedData, props);
   return addEventKeys(props, cleanedData);
 }

--- a/packages/victory-core/src/victory-util/data.ts
+++ b/packages/victory-core/src/victory-util/data.ts
@@ -297,8 +297,11 @@ export function formatData(
               if (typeof value === "string" && stringMap[type]) {
                 memo[`${type}Name`] = value;
                 memo[`_${type}`] = stringMap[type][value];
+              } else if (type === "x" && props.sortKey) {
+                memo[`${type}Name`] = value.toString();
+                memo[`_${type}`] = index + 1;
               } else {
-                memo[`_${type}`] = type === "x" ? index + 1 : value;
+                memo[`_${type}`] = value;
               }
             }
             return memo;


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Uses sorted values if a sortKey is specified when `x` is a number

Fixes https://github.com/FormidableLabs/victory/issues/2881

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

To reproduce, create a bar chart that has numerical `x` values and specify a sortKey
NOTE: There may be a different bug in that a key of `y` won't sort, you have to name it and use the `y` prop to specify your value, and then sort off that value Ex:
```ts
<VictoryBar
  data={data2015}
  y="earnings"
  sortKey="earnings"
/>
```

Unsorted, numerical values will attempt to space along independent axis:
```ts
<VictoryChart domainPadding={20} theme={VictoryTheme.material}>
  <VictoryAxis />
  <VictoryAxis dependentAxis tickFormat={(x) => `$${x / 1000}k`} />
  <VictoryBar
      data={[
          { x: 1, earnings: 18000 },
          { x: 2, earnings: 13250 },
          { x: 3, earnings: 15000 },
          { x: 14, earnings: 12000 },
       ]}
       y="earnings"
    />
</VictoryChart>
```
![Screenshot 2024-10-17 at 10 22 56 AM](https://github.com/user-attachments/assets/388495b0-8de6-4b8f-8c49-2f02e0674d6c)

Sorting this data with `sortKey` now sorts the bars (this is the fix):
![Screenshot 2024-10-17 at 10 25 46 AM](https://github.com/user-attachments/assets/8a546a7d-f402-4c71-acac-bbecae70e5cb)

Notice that the spacing is no longer applied, since sorting breaks down any sort of relative comparisons. This also means axis labels must be managed, but I don't feel like either of those two scenarios are new or regressions.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
