### PR TITLE
fix for 'Candlestick labels show incorrect midpoint label'

### DIFF
--- a/.changeset/wicked-fishes-flow.md
+++ b/.changeset/wicked-fishes-flow.md
@@ -1,0 +1,5 @@
+---
+"victory-candlestick": patch
+---
+
+Prevents boolean passed to candlestick labels prop from rendering

--- a/packages/victory-candlestick/src/victory-candlestick.test.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.test.tsx
@@ -187,6 +187,17 @@ describe("components/victory-candlestick", () => {
       const points = container.querySelectorAll("rect");
       expect(points).toHaveLength(1);
     });
+
+    it("does not render a label when it receives true as the lablels prop", () => {
+      const data = [{ x: 1, open: 10, close: 17, high: 19, low: 8 }];
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const { container } = render(<VictoryCandlestick data={data} labels />);
+      const trueLabel = Array.from(
+        container.querySelectorAll("text[id^=candlestick-labels] > tspan"),
+      ).find((t) => t.textContent === "true");
+      expect(trueLabel).toBe(undefined);
+    });
   });
 
   describe("event handling", () => {

--- a/packages/victory-candlestick/src/victory-candlestick.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.tsx
@@ -28,7 +28,7 @@ export interface VictoryCandlestickStyleInterface {
   data?: VictoryStyleObject;
   high?: VictoryStyleObject;
   highLabels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
-  labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
+  labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[] | boolean;
   low?: VictoryStyleObject;
   lowLabels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
   open?: VictoryStyleObject;
@@ -271,7 +271,8 @@ class VictoryCandlestickBase extends React.Component<VictoryCandlestickProps> {
           );
           if (
             (labelProps as any).text !== undefined &&
-            (labelProps as any).text !== null
+            (labelProps as any).text !== null &&
+            typeof (labelProps as any).text !== "boolean"
           ) {
             return React.cloneElement(labelComponent, labelProps);
           }

--- a/packages/victory-candlestick/src/victory-candlestick.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.tsx
@@ -28,7 +28,7 @@ export interface VictoryCandlestickStyleInterface {
   data?: VictoryStyleObject;
   high?: VictoryStyleObject;
   highLabels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
-  labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[] | boolean;
+  labels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
   low?: VictoryStyleObject;
   lowLabels?: VictoryLabelStyleObject | VictoryLabelStyleObject[];
   open?: VictoryStyleObject;


### PR DESCRIPTION
### Description

Adds a check for a boolean value in label text and does not return a label component if that is the case.

Fixes #2923 
