### PR TITLE
Minor docs fixes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,11 @@
 {
   "redirects": [
     {
+      "source": "/open-source/victory/docs",
+      "destination": "/open-source/victory/docs/introduction",
+      "permanent": true
+    },
+    {
       "source": "/open-source/victory/docs/faq",
       "destination": "/open-source/victory/docs/introduction",
       "permanent": true

--- a/website/docs/api/victory-common-theme-props.mdx
+++ b/website/docs/api/victory-common-theme-props.mdx
@@ -4,14 +4,6 @@ title: VictoryCommonThemeProps
 
 Common props for all Victory components that use themes. Some components override these props with specific implementations. See the specific component's API documentation for more information.
 
-## Inherited Props
-
-<CommonProps
-  interfaces={[
-    "VictoryCommonProps",
-  ]}
-/>
-
 ## Props
 
 ---


### PR DESCRIPTION
### Add missing redirect for root docs path

The new Victory site was missing a redirect from the root `/docs` path to `/docs/introduction`.

### Remove incorrect inherited props component

The `VictoryCommonThemeProps` api document was incorrectly showing that it inherits from `VictoryCommonProps`.