### PR TITLE
fix/bars-disappear-on-zoom

### DIFF
--- a/.changeset/soft-moons-exist.md
+++ b/.changeset/soft-moons-exist.md
@@ -1,0 +1,6 @@
+---
+"victory-bar": patch
+"victory-core": patch
+---
+
+Zoomed bar graph items will no longer be culled from the view when more than 50% of width or height is outside of the clipping parent. Instead they will be clipped once 100% outside"

--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -557,6 +557,14 @@ export default class VictoryZoomContainerDemo extends React.Component<
         >
           <VictoryBar />
         </VictoryChart>
+
+        <VictoryChart
+          containerComponent={<VictoryZoomContainer />}
+          style={{ parent: parentStyle }}
+          horizontal
+        >
+          <VictoryBar />
+        </VictoryChart>
       </div>
     );
   }

--- a/demo/ts/components/victory-zoom-container-demo.tsx
+++ b/demo/ts/components/victory-zoom-container-demo.tsx
@@ -550,6 +550,13 @@ export default class VictoryZoomContainerDemo extends React.Component<
           <VictoryAxis />
           <VictoryAxis dependentAxis />
         </VictoryChart>
+
+        <VictoryChart
+          containerComponent={<VictoryZoomContainer />}
+          style={{ parent: parentStyle }}
+        >
+          <VictoryBar />
+        </VictoryChart>
       </div>
     );
   }

--- a/packages/victory-bar/src/helper-methods.ts
+++ b/packages/victory-bar/src/helper-methods.ts
@@ -61,6 +61,14 @@ const getCalculatedValues = (props) => {
   let data = Data.getData(props);
   data = Data.formatDataFromDomain(data, domain, 0);
 
+  if (props.groupComponent.type.displayName === 'VictoryClipContainer') {
+    data = data.map((datum) => {
+      datum._x = datum.x;
+      datum._y = datum.y;
+      return datum;
+    });
+  }
+
   return { style, data, scale, domain, origin };
 };
 

--- a/packages/victory-bar/src/helper-methods.ts
+++ b/packages/victory-bar/src/helper-methods.ts
@@ -5,7 +5,7 @@ import {
   Helpers,
   LabelHelpers,
   Scale,
-  VictoryClipContainer
+  VictoryClipContainer,
 } from "victory-core";
 
 export const getBarPosition = (props, datum) => {

--- a/packages/victory-bar/src/helper-methods.ts
+++ b/packages/victory-bar/src/helper-methods.ts
@@ -5,6 +5,7 @@ import {
   Helpers,
   LabelHelpers,
   Scale,
+  VictoryClipContainer
 } from "victory-core";
 
 export const getBarPosition = (props, datum) => {
@@ -61,7 +62,7 @@ const getCalculatedValues = (props) => {
   let data = Data.getData(props);
   data = Data.formatDataFromDomain(data, domain, 0);
 
-  if (props.groupComponent.type.displayName === 'VictoryClipContainer') {
+  if (props.groupComponent.type === VictoryClipContainer) {
     data = data.map((datum) => {
       datum._x = datum.x;
       datum._y = datum.y;

--- a/packages/victory-bar/src/helper-methods.ts
+++ b/packages/victory-bar/src/helper-methods.ts
@@ -62,12 +62,10 @@ const getCalculatedValues = (props) => {
   let data = Data.getData(props);
   data = Data.formatDataFromDomain(data, domain, 0);
 
+  // when inside a zoom container, reset the _x and _y properties of each datum to the original
+  // x and y property values so they will not be clipped. See https://github.com/FormidableLabs/victory/pull/2970
   if (props.groupComponent.type === VictoryClipContainer) {
-    data = data.map((datum) => {
-      datum._x = datum.x;
-      datum._y = datum.y;
-      return datum;
-    });
+    data = data.map((datum) => ({ ...datum, _x: datum.x, _y: datum.y }));
   }
 
   return { style, data, scale, domain, origin };

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -38,8 +38,8 @@ export type VictoryBarAlignmentType = "start" | "middle" | "end";
 
 export interface VictoryBarProps
   extends VictoryCommonProps,
-    VictoryDatableProps,
-    VictoryMultiLabelableProps {
+  VictoryDatableProps,
+  VictoryMultiLabelableProps {
   alignment?: VictoryBarAlignmentType;
   barRatio?: number;
   barWidth?: NumberOrCallback;
@@ -141,7 +141,12 @@ class VictoryBarBase extends React.Component<VictoryBarProps> {
       return this.animateComponent(props, animationWhitelist);
     }
 
-    const children = this.renderData(props);
+    let children;
+    if (props.groupComponent.type.displayName === 'VictoryClipContainer') {
+      children = this.renderData(props, () => true);
+    } else {
+      children = this.renderData(props);
+    }
 
     const component = props.standalone
       ? this.renderContainer(props.containerComponent, children)

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -13,6 +13,7 @@ import {
   EventPropTypeInterface,
   NumberOrCallback,
   StringOrNumberOrCallback,
+  VictoryClipContainer,
   VictoryCommonProps,
   VictoryDatableProps,
   VictoryMultiLabelableProps,
@@ -142,7 +143,7 @@ class VictoryBarBase extends React.Component<VictoryBarProps> {
     }
 
     let children;
-    if (props.groupComponent.type.displayName === 'VictoryClipContainer') {
+    if (props.groupComponent.type === VictoryClipContainer) {
       children = this.renderData(props, () => true);
     } else {
       children = this.renderData(props);

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -39,8 +39,8 @@ export type VictoryBarAlignmentType = "start" | "middle" | "end";
 
 export interface VictoryBarProps
   extends VictoryCommonProps,
-  VictoryDatableProps,
-  VictoryMultiLabelableProps {
+    VictoryDatableProps,
+    VictoryMultiLabelableProps {
   alignment?: VictoryBarAlignmentType;
   barRatio?: number;
   barWidth?: NumberOrCallback;

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -128,7 +128,9 @@ class VictoryBarBase extends React.Component<VictoryBarProps> {
     "groupComponent",
     "containerComponent",
   ];
-
+  // passed to addEvents.renderData to prevent data props with undefined _x or _y from excluding data from render.
+  // used when inside of VictoryZoomContainer
+  static shouldRenderDatum = () => true;
   // Overridden in native versions
   shouldAnimate() {
     return !!this.props.animate;
@@ -144,7 +146,7 @@ class VictoryBarBase extends React.Component<VictoryBarProps> {
 
     let children;
     if (props.groupComponent.type === VictoryClipContainer) {
-      children = this.renderData(props, () => true);
+      children = this.renderData(props, VictoryBarBase.shouldRenderDatum);
     } else {
       children = this.renderData(props);
     }

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -39,8 +39,8 @@ export type VictoryBarAlignmentType = "start" | "middle" | "end";
 
 export interface VictoryBarProps
   extends VictoryCommonProps,
-    VictoryDatableProps,
-    VictoryMultiLabelableProps {
+  VictoryDatableProps,
+  VictoryMultiLabelableProps {
   alignment?: VictoryBarAlignmentType;
   barRatio?: number;
   barWidth?: NumberOrCallback;
@@ -145,6 +145,9 @@ class VictoryBarBase extends React.Component<VictoryBarProps> {
     }
 
     let children;
+    // when inside a zoom container (the only place VictoryClipContainer is used), all data
+    // should be renderable so bars won't dissappear before they've fully exited the container's bounds
+    // see https://github.com/FormidableLabs/victory/pull/2970
     if (props.groupComponent.type === VictoryClipContainer) {
       children = this.renderData(props, VictoryBarBase.shouldRenderDatum);
     } else {

--- a/packages/victory-core/src/victory-util/add-events.tsx
+++ b/packages/victory-core/src/victory-util/add-events.tsx
@@ -57,7 +57,7 @@ export interface EventsMixinClass<TProps> {
   ): React.ReactElement;
   cacheValues<TThis>(this: TThis, obj: Partial<TThis>): void;
   getEventState: typeof Events.getEventState;
-  renderData(props: TProps);
+  renderData(props: TProps, shouldRenderDatum?: () => boolean);
   renderContinuousData(props: TProps);
   animateComponent(
     props: TProps,


### PR DESCRIPTION
### Description

Addresses the issue where bar chart items more than 50% out of their chart area when zoomed disappear completely, as the bar middle point was being used to determine whether they should be culled from view. 

Fixes # [2905](https://github.com/FormidableLabs/victory/issues/2905)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

Original video from issue:

https://github.com/user-attachments/assets/311b9725-00b7-4867-a539-90f9dc8e125e

Video after fix:

https://github.com/user-attachments/assets/965e120c-73ee-43bc-9923-33a666e56e85



