### PR TITLE
Remove the deprecated babel-plugin-lodash

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -18,7 +18,6 @@ module.exports = {
     "@babel/preset-react",
     "@babel/preset-typescript",
   ],
-  plugins: ["lodash"],
   ignore: ["**/*.d.ts"],
   env: {
     commonjs: {

--- a/.changeset/lucky-pots-double.md
+++ b/.changeset/lucky-pots-double.md
@@ -1,0 +1,29 @@
+---
+"victory-area": patch
+"victory-axis": patch
+"victory-bar": patch
+"victory-box-plot": patch
+"victory-brush-container": patch
+"victory-brush-line": patch
+"victory-candlestick": patch
+"victory-chart": patch
+"victory-core": patch
+"victory-create-container": patch
+"victory-cursor-container": patch
+"victory-errorbar": patch
+"victory-group": patch
+"victory-legend": patch
+"victory-line": patch
+"victory-native": patch
+"victory-pie": patch
+"victory-polar-axis": patch
+"victory-selection-container": patch
+"victory-shared-events": patch
+"victory-stack": patch
+"victory-tooltip": patch
+"victory-voronoi": patch
+"victory-voronoi-container": patch
+"victory-zoom-container": patch
+---
+
+Remove deprecated babel-plugin-lodash plugin

--- a/demo/ts/components/accessibility-demo.tsx
+++ b/demo/ts/components/accessibility-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isNumber } from "lodash";
+import isNumber from "lodash/isNumber";
 import { VictoryGroup } from "victory-group";
 import { VictoryStack } from "victory-stack";
 import { VictoryChart } from "victory-chart";

--- a/demo/ts/components/create-container-demo.tsx
+++ b/demo/ts/components/create-container-demo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { round } from "lodash";
+import round from "lodash/round";
 import { VictoryChart } from "victory-chart";
 import { VictoryStack } from "victory-stack";
 import { VictoryGroup } from "victory-group";

--- a/demo/ts/components/external-events-demo.tsx
+++ b/demo/ts/components/external-events-demo.tsx
@@ -6,7 +6,7 @@ import { VictoryBar } from "victory-bar";
 import { VictoryLine } from "victory-line";
 import { VictoryZoomContainer } from "victory-zoom-container";
 import { VictoryVoronoiContainer } from "victory-voronoi-container";
-import { range } from "lodash";
+import range from "lodash/range";
 import { VictoryTheme, VictoryThemePalette } from "victory-core";
 
 const themeColors: VictoryThemePalette =

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,10 +16,12 @@ export default tseslint.config(
     ignores: [
       "**/*.d.ts",
       "**/.wireit/",
+      "**/.docusaurus/",
       "**/artifacts/",
       "**/coverage/",
       "**/demo/rn/",
       "**/dist/",
+      "**/build/",
       "**/es/",
       "**/lib/",
       "**/lib-vendor/",
@@ -140,6 +142,7 @@ export default tseslint.config(
     files: ["**/demo/**/*.{ts,tsx}"],
     rules: {
       "no-magic-numbers": "off",
+      "no-restricted-imports": "off",
       "react/no-multi-comp": "off",
       "@typescript-eslint/no-empty-object-type": "off",
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,6 +77,13 @@ export default tseslint.config(
       "no-restricted-imports": [
         "error",
         {
+          paths: [
+            {
+              name: "lodash",
+              message:
+                "Be sure to import specific lodash functions, not the entire library!",
+            },
+          ],
           patterns: [
             {
               group: ["victory*/src", "victory*/src/**"],

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "autoprefixer": "^10.0.1",
     "babel-jest": "29.7.0",
     "babel-loader": "9.1.3",
-    "babel-plugin-lodash": "3.3.4",
     "babel-plugin-module-resolver": "5.0.0",
     "babel-preset-react-native": "4.0.1",
     "chromatic": "^11.16.3",

--- a/packages/victory-area/src/area.tsx
+++ b/packages/victory-area/src/area.tsx
@@ -1,6 +1,6 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 import * as d3Shape from "victory-vendor/d3-shape";
 import {
   Helpers,

--- a/packages/victory-axis/src/helper-methods.tsx
+++ b/packages/victory-axis/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 import { Helpers, Scale, Axis } from "victory-core";
 import { VictoryAxisProps } from "./victory-axis";
 

--- a/packages/victory-axis/src/victory-axis.tsx
+++ b/packages/victory-axis/src/victory-axis.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 import {
   VictoryLabel,
   VictoryContainer,

--- a/packages/victory-bar/src/bar-helper-methods.ts
+++ b/packages/victory-bar/src/bar-helper-methods.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "lodash";
+import isPlainObject from "lodash/isPlainObject";
 import { Helpers, VictoryStyleObject } from "victory-core";
 import { BarProps } from "./bar";
 import {

--- a/packages/victory-bar/src/bar.tsx
+++ b/packages/victory-bar/src/bar.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 import {
   Helpers,
   NumberOrCallback,

--- a/packages/victory-box-plot/src/helper-methods.tsx
+++ b/packages/victory-box-plot/src/helper-methods.tsx
@@ -1,4 +1,8 @@
-import { orderBy, defaults, uniq, groupBy } from "lodash";
+import defaults from "lodash/defaults";
+import groupBy from "lodash/groupBy";
+import orderBy from "lodash/orderBy";
+import uniq from "lodash/uniq";
+
 import { Helpers, Scale, Domain, Data, Collection } from "victory-core";
 import {
   min as d3Min,

--- a/packages/victory-brush-container/src/brush-helpers.ts
+++ b/packages/victory-brush-container/src/brush-helpers.ts
@@ -1,5 +1,7 @@
+import defaults from "lodash/defaults";
+import throttle from "lodash/throttle";
+
 import { Helpers as CoreHelpers, Selection } from "victory-core";
-import { throttle, defaults } from "lodash";
 import isEqual from "react-fast-compare";
 
 const Helpers = {

--- a/packages/victory-brush-container/src/victory-brush-container.tsx
+++ b/packages/victory-brush-container/src/victory-brush-container.tsx
@@ -8,7 +8,7 @@ import {
   VictoryEventHandler,
 } from "victory-core";
 import { BrushHelpers } from "./brush-helpers";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 import isEqual from "react-fast-compare";
 
 export interface VictoryBrushContainerProps extends VictoryContainerProps {

--- a/packages/victory-brush-line/src/victory-brush-line.tsx
+++ b/packages/victory-brush-line/src/victory-brush-line.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import defaults from "lodash/defaults";
+import pick from "lodash/pick";
+
 import {
   Selection,
   Helpers,
@@ -10,7 +13,6 @@ import {
   DomainTuple,
   VictoryStyleObject,
 } from "victory-core";
-import { defaults, pick } from "lodash";
 import isEqual from "react-fast-compare";
 
 export type VictoryBrushLineTargetType = "data" | "labels" | "parent";

--- a/packages/victory-candlestick/src/candle.tsx
+++ b/packages/victory-candlestick/src/candle.tsx
@@ -7,7 +7,7 @@ import {
   VictoryCommonPrimitiveProps,
   VictoryStyleObject,
 } from "victory-core";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 export interface CandleProps extends VictoryCommonPrimitiveProps {
   candleRatio?: number;

--- a/packages/victory-candlestick/src/helper-methods.ts
+++ b/packages/victory-candlestick/src/helper-methods.ts
@@ -1,4 +1,6 @@
-import { defaults, isPlainObject } from "lodash";
+import defaults from "lodash/defaults";
+import isPlainObject from "lodash/isPlainObject";
+
 import {
   Helpers,
   Scale,

--- a/packages/victory-chart/src/helper-methods.tsx
+++ b/packages/victory-chart/src/helper-methods.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Helpers, Scale, Axis, Wrapper } from "victory-core";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 const fallbackProps = {
   width: 450,

--- a/packages/victory-chart/src/victory-chart.tsx
+++ b/packages/victory-chart/src/victory-chart.tsx
@@ -1,5 +1,7 @@
-import { defaults, isEmpty } from "lodash";
 import React from "react";
+import defaults from "lodash/defaults";
+import isEmpty from "lodash/isEmpty";
+
 import {
   Background,
   Helpers,

--- a/packages/victory-core/src/exports.test.ts
+++ b/packages/victory-core/src/exports.test.ts
@@ -142,7 +142,7 @@ import {
   mergeRefs,
   usePortalContext,
 } from "./index";
-import { pick } from "lodash";
+import pick from "lodash/pick";
 
 describe("victory-core", () => {
   it("exports addEvents", () => {

--- a/packages/victory-core/src/victory-animation/util.ts
+++ b/packages/victory-core/src/victory-animation/util.ts
@@ -1,5 +1,7 @@
+import isPlainObject from "lodash/isPlainObject";
+import orderBy from "lodash/orderBy";
+
 import { interpolate } from "victory-vendor/d3-interpolate";
-import { isPlainObject, orderBy } from "lodash";
 
 export const isInterpolatable = function (obj) {
   // d3 turns null into 0 and undefined into NaN, which we don't want.

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.tsx
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.tsx
@@ -1,7 +1,10 @@
 import React from "react";
+import defaults from "lodash/defaults";
+import isObject from "lodash/isObject";
+import uniqueId from "lodash/uniqueId";
+
 import * as Helpers from "../victory-util/helpers";
 import * as UserProps from "../victory-util/user-props";
-import { defaults, isObject, uniqueId } from "lodash";
 import { ClipPath } from "../victory-primitives/clip-path";
 import { Circle } from "../victory-primitives/circle";
 import { Rect } from "../victory-primitives/rect";

--- a/packages/victory-core/src/victory-container/victory-container.tsx
+++ b/packages/victory-core/src/victory-container/victory-container.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { Portal } from "../victory-portal/portal";
 import * as UserProps from "../victory-util/user-props";
 import { OriginType } from "../victory-label/victory-label";

--- a/packages/victory-core/src/victory-label/victory-label.tsx
+++ b/packages/victory-core/src/victory-label/victory-label.tsx
@@ -1,6 +1,8 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-0.5, 0.5, 0, 1, 2] }]*/
-import { defaults, isEmpty } from "lodash";
 import React from "react";
+import defaults from "lodash/defaults";
+import isEmpty from "lodash/isEmpty";
+
 import { VictoryPortal } from "../victory-portal/victory-portal";
 import { Rect } from "../victory-primitives/rect";
 import { Text } from "../victory-primitives/text";

--- a/packages/victory-core/src/victory-portal/victory-portal.tsx
+++ b/packages/victory-core/src/victory-portal/victory-portal.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
-import { defaults, uniqueId } from "lodash";
+import defaults from "lodash/defaults";
+import uniqueId from "lodash/uniqueId";
+
 import * as Log from "../victory-util/log";
 import * as Helpers from "../victory-util/helpers";
 import { usePortalContext } from "./portal-context";

--- a/packages/victory-core/src/victory-primitives/arc.tsx
+++ b/packages/victory-core/src/victory-primitives/arc.tsx
@@ -1,6 +1,6 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [0, 1, 2, 180] }]*/
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import * as Helpers from "../victory-util/helpers";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";

--- a/packages/victory-core/src/victory-primitives/background.tsx
+++ b/packages/victory-core/src/victory-primitives/background.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import * as Helpers from "../victory-util/helpers";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";

--- a/packages/victory-core/src/victory-primitives/border.tsx
+++ b/packages/victory-core/src/victory-primitives/border.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import * as Helpers from "../victory-util/helpers";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";

--- a/packages/victory-core/src/victory-primitives/line-segment.tsx
+++ b/packages/victory-core/src/victory-primitives/line-segment.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import * as Helpers from "../victory-util/helpers";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";

--- a/packages/victory-core/src/victory-primitives/point.tsx
+++ b/packages/victory-core/src/victory-primitives/point.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import * as Helpers from "../victory-util/helpers";
 import * as pathHelpers from "../victory-util/point-path-helpers";

--- a/packages/victory-core/src/victory-primitives/whisker.tsx
+++ b/packages/victory-core/src/victory-primitives/whisker.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import * as Helpers from "../victory-util/helpers";
 import { VictoryCommonPrimitiveProps } from "../victory-util/common-props";

--- a/packages/victory-core/src/victory-transition/victory-transition.tsx
+++ b/packages/victory-core/src/victory-transition/victory-transition.tsx
@@ -1,11 +1,13 @@
 import React from "react";
+import defaults from "lodash/defaults";
+import pick from "lodash/pick";
+import isEqual from "react-fast-compare";
+
 import { VictoryAnimation } from "../victory-animation/victory-animation";
 import * as Collection from "../victory-util/collection";
 import * as Helpers from "../victory-util/helpers";
 import TimerContext from "../victory-util/timer-context";
 import * as Transitions from "../victory-util/transitions";
-import { defaults, pick } from "lodash";
-import isEqual from "react-fast-compare";
 import Timer from "../victory-util/timer";
 
 type VictoryTransitionChild = React.ReactElement<

--- a/packages/victory-core/src/victory-util/add-events.tsx
+++ b/packages/victory-core/src/victory-util/add-events.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { defaults, isEmpty, pick } from "lodash";
+import defaults from "lodash/defaults";
+import isEmpty from "lodash/isEmpty";
+import pick from "lodash/pick";
+
 import isEqual from "react-fast-compare";
 
 import { VictoryLabelableProps } from "../types/prop-types";

--- a/packages/victory-core/src/victory-util/axis.tsx
+++ b/packages/victory-core/src/victory-util/axis.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { defaults, isObject, uniq, orderBy } from "lodash";
+import defaults from "lodash/defaults";
+import isObject from "lodash/isObject";
+import uniq from "lodash/uniq";
+import orderBy from "lodash/orderBy";
+
 import * as Collection from "./collection";
 import * as Domain from "./domain";
 import * as Helpers from "./helpers";

--- a/packages/victory-core/src/victory-util/data.ts
+++ b/packages/victory-core/src/victory-util/data.ts
@@ -1,14 +1,13 @@
 import React from "react";
-import {
-  uniq,
-  isPlainObject,
-  property,
-  orderBy,
-  isEmpty,
-  isEqual,
-  isUndefined,
-  omitBy,
-} from "lodash";
+import isEmpty from "lodash/isEmpty";
+import isEqual from "lodash/isEqual";
+import isPlainObject from "lodash/isPlainObject";
+import isUndefined from "lodash/isUndefined";
+import omitBy from "lodash/omitBy";
+import orderBy from "lodash/orderBy";
+import property from "lodash/property";
+import uniq from "lodash/uniq";
+
 import * as Helpers from "./helpers";
 import * as Collection from "./collection";
 import * as Scale from "./scale";

--- a/packages/victory-core/src/victory-util/domain.ts
+++ b/packages/victory-core/src/victory-util/domain.ts
@@ -1,5 +1,8 @@
 import React from "react";
-import { isPlainObject, sortedUniq, isDate } from "lodash";
+import isDate from "lodash/isDate";
+import isPlainObject from "lodash/isPlainObject";
+import sortedUniq from "lodash/sortedUniq";
+
 import * as Data from "./data";
 import * as Scale from "./scale";
 import * as Helpers from "./helpers";

--- a/packages/victory-core/src/victory-util/events.ts
+++ b/packages/victory-core/src/victory-util/events.ts
@@ -1,6 +1,9 @@
 import React from "react";
+import isEmpty from "lodash/isEmpty";
+import pickBy from "lodash/pickBy";
+import omitBy from "lodash/omitBy";
+import uniq from "lodash/uniq";
 
-import { isEmpty, pickBy, omitBy, uniq } from "lodash";
 import type { EventMixinCalculatedValues } from "./add-events";
 import { isFunction } from "./helpers";
 

--- a/packages/victory-core/src/victory-util/helpers.ts
+++ b/packages/victory-core/src/victory-util/helpers.ts
@@ -1,5 +1,8 @@
 import React, { isValidElement } from "react";
-import { defaults, property, pick } from "lodash";
+import defaults from "lodash/defaults";
+import property from "lodash/property";
+import pick from "lodash/pick";
+
 import { CallbackArgs } from "../types/callbacks";
 import { ValueOrAccessor } from "../types/prop-types";
 

--- a/packages/victory-core/src/victory-util/hooks/use-animation-state.ts
+++ b/packages/victory-core/src/victory-util/hooks/use-animation-state.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import * as Collection from "../collection";
 import * as Transitions from "../transitions";

--- a/packages/victory-core/src/victory-util/label-helpers.ts
+++ b/packages/victory-core/src/victory-util/label-helpers.ts
@@ -1,6 +1,6 @@
 import { VictoryLabelProps } from "../victory-label/victory-label";
 import * as Helpers from "./helpers";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 // Private Functions
 

--- a/packages/victory-core/src/victory-util/scale.ts
+++ b/packages/victory-core/src/victory-util/scale.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "lodash";
+import isPlainObject from "lodash/isPlainObject";
 import * as Helpers from "./helpers";
 import * as Collection from "./collection";
 import * as d3Scale from "victory-vendor/d3-scale";

--- a/packages/victory-core/src/victory-util/textsize.ts
+++ b/packages/victory-core/src/victory-util/textsize.ts
@@ -1,6 +1,7 @@
 // http://www.pearsonified.com/2012/01/characters-per-line.php
 /* eslint-disable no-magic-numbers */
-import { defaults, memoize } from "lodash";
+import defaults from "lodash/defaults";
+import memoize from "lodash/memoize";
 
 // Based on measuring specific character widths
 // as in the following example https://bl.ocks.org/tophtucker/62f93a4658387bb61e4510c37e2e97cf

--- a/packages/victory-core/src/victory-util/transitions.ts
+++ b/packages/victory-core/src/victory-util/transitions.ts
@@ -1,5 +1,7 @@
-import { defaults, identity } from "lodash";
 import React from "react";
+import defaults from "lodash/defaults";
+import identity from "lodash/identity";
+
 import { AnimatePropTypeInterface } from "../types/prop-types";
 
 function getDatumKey(datum, idx) {

--- a/packages/victory-core/src/victory-util/wrapper.tsx
+++ b/packages/victory-core/src/victory-util/wrapper.tsx
@@ -1,5 +1,9 @@
-import { defaults, uniq, groupBy, uniqBy } from "lodash";
 import React from "react";
+import defaults from "lodash/defaults";
+import uniq from "lodash/uniq";
+import groupBy from "lodash/groupBy";
+import uniqBy from "lodash/uniqBy";
+
 import * as Axis from "./axis";
 import * as Style from "./style";
 import * as Data from "./data";

--- a/packages/victory-create-container/src/create-container.tsx
+++ b/packages/victory-create-container/src/create-container.tsx
@@ -1,22 +1,31 @@
+import React from "react";
+import forOwn from "lodash/forOwn";
+import groupBy from "lodash/groupBy";
+import isEmpty from "lodash/isEmpty";
+import toPairs from "lodash/toPairs";
+
 import {
   VictoryZoomContainer,
   useVictoryZoomContainer,
 } from "victory-zoom-container";
+
 import {
   VictorySelectionContainer,
   useVictorySelectionContainer,
 } from "victory-selection-container";
-import React from "react";
+
 import { VictoryContainer, VictoryContainerProps } from "victory-core";
-import { forOwn, groupBy, isEmpty, toPairs } from "lodash";
+
 import {
   VictoryVoronoiContainer,
   useVictoryVoronoiContainer,
 } from "victory-voronoi-container";
+
 import {
   VictoryCursorContainer,
   useVictoryCursorContainer,
 } from "victory-cursor-container";
+
 import {
   VictoryBrushContainer,
   useVictoryBrushContainer,

--- a/packages/victory-cursor-container/src/cursor-helpers.tsx
+++ b/packages/victory-cursor-container/src/cursor-helpers.tsx
@@ -1,5 +1,5 @@
 import { Helpers, Selection, SVGCoordinateType } from "victory-core";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 
 const ON_MOUSE_MOVE_THROTTLE_MS = 16;
 

--- a/packages/victory-cursor-container/src/victory-cursor-container.tsx
+++ b/packages/victory-cursor-container/src/victory-cursor-container.tsx
@@ -12,7 +12,8 @@ import {
   DomainTuple,
   PaddingProps,
 } from "victory-core";
-import { defaults, isObject } from "lodash";
+import defaults from "lodash/defaults";
+import isObject from "lodash/isObject";
 import { CursorHelpers } from "./cursor-helpers";
 
 export type CursorCoordinatesPropType = CoordinatesPropType | number;

--- a/packages/victory-errorbar/src/error-bar.test.tsx
+++ b/packages/victory-errorbar/src/error-bar.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
-import { forEach, omit } from "lodash";
+import forEach from "lodash/forEach";
+import omit from "lodash/omit";
 import React from "react";
 import * as d3Scale from "victory-vendor/d3-scale";
 

--- a/packages/victory-errorbar/src/error-bar.tsx
+++ b/packages/victory-errorbar/src/error-bar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import {
   Helpers,

--- a/packages/victory-errorbar/src/helper-methods.tsx
+++ b/packages/victory-errorbar/src/helper-methods.tsx
@@ -1,4 +1,5 @@
-import { defaults, assign } from "lodash";
+import assign from "lodash/assign";
+import defaults from "lodash/defaults";
 import {
   Helpers,
   LabelHelpers,

--- a/packages/victory-group/src/victory-group.tsx
+++ b/packages/victory-group/src/victory-group.tsx
@@ -1,4 +1,5 @@
-import { defaults, isEmpty } from "lodash";
+import defaults from "lodash/defaults";
+import isEmpty from "lodash/isEmpty";
 import React from "react";
 import {
   EventPropTypeInterface,

--- a/packages/victory-legend/src/helper-methods.ts
+++ b/packages/victory-legend/src/helper-methods.ts
@@ -1,4 +1,6 @@
-import { defaults, groupBy, range } from "lodash";
+import defaults from "lodash/defaults";
+import groupBy from "lodash/groupBy";
+import range from "lodash/range";
 import { Helpers, Style, TextSize } from "victory-core";
 import { VictoryLegendProps } from "./victory-legend";
 

--- a/packages/victory-line/src/curve.tsx
+++ b/packages/victory-line/src/curve.tsx
@@ -1,6 +1,6 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import {
   Helpers,

--- a/packages/victory-line/src/victory-line.test.tsx
+++ b/packages/victory-line/src/victory-line.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { random } from "lodash";
+import random from "lodash/random";
 import React from "react";
 import { VictoryChart } from "victory-chart";
 import { Helpers } from "victory-core";

--- a/packages/victory-native/src/components/victory-brush-line.tsx
+++ b/packages/victory-native/src/components/victory-brush-line.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { PanResponder } from "react-native";
 import { G, Rect } from "react-native-svg";
-import { get } from "lodash";
+import get from "lodash/get";
 import { VictoryEventHandler } from "victory-core";
 import {
   VictoryBrushLine as VictoryBrushLineBase,

--- a/packages/victory-native/src/components/victory-clip-container.tsx
+++ b/packages/victory-native/src/components/victory-clip-container.tsx
@@ -4,7 +4,7 @@ import { Circle } from "./victory-primitives/circle";
 import { Rect } from "./victory-primitives/rect";
 import { ClipPath } from "./victory-primitives/clip-path";
 import { VictoryClipContainer as VictoryClipContainerBase } from "victory-core/es";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 
 export class VictoryClipContainer extends VictoryClipContainerBase {
   static defaultProps = {

--- a/packages/victory-native/src/components/victory-container.tsx
+++ b/packages/victory-native/src/components/victory-container.tsx
@@ -1,6 +1,6 @@
 import React, { RefObject } from "react";
 import Svg, { Rect } from "react-native-svg";
-import { get } from "lodash";
+import get from "lodash/get";
 import { View, PanResponder } from "react-native";
 import {
   VictoryContainerProps,

--- a/packages/victory-native/src/helpers/native-zoom-helpers.ts
+++ b/packages/victory-native/src/helpers/native-zoom-helpers.ts
@@ -1,4 +1,5 @@
-import { throttle, defaults } from "lodash";
+import defaults from "lodash/defaults";
+import throttle from "lodash/throttle";
 import { Dimensions } from "react-native";
 import isEqual from "react-fast-compare";
 import { Collection, Helpers as CoreHelpers } from "victory-core";

--- a/packages/victory-native/src/helpers/wrap-core-component.tsx
+++ b/packages/victory-native/src/helpers/wrap-core-component.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 import hoistNonReactStatics from "hoist-non-react-statics";
 
 /**

--- a/packages/victory-pie/src/helper-methods.ts
+++ b/packages/victory-pie/src/helper-methods.ts
@@ -1,5 +1,6 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2, 45, 90, 135, 180, 225, 270, 315, 360] }]*/
-import { defaults, isPlainObject } from "lodash";
+import defaults from "lodash/defaults";
+import isPlainObject from "lodash/isPlainObject";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 import { Helpers, Data, Style } from "victory-core";

--- a/packages/victory-pie/src/slice.tsx
+++ b/packages/victory-pie/src/slice.tsx
@@ -8,7 +8,7 @@ import {
   VictoryCommonProps,
   VictoryStyleInterface,
 } from "victory-core";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 import * as d3Shape from "victory-vendor/d3-shape";
 
 export type VictorySliceLabelPositionType =

--- a/packages/victory-polar-axis/src/helper-methods.ts
+++ b/packages/victory-polar-axis/src/helper-methods.ts
@@ -1,4 +1,5 @@
-import { uniqBy, defaults } from "lodash";
+import defaults from "lodash/defaults";
+import uniqBy from "lodash/uniqBy";
 import { Helpers, LabelHelpers, Scale, Axis } from "victory-core";
 import { VictoryPolarAxisProps } from "./types";
 

--- a/packages/victory-polar-axis/src/victory-polar-axis.tsx
+++ b/packages/victory-polar-axis/src/victory-polar-axis.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 import {
   VictoryLabel,
   VictoryContainer,

--- a/packages/victory-selection-container/src/selection-helpers.tsx
+++ b/packages/victory-selection-container/src/selection-helpers.tsx
@@ -1,5 +1,6 @@
 import { Selection, Data, Helpers, Datum } from "victory-core";
-import { defaults, throttle } from "lodash";
+import defaults from "lodash/defaults";
+import throttle from "lodash/throttle";
 import React from "react";
 
 const ON_MOUSE_MOVE_THROTTLE_MS = 16;

--- a/packages/victory-shared-events/src/victory-shared-events.tsx
+++ b/packages/victory-shared-events/src/victory-shared-events.tsx
@@ -1,5 +1,10 @@
-import { defaults, isEmpty, fromPairs } from "lodash";
 import React from "react";
+import defaults from "lodash/defaults";
+import isEmpty from "lodash/isEmpty";
+import fromPairs from "lodash/fromPairs";
+import isEqual from "react-fast-compare";
+import stringify from "json-stringify-safe";
+
 import {
   Collection,
   EventCallbackInterface,
@@ -10,8 +15,6 @@ import {
   StringOrNumberOrCallback,
   TimerContext,
 } from "victory-core";
-import isEqual from "react-fast-compare";
-import stringify from "json-stringify-safe";
 
 export type VictorySharedEventsProps = {
   children?: React.ReactElement | React.ReactElement[];

--- a/packages/victory-stack/src/helper-methods.tsx
+++ b/packages/victory-stack/src/helper-methods.tsx
@@ -1,4 +1,4 @@
-import { orderBy } from "lodash";
+import orderBy from "lodash/orderBy";
 import React from "react";
 import { Helpers, Scale, Wrapper } from "victory-core";
 import isEqual from "react-fast-compare";

--- a/packages/victory-stack/src/victory-stack.tsx
+++ b/packages/victory-stack/src/victory-stack.tsx
@@ -1,5 +1,7 @@
-import { defaults, isEmpty } from "lodash";
 import React from "react";
+import defaults from "lodash/defaults";
+import isEmpty from "lodash/isEmpty";
+
 import {
   CategoryPropType,
   DomainPropType,

--- a/packages/victory-tooltip/src/flyout.tsx
+++ b/packages/victory-tooltip/src/flyout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import {
   Helpers,

--- a/packages/victory-tooltip/src/victory-tooltip.tsx
+++ b/packages/victory-tooltip/src/victory-tooltip.tsx
@@ -15,7 +15,11 @@ import {
   OrientationTypes,
   VictoryThemeDefinition,
 } from "victory-core";
-import { defaults, uniqueId, isPlainObject, orderBy } from "lodash";
+
+import defaults from "lodash/defaults";
+import uniqueId from "lodash/uniqueId";
+import isPlainObject from "lodash/isPlainObject";
+import orderBy from "lodash/orderBy";
 
 import { Flyout } from "./flyout";
 

--- a/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
+++ b/packages/victory-voronoi-container/src/victory-voronoi-container.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { defaults, pick } from "lodash";
+import defaults from "lodash/defaults";
+import pick from "lodash/pick";
 import { VictoryTooltip } from "victory-tooltip";
 import {
   Helpers,

--- a/packages/victory-voronoi-container/src/voronoi-helpers.ts
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.ts
@@ -1,5 +1,7 @@
 import { Collection, Selection, Data, Helpers } from "victory-core";
-import { isEmpty, isRegExp, throttle } from "lodash";
+import isEmpty from "lodash/isEmpty";
+import isRegExp from "lodash/isRegExp";
+import throttle from "lodash/throttle";
 import isEqual from "react-fast-compare";
 import Delaunay from "delaunay-find/lib/index.js";
 import React from "react";

--- a/packages/victory-voronoi/src/victory-voronoi.test.tsx
+++ b/packages/victory-voronoi/src/victory-voronoi.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { random } from "lodash";
+import random from "lodash/random";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { Helpers } from "victory-core";
 

--- a/packages/victory-voronoi/src/voronoi.tsx
+++ b/packages/victory-voronoi/src/voronoi.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 import {
   Helpers,

--- a/packages/victory-zoom-container/src/victory-zoom-container.tsx
+++ b/packages/victory-zoom-container/src/victory-zoom-container.tsx
@@ -8,7 +8,7 @@ import {
   Data,
   VictoryEventHandler,
 } from "victory-core";
-import { defaults } from "lodash";
+import defaults from "lodash/defaults";
 
 const DEFAULT_DOWNSAMPLE = 150;
 

--- a/packages/victory-zoom-container/src/zoom-helpers.ts
+++ b/packages/victory-zoom-container/src/zoom-helpers.ts
@@ -1,7 +1,10 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2, 1000] }]*/
 import { Children } from "react";
+import defaults from "lodash/defaults";
+import delay from "lodash/delay";
+import throttle from "lodash/throttle";
+
 import { Helpers, Selection, Collection, Wrapper } from "victory-core";
-import { throttle, defaults, delay } from "lodash";
 
 export const RawZoomHelpers = {
   checkDomainEquality(a, b) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,6 @@ importers:
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.23.9)(webpack@5.74.0)
-      babel-plugin-lodash:
-        specifier: 3.3.4
-        version: 3.3.4
       babel-plugin-module-resolver:
         specifier: 5.0.0
         version: 5.0.0
@@ -4721,15 +4718,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /@babel/types@7.23.6:
-    resolution: {integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
-    dev: true
 
   /@babel/types@7.24.0:
     resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
@@ -10918,16 +10906,6 @@ packages:
       '@babel/types': 7.24.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.5
-    dev: true
-
-  /babel-plugin-lodash@3.3.4:
-    resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
-    dependencies:
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/types': 7.23.6
-      glob: 7.2.3
-      lodash: 4.17.21
-      require-package-name: 2.0.1
     dev: true
 
   /babel-plugin-module-resolver@5.0.0:
@@ -21318,10 +21296,6 @@ packages:
 
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-
-  /require-package-name@2.0.1:
-    resolution: {integrity: sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==}
-    dev: true
 
   /requireg@0.2.2:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}

--- a/stories/utils/data.ts
+++ b/stories/utils/data.ts
@@ -1,4 +1,4 @@
-import { range } from "lodash";
+import range from "lodash/range";
 import seedrandom from "seedrandom";
 
 export const getArrayData = (num: number, samples = 10) => {

--- a/stories/victory-charts/victory-legend/title.stories.tsx
+++ b/stories/victory-charts/victory-legend/title.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
-import { range } from "lodash";
+import range from "lodash/range";
 
 import {
   VictoryAxis,

--- a/test/helpers/svg.ts
+++ b/test/helpers/svg.ts
@@ -1,7 +1,10 @@
 import * as d3Scale from "victory-vendor/d3-scale";
 import * as d3Shape from "victory-vendor/d3-shape";
 import { _internalD3Voronoi as d3Voronoi } from "victory-voronoi/lib/helper-methods";
-import { without, min, max, property } from "lodash";
+import without from "lodash/without";
+import min from "lodash/min";
+import max from "lodash/max";
+import property from "lodash/property";
 
 const RECTANGULAR_SEQUENCE = ["M", "A", "L", "A", "L", "A", "L", "A", "z"];
 const CIRCULAR_SEQUENCE = ["M", "m", "a", "a"];

--- a/website/src/pages/_components/landing-demo.tsx
+++ b/website/src/pages/_components/landing-demo.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from "react";
 
 import axios from "axios";
-import { last } from "lodash";
+import last from "lodash/last";
 import { format, startOfWeek, parse, subDays } from "date-fns";
 
 import {


### PR DESCRIPTION
The `babel-plugin-lodash` has been deprecated for over a year. This plugin automatically replaced lodash imports with their single import equivalents. This also fixes a build warning in Babel about using outdated transformations.

This change removes the plugin, converts all imports to the single import format, and adds an ESLint rule to prevent anyone from incorrectly using the full lodash import in the future.

#### Notes

- The import order of some of these files is a bit messy, we should consider an eslint rule for import order
- This new rule is disabled in the /demos since that folder is deprecated and will eventually be removed