### PR TITLE
fix(#2941): prevent unique clipId from incrementing on rerender

### DIFF
--- a/.changeset/great-pugs-warn.md
+++ b/.changeset/great-pugs-warn.md
@@ -1,0 +1,5 @@
+---
+"victory-core": patch
+---
+
+Fix SSR VictoryClipContainer clipId hydration error. Prevent unique clip id from incrementing on rerender.

--- a/packages/victory-core/src/victory-clip-container/victory-clip-container.tsx
+++ b/packages/victory-core/src/victory-clip-container/victory-clip-container.tsx
@@ -43,12 +43,14 @@ export class VictoryClipContainer extends React.Component<VictoryClipContainerPr
     groupComponent: <g />,
   };
   public clipId: VictoryClipContainerProps["clipId"];
+  private uniqueClipId: string;
 
   constructor(props: VictoryClipContainerProps) {
     super(props);
+    this.uniqueClipId = uniqueId("victory-clip-");
     this.clipId =
       !isObject(props) || props.clipId === undefined
-        ? uniqueId("victory-clip-")
+        ? this.uniqueClipId
         : props.clipId;
   }
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2941 hydration error on rerender in Next.js

1. ensure that `uniqueId()` is called only once and not on every re-render
2. Store the result so that is initialized only once


#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Manual testing for this one.

#### Screenshots
Before:


After: 


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [X] I have included a changeset if this change will require a version change to one of the packages.
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
