### PR TITLE
fix 'Pie Chart ignores categories prop'

### DIFF
--- a/.changeset/proud-bugs-brush.md
+++ b/.changeset/proud-bugs-brush.md
@@ -1,0 +1,5 @@
+---
+"victory-pie": patch
+---
+
+Added logic to sort pie chart slices by categories prop

--- a/demo/ts/components/victory-pie-demo.tsx
+++ b/demo/ts/components/victory-pie-demo.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { random, range } from "lodash";
 import { VictoryPie } from "victory-pie";
 import { VictoryTooltip } from "victory-tooltip";
-import { VictoryTheme, LineSegment, Helpers } from "victory-core";
+import { VictoryTheme, Helpers } from "victory-core";
 
 interface VictoryPieDemoState {
   data: {

--- a/demo/ts/components/victory-pie-demo.tsx
+++ b/demo/ts/components/victory-pie-demo.tsx
@@ -156,6 +156,18 @@ export default class VictoryPieDemo extends React.Component<
           <VictoryPie
             theme={VictoryTheme.clean}
             style={{ parent: parentStyle }}
+            categories={{ x: ["E", "A", "D", "C", "B"] }}
+          />
+
+          <VictoryPie
+            theme={VictoryTheme.clean}
+            style={{ parent: parentStyle }}
+            categories={{ x: ["E", "A", "C"] }}
+          />
+
+          <VictoryPie
+            theme={VictoryTheme.clean}
+            style={{ parent: parentStyle }}
           />
 
           <VictoryPie

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -66,8 +66,10 @@ const sortDataByCategories = (props, data) => {
     const sorted: string[] = [];
     props.categories.x.forEach((category) => {
       const idx = data.findIndex(({ x }) => x === category);
-      const datum = data.splice(idx, 1)[0];
-      sorted.push(datum);
+      if (idx >= 0) {
+        const datum = data.splice(idx, 1)[0];
+        sorted.push(datum);
+      }
     });
     return [...sorted, ...data];
   }

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -59,16 +59,21 @@ const getSlices = (props, data) => {
   return layoutFunction(data);
 };
 
-const sortDataByCategories = (props, data) =>
-  Array.isArray(props?.categories?.x)
-    ? props.categories.x.reduce((newData, category) => {
-        const datum = data.find(({ x }) => x === category);
-        if (datum) {
-          newData.push(datum);
-        }
-        return newData;
-      }, [])
-    : data;
+// sorts data by the categories prop. if all of the data keys aren't included in categories,
+// any remaining data will be appended to the data array.
+const sortDataByCategories = (props, data) => {
+  if (Array.isArray(props?.categories?.x)) {
+    const sorted: string[] = [];
+    props.categories.x.forEach((category) => {
+      const idx = data.findIndex(({ x }) => x === category);
+      const datum = data.splice(idx, 1)[0];
+      sorted.push(datum);
+    });
+    return [...sorted, ...data];
+  }
+
+  return data;
+};
 
 const getCalculatedValues = (props) => {
   const { colorScale, theme } = props;

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -61,6 +61,8 @@ const getSlices = (props, data) => {
 
 // sorts data by the categories prop. if all of the data keys aren't included in categories,
 // any remaining data will be appended to the data array.
+// if extraneous categories are included in the categories prop, the will be ignored and have no effect
+// on the rendered component.
 const sortDataByCategories = (props, data) => {
   if (Array.isArray(props?.categories?.x)) {
     const sorted: string[] = [];

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -3,6 +3,8 @@ import { defaults, isPlainObject } from "lodash";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 import { Helpers, Data, Style } from "victory-core";
+import { VictoryPieProps } from "./victory-pie";
+import { getCategories } from "victory-core/lib/victory-util/data";
 
 const checkForValidText = (text) => {
   if (text === undefined || text === null || Helpers.isFunction(text)) {
@@ -59,24 +61,27 @@ const getSlices = (props, data) => {
   return layoutFunction(data);
 };
 
-// sorts data by the categories prop. if all of the data keys aren't included in categories,
-// any remaining data will be appended to the data array.
-// if extraneous categories are included in the categories prop, the will be ignored and have no effect
-// on the rendered component.
-const sortDataByCategories = (props, data) => {
-  if (Array.isArray(props?.categories?.x)) {
-    const sorted: string[] = [];
-    props.categories.x.forEach((category) => {
-      const idx = data.findIndex(({ x }) => x === category);
-      if (idx >= 0) {
-        const datum = data.splice(idx, 1)[0];
-        sorted.push(datum);
-      }
-    });
-    return [...sorted, ...data];
-  }
+const getCategoriesFromProps = (props: VictoryPieProps) =>
+  Array.isArray(props.categories)
+    ? props.categories
+    : (props?.categories as { x: string[] })?.x ?? [];
 
-  return data;
+/**
+ * Sorts data by props.categories or props.categories.x. If all of the data keys aren't
+ * included in categories, any remaining data will be appended to the data array.
+ * If extraneous categories are included in the categories prop, the will be ignored and
+ * have no effect on the rendered component.
+ */
+const getDataSortedByCategories = (props: VictoryPieProps, data) => {
+  const sorted: string[] = [];
+  getCategoriesFromProps(props).forEach((category) => {
+    const idx = data.findIndex(({ x }) => x === category);
+    if (idx >= 0) {
+      const datum = data.splice(idx, 1)[0];
+      sorted.push(datum);
+    }
+  });
+  return [...sorted, ...data];
 };
 
 const getCalculatedValues = (props) => {
@@ -89,7 +94,7 @@ const getCalculatedValues = (props) => {
   const padding = Helpers.getPadding(props);
   const defaultRadius = getRadius(props, padding);
   const origin = getOrigin(props, padding);
-  const data = sortDataByCategories(props, Data.getData(props));
+  const data = getDataSortedByCategories(props, Data.getData(props));
   const slices = getSlices(props, data);
   return Object.assign({}, props, {
     style,

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -59,6 +59,17 @@ const getSlices = (props, data) => {
   return layoutFunction(data);
 };
 
+const sortDataByCategories = (props, data) =>
+  Array.isArray(props?.categories?.x)
+    ? props.categories.x.reduce((newData, category) => {
+        const datum = data.find(({ x }) => x === category);
+        if (datum) {
+          newData.push(datum);
+        }
+        return newData;
+      }, [])
+    : data;
+
 const getCalculatedValues = (props) => {
   const { colorScale, theme } = props;
   const styleObject = Helpers.getDefaultStyles(props, "pie");
@@ -69,7 +80,7 @@ const getCalculatedValues = (props) => {
   const padding = Helpers.getPadding(props);
   const defaultRadius = getRadius(props, padding);
   const origin = getOrigin(props, padding);
-  const data = Data.getData(props);
+  const data = sortDataByCategories(props, Data.getData(props));
   const slices = getSlices(props, data);
   return Object.assign({}, props, {
     style,

--- a/packages/victory-pie/src/victory-pie.test.tsx
+++ b/packages/victory-pie/src/victory-pie.test.tsx
@@ -151,6 +151,30 @@ describe("components/victory-pie", () => {
       expect(xValues).toEqual(xValuesFromGivenData);
     });
 
+    it("renders data values sorted by categories prop", () => {
+      const { container } = render(
+        <VictoryPie categories={{ x: ["E", "A", "D", "C", "B"] }} />,
+      );
+
+      const xValues = Array.from(
+        container.querySelectorAll("text[id^=pie-labels] > tspan"),
+      ).map((slice) => slice.textContent);
+
+      expect(xValues).toEqual(["E", "A", "D", "C", "B"]);
+    });
+
+    it("renders data values sorted by categories prop, appending any data keys missing from categories and ignoring any categories values that are not valid data keys", () => {
+      const { container } = render(
+        <VictoryPie categories={{ x: ["E", "C", "B", "Z"] }} />,
+      );
+
+      const xValues = Array.from(
+        container.querySelectorAll("text[id^=pie-labels] > tspan"),
+      ).map((slice) => slice.textContent);
+
+      expect(xValues).toEqual(["E", "C", "B", "A", "D"]);
+    });
+
     it("renders data values sorted by sortKey prop", () => {
       const data = Helpers.range(9)
         .map((i) => ({ x: i, y: i }))

--- a/stories/victory-pie.stories.tsx
+++ b/stories/victory-pie.stories.tsx
@@ -29,6 +29,21 @@ export const DefaultRendering = () => {
   );
 };
 
+export const Categories = () => {
+  return (
+    <>
+      <VictoryPie
+        style={parentStyle}
+        categories={{ x: ["B", "A", "E", "C", "D"] }}
+      />
+      <VictoryPie
+        style={parentStyle}
+        categories={{ x: ["E", "C", "A", "D", "B"] }}
+      />
+    </>
+  );
+};
+
 export const Data = () => {
   return (
     <>


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

Adds logic to sort pie chart slices by the categories in categories prop. Adds a story as well.

Fixes #2921
