### PR TITLE
add types for create container, rm invalid prop

### DIFF
--- a/demo/ts/components/create-container-demo.tsx
+++ b/demo/ts/components/create-container-demo.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
-import PropTypes from "prop-types";
 import { round } from "lodash";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";
-import { createContainer } from "victory-create-container";
+import { ContainerType, createContainer } from "victory-create-container";
 import { VictoryBar } from "victory-bar";
 import { VictoryLine } from "victory-line";
 import { VictoryScatter } from "victory-scatter";
@@ -15,7 +14,11 @@ import { VictoryTheme } from "victory-core";
 
 const themeColors = VictoryTheme.clean.palette?.colors || {};
 
-const Charts = ({ behaviors }) => {
+const Charts = ({
+  behaviors,
+}: {
+  behaviors: [ContainerType, ContainerType];
+}) => {
   const containerStyle: React.CSSProperties = {
     display: "flex",
     flexDirection: "row",
@@ -26,7 +29,7 @@ const Charts = ({ behaviors }) => {
   const chartStyle = {
     parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" },
   };
-  const CustomContainer: any = createContainer(behaviors[0], behaviors[1]);
+  const CustomContainer = createContainer(behaviors[0], behaviors[1]);
   const behaviorsList = behaviors.map((behavior) => `"${behavior}"`).join(", ");
 
   return (
@@ -50,7 +53,6 @@ const Charts = ({ behaviors }) => {
                   flyoutStyle={{ fill: "white" }}
                 />
               }
-              selectedDomain={{ x: [1.5, 2] }}
             />
           }
         >
@@ -119,7 +121,7 @@ const Charts = ({ behaviors }) => {
           style={{ parent: chartStyle.parent }}
           containerComponent={
             <CustomContainer
-              labels={({ datum }) => round(datum.x, 2)}
+              labels={({ datum }) => round(datum.x, 2).toString()}
               cursorLabel={({ datum }) => round(datum.x, 2)}
               selectionStyle={{
                 stroke: themeColors.red,
@@ -127,7 +129,6 @@ const Charts = ({ behaviors }) => {
                 fill: themeColors.red,
                 fillOpacity: 0.1,
               }}
-              selectedDomain={{ x: [0.4, 0.95], y: [0.5, 0.8] }}
               defaultCursorValue={0.99}
             />
           }
@@ -149,9 +150,7 @@ const Charts = ({ behaviors }) => {
         <VictoryChart
           theme={VictoryTheme.clean}
           style={chartStyle}
-          containerComponent={
-            <CustomContainer selectedDomain={{ x: [0, 0] }} />
-          }
+          containerComponent={<CustomContainer />}
         >
           <VictoryGroup style={chartStyle}>
             <VictoryScatter
@@ -229,9 +228,7 @@ const Charts = ({ behaviors }) => {
         <VictoryStack
           theme={VictoryTheme.clean}
           style={chartStyle}
-          containerComponent={
-            <CustomContainer selectedDomain={{ x: [1.5, 2.5], y: [-3, 4] }} />
-          }
+          containerComponent={<CustomContainer />}
         >
           <VictoryBar
             barWidth={({ active }) => (active ? 10 : 8)}
@@ -273,10 +270,6 @@ const Charts = ({ behaviors }) => {
       </div>
     </div>
   );
-};
-
-Charts.propTypes = {
-  behaviors: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 class App extends React.Component {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes `create-container-demo` passing an outdated prop, `selectedDomain` and it not being caught by TS. This was due to the `any` on the container as well as an implicit `any` on the demo's prop types. Removing this value instead of trying to map it to the new properties (like `zoomDomain`) has the fewest changes to the result.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Run demo locally

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

![Screenshot 2024-10-28 at 10 24 23 AM](https://github.com/user-attachments/assets/441fef52-eea2-41a3-9c0a-4ec6fc04485a)
