### PR TITLE
Remove duplicate types from interfaces

### DIFF
--- a/.changeset/quick-camels-cheer.md
+++ b/.changeset/quick-camels-cheer.md
@@ -1,0 +1,16 @@
+---
+"victory-area": patch
+"victory-axis": patch
+"victory-bar": patch
+"victory-candlestick": patch
+"victory-core": patch
+"victory-errorbar": patch
+"victory-group": patch
+"victory-histogram": patch
+"victory-line": patch
+"victory-pie": patch
+"victory-polar-axis": patch
+"victory-stack": patch
+---
+
+Remove duplicate types from interfaces

--- a/packages/victory-area/src/victory-area.tsx
+++ b/packages/victory-area/src/victory-area.tsx
@@ -47,7 +47,6 @@ export interface VictoryAreaProps
   events?: EventPropTypeInterface<VictoryAreaTTargetType, string | number>[];
   // eslint-disable-next-line @typescript-eslint/ban-types
   interpolation?: InterpolationPropType | Function;
-  samples?: number;
   style?: VictoryStyleInterface;
 }
 

--- a/packages/victory-axis/src/victory-axis.tsx
+++ b/packages/victory-axis/src/victory-axis.tsx
@@ -9,7 +9,6 @@ import {
   addEvents,
   Axis,
   UserProps,
-  DomainPropType,
   EventPropTypeInterface,
   OrientationTypes,
   VictoryAxisCommonProps,
@@ -49,7 +48,6 @@ export interface VictoryAxisProps
     VictoryCommonProps,
     VictorySingleLabelableProps {
   crossAxis?: boolean;
-  domain?: DomainPropType;
   events?: EventPropTypeInterface<VictoryAxisTTargetType, number | string>[];
   fixLabelOverlap?: boolean;
   offsetX?: number;

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -50,7 +50,6 @@ export interface VictoryBarProps
   >[];
   eventKey?: StringOrNumberOrCallback;
   getPath?: (props: VictoryBarProps) => string;
-  horizontal?: boolean;
   style?: VictoryStyleInterface;
 }
 

--- a/packages/victory-candlestick/src/victory-candlestick.tsx
+++ b/packages/victory-candlestick/src/victory-candlestick.tsx
@@ -44,7 +44,6 @@ export type VictoryCandlestickLabelsType =
 export interface VictoryCandlestickProps
   extends Omit<VictoryCommonProps, "polar">,
     VictoryDatableProps,
-    VictoryLabelableProps,
     VictoryMultiLabelableProps {
   candleColors?: {
     positive?: string;

--- a/packages/victory-core/src/victory-theme/types.ts
+++ b/packages/victory-core/src/victory-theme/types.ts
@@ -9,6 +9,7 @@ import {
   PaddingOrCallback,
   StringOrNumberOrCallback,
 } from "../types/callbacks";
+import { DomainPropType } from "../types/prop-types";
 
 export type BlockProps = {
   top?: number;
@@ -49,7 +50,7 @@ export interface VictoryAxisCommonProps {
   axisLabelComponent?: React.ReactElement;
   axisValue?: number | string | object | Date;
   dependentAxis?: boolean;
-  disableInlineStyles?: boolean;
+  domain?: DomainPropType;
   gridComponent?: React.ReactElement;
   invertAxis?: boolean;
   style?: {

--- a/packages/victory-errorbar/src/victory-errorbar.tsx
+++ b/packages/victory-errorbar/src/victory-errorbar.tsx
@@ -41,7 +41,6 @@ export type ErrorType =
 export interface VictoryErrorBarProps
   extends Omit<VictoryCommonProps, "polar">,
     VictoryDatableProps,
-    VictoryLabelableProps,
     VictoryMultiLabelableProps {
   borderWidth?: number;
   errorX?: ErrorType;

--- a/packages/victory-group/src/victory-group.tsx
+++ b/packages/victory-group/src/victory-group.tsx
@@ -35,18 +35,13 @@ export interface VictoryGroupProps
   extends VictoryCommonProps,
     VictoryDatableProps,
     VictoryMultiLabelableProps {
-  categories?: CategoryPropType;
   children?: React.ReactNode;
   color?: string;
-  colorScale?: ColorScalePropType;
-  domain?: DomainPropType;
-  domainPadding?: DomainPaddingPropType;
   events?: EventPropTypeInterface<
     VictoryGroupTTargetType,
     StringOrNumberOrCallback
   >[];
   eventKey?: StringOrNumberOrCallback;
-  horizontal?: boolean;
   offset?: number;
   style?: VictoryStyleInterface;
   displayName?: string;

--- a/packages/victory-histogram/src/victory-histogram.tsx
+++ b/packages/victory-histogram/src/victory-histogram.tsx
@@ -46,7 +46,6 @@ export interface VictoryHistogramProps
     number | string | number[] | string[]
   >[];
   eventKey?: StringOrNumberOrCallback;
-  horizontal?: boolean;
   style?: VictoryStyleInterface;
 }
 

--- a/packages/victory-line/src/victory-line.tsx
+++ b/packages/victory-line/src/victory-line.tsx
@@ -116,12 +116,10 @@ export type VictoryLineTTargetType = "data" | "labels" | "parent";
 export interface VictoryLineProps
   extends VictoryCommonProps,
     VictoryDatableProps,
-    VictoryLabelableProps,
     VictoryMultiLabelableProps {
   events?: EventPropTypeInterface<VictoryLineTTargetType, number | string>[];
   eventKey?: StringOrNumberOrCallback | string[];
   // eslint-disable-next-line @typescript-eslint/ban-types
   interpolation?: InterpolationPropType | Function;
-  samples?: number;
   style?: VictoryStyleInterface;
 }

--- a/packages/victory-pie/src/victory-pie.tsx
+++ b/packages/victory-pie/src/victory-pie.tsx
@@ -33,9 +33,7 @@ import {
 export interface VictoryPieProps
   extends Omit<VictoryCommonProps, "polar">,
     VictoryDatableProps,
-    VictoryLabelableProps,
     VictoryMultiLabelableProps {
-  colorScale?: ColorScalePropType;
   cornerRadius?: SliceNumberOrCallback<SliceProps, "cornerRadius">;
   endAngle?: number;
   events?: EventPropTypeInterface<
@@ -56,7 +54,6 @@ export interface VictoryPieProps
 
   labelIndicatorComponent?: React.ReactElement;
   labelRadius?: number | ((props: SliceProps) => number);
-  origin?: OriginType;
   padAngle?: NumberOrCallback;
   radius?: NumberOrCallback;
   startAngle?: number;

--- a/packages/victory-polar-axis/src/types.ts
+++ b/packages/victory-polar-axis/src/types.ts
@@ -1,5 +1,4 @@
 import {
-  DomainPropType,
   EventPropTypeInterface,
   LabelOrientationType,
   VictoryAxisCommonProps,
@@ -19,16 +18,13 @@ export interface VictoryPolarAxisProps
     VictoryCommonProps,
     VictorySingleLabelableProps {
   axisAngle?: number;
-  axisValue?: number | string | Date;
   circularAxisComponent?: React.ReactElement;
   circularGridComponent?: React.ReactElement;
-  domain?: DomainPropType;
   endAngle?: number;
   events?: EventPropTypeInterface<
     VictoryPolarAxisTTargetType,
     string | number
   >[];
-  gridComponent?: React.ReactElement;
   innerRadius?: number;
   labelOrientation?: LabelOrientationType;
   labelPlacement?: LabelOrientationType;

--- a/packages/victory-stack/src/victory-stack.tsx
+++ b/packages/victory-stack/src/victory-stack.tsx
@@ -32,12 +32,10 @@ const fallbackProps = {
 export type VictoryStackTTargetType = "data" | "labels" | "parent";
 export interface VictoryStackProps
   extends VictoryCommonProps,
-    VictoryLabelableProps,
     VictoryMultiLabelableProps {
   bins?: number | number[] | Date[];
   categories?: CategoryPropType;
   children?: React.ReactNode | React.ReactNode[];
-  colorScale?: ColorScalePropType;
   domain?: DomainPropType;
   events?: EventPropTypeInterface<
     VictoryStackTTargetType,


### PR DESCRIPTION
Several components had props interface definitions with duplicate type definitions. These interfaces extend and underlying type and do not need to redefine the properties.