### PR TITLE
backwards generic params compatibility

### DIFF
--- a/.changeset/fuzzy-candles-rule.md
+++ b/.changeset/fuzzy-candles-rule.md
@@ -1,0 +1,5 @@
+---
+"victory-create-container": patch
+---
+
+update createContainer types to be backwards compatibile


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Updated types to allow for either prop types in generic or the `ContainerType` to be inferred. This helps types remain backwards compatible with older types https://github.com/eatyourpeas/victory/blob/9a20d57c111023867bbdf1a9f3b4835acd76f4d3/packages/victory-create-container/src/index.d.ts#L4

**NOTE** This isn't type safe. You can do
```
const VictoryZoomVoronoiContainer = createContainer<VictoryZoomContainerProps, VictoryBrushContainerProps>(
  'zoom',
  'voronoi',
);
``` 
and it won't complain. This was true in the older versions too since it was attempting to type JavaScript. Inferring the types is definitely the better option. To the point where **I am curious on if we should allow this behavior** 🤨

Fixes # https://github.com/FormidableLabs/victory/issues/2815

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Tested locally with old version
```
const VictoryZoomVoronoiContainer = createContainer<VictoryZoomContainerProps, VictoryVoronoiContainerProps>(
    'zoom',
    'voronoi',
);
```
And new version
```
const VictoryZoomVoronoiContainer = createContainer(
    'zoom',
    'voronoi',
);
```

Also, you can do this too, this is what is inferred with new version
```
const VictoryZoomVoronoiContainer = createContainer<'zoom', 'voronoi'>(
    'zoom',
    'voronoi',
);
```


### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
