### PR TITLE
fix: make sure VictoryPortal id does not change between re-renders

### DIFF
--- a/.changeset/four-melons-divide.md
+++ b/.changeset/four-melons-divide.md
@@ -1,0 +1,5 @@
+---
+"victory-core": minor
+---
+
+Fix VictoryPortal id changing for every render

--- a/packages/victory-core/src/victory-portal/victory-portal.tsx
+++ b/packages/victory-core/src/victory-portal/victory-portal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { defaults, uniqueId } from "lodash";
 import * as Log from "../victory-util/log";
 import * as Helpers from "../victory-util/helpers";
@@ -15,7 +15,7 @@ const defaultProps: Partial<VictoryPortalProps> = {
 
 export const VictoryPortal = (initialProps: VictoryPortalProps) => {
   const props = { ...defaultProps, ...initialProps };
-  const id = uniqueId();
+  const [id] = useState(uniqueId());
   const portalContext = usePortalContext();
 
   if (!portalContext) {


### PR DESCRIPTION
### Description

Fixes # [(2928)](https://github.com/FormidableLabs/victory/issues/2928)

This PR makes sure generated id of portal does not change during it's lifetime.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I have forked victory and tested the change on my code which was affected by the bug.

