### PR TITLE
feat: add color scale overrides and final polish

### DIFF
--- a/website/src/pages/themes/_components/accordion.tsx
+++ b/website/src/pages/themes/_components/accordion.tsx
@@ -27,7 +27,7 @@ const Accordion = ({
         <button
           type="button"
           className={clsx(
-            "bg-white flex items-center justify-between w-full px-5 py-3 text-sm font-bold rtl:text-right text-grayscale-500 border border-b-0 border-grayscale-300 gap-3 group-last:border-b",
+            "bg-white flex items-center justify-between w-full px-5 py-3 text-sm font-bold rtl:text-right text-grayscale-500 border border-b-0 border-grayscale-300 gap-3 group-last:border-b cursor-pointer",
             { "group-last:border-b-0": isOpen },
           )}
           aria-expanded="true"

--- a/website/src/pages/themes/_components/code-block.tsx
+++ b/website/src/pages/themes/_components/code-block.tsx
@@ -1,0 +1,28 @@
+import clsx from "clsx";
+import { Highlight } from "prism-react-renderer";
+import React from "react";
+
+type CodeBlockProps = {
+  code: string;
+  language: string;
+  className?: string;
+};
+
+const CodeBlock = ({ code, language, className: classes }: CodeBlockProps) => {
+  return (
+    <Highlight code={code} language={language}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={clsx(classes, className)} style={style}>
+          {tokens.map((line, i) => (
+            <div {...getLineProps({ line, key: i })} key={i}>
+              {line.map((token, key) => (
+                <span {...getTokenProps({ token, key })} key={key} />
+              ))}
+            </div>
+          ))}
+        </pre>
+      )}
+    </Highlight>
+  );
+};
+export default CodeBlock;

--- a/website/src/pages/themes/_components/color-picker.tsx
+++ b/website/src/pages/themes/_components/color-picker.tsx
@@ -1,15 +1,23 @@
 import React from "react";
 import { TiPencil } from "react-icons/ti";
 import clsx from "clsx";
+import Select from "./select";
 
 type ColorPickerProps = {
   label?: string;
   color: string;
   id: string;
-  onColorChange: (color: string) => void;
+  onColorChange: (color?: string) => void;
   showColorName?: boolean;
   className?: string;
 };
+
+const PLACEHOLDER_COLOR = "#000000";
+const DEFAULT_COLOR = undefined;
+enum ColorPickerOptions {
+  NONE = "none",
+  CUSTOM = "custom",
+}
 
 const ColorPicker = ({
   label,
@@ -20,6 +28,28 @@ const ColorPicker = ({
   className,
 }: ColorPickerProps) => {
   const [isPickerOpen, setIsPickerOpen] = React.useState(false);
+  const [colorOption, setColorOption] = React.useState<string | undefined>(
+    () => {
+      if (color === ColorPickerOptions.NONE || color === "transparent") {
+        return ColorPickerOptions.NONE;
+      }
+      if (color === DEFAULT_COLOR) {
+        return DEFAULT_COLOR;
+      }
+      return ColorPickerOptions.CUSTOM;
+    },
+  );
+
+  const handleColorOptionChange = (value?: string) => {
+    setColorOption(value);
+    if (value === ColorPickerOptions.NONE) {
+      onColorChange(ColorPickerOptions.NONE);
+    } else if (value === DEFAULT_COLOR) {
+      onColorChange(DEFAULT_COLOR);
+    } else {
+      onColorChange(PLACEHOLDER_COLOR);
+    }
+  };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (onColorChange) {
@@ -34,65 +64,86 @@ const ColorPicker = ({
           {label}
         </label>
       )}
-      <div
-        className={clsx("relative inline-flex rounded-full group/swatch", {
-          "border-2 border-grayscale-300 p-0.5 cursor-pointer justify-between bg-grayscale-100":
-            showColorName,
-        })}
-      >
-        <div className="flex items-center">
-          <div className="relative">
-            <div
-              className={clsx(
-                "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor",
-                {
-                  "outline-2 border-2 border-white outline outline-grayscale-300":
-                    !showColorName,
-                },
-                { "w-[30px] h-[30px] p-0.5": showColorName },
-              )}
-              style={{
-                color,
-              }}
+      <div className="flex items-center gap-2">
+        {showColorName && (
+          <div className="flex items-center my-2 flex-1">
+            <Select
+              id="color-option"
+              value={colorOption}
+              options={[
+                { label: "Default", value: DEFAULT_COLOR },
+                { label: "None", value: ColorPickerOptions.NONE },
+                { label: "Custom", value: ColorPickerOptions.CUSTOM },
+              ]}
+              onChange={handleColorOptionChange}
             />
-            {!showColorName && (
+          </div>
+        )}
+        {colorOption === ColorPickerOptions.CUSTOM && (
+          <div
+            className={clsx(
+              "relative inline-flex rounded-full group/swatch flex-1",
+              {
+                "border-2 border-grayscale-300 p-0.5 cursor-pointer justify-between bg-grayscale-100":
+                  showColorName,
+              },
+            )}
+          >
+            <div className="flex items-center">
+              <div className="relative">
+                <div
+                  className={clsx(
+                    "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor",
+                    {
+                      "outline-2 border-2 border-white outline outline-grayscale-300":
+                        !showColorName,
+                    },
+                    { "w-[30px] h-[30px] p-0.5": showColorName },
+                  )}
+                  style={{
+                    color,
+                  }}
+                />
+                {!showColorName && (
+                  <div
+                    className={`absolute top-0 left-0 w-full h-full text-white flex justify-center items-center text-xl rounded-full opacity-0 group-hover/swatch:opacity-100 ${
+                      isPickerOpen ? "opacity-100" : ""
+                    }`}
+                  >
+                    <TiPencil />
+                  </div>
+                )}
+              </div>
+              {showColorName && (
+                <span
+                  className={
+                    "text-sm font-medium text-grayscale-900 uppercase ml-2 cursor-pointer"
+                  }
+                >
+                  {color}
+                </span>
+              )}
+            </div>
+            {showColorName && (
               <div
-                className={`absolute top-0 left-0 w-full h-full text-white flex justify-center items-center text-xl rounded-full opacity-0 group-hover/swatch:opacity-100 ${
-                  isPickerOpen ? "opacity-100" : ""
-                }`}
+                className={`text-grayscale-400 flex justify-center items-center text-xl rounded-full place-items-end ml-6 mr-1`}
               >
                 <TiPencil />
               </div>
             )}
-          </div>
-          {showColorName && (
-            <span
-              className={
-                "text-sm font-medium text-grayscale-900 uppercase ml-2 cursor-pointer"
-              }
-            >
-              {color}
-            </span>
-          )}
-        </div>
-        {showColorName && (
-          <div
-            className={`text-grayscale-400 flex justify-center items-center text-xl rounded-full place-items-end ml-6 mr-1`}
-          >
-            <TiPencil />
+            <input
+              id={id}
+              className={`absolute top-0 left-0 w-full h-full cursor-pointer opacity-0 z-10 group-hover/swatch:border-currentColor ${
+                isPickerOpen ? "border-currentColor" : ""
+              }`}
+              type="color"
+              value={color}
+              onChange={handleChange}
+              onFocus={() => setIsPickerOpen(true)}
+              onBlur={() => setIsPickerOpen(false)}
+            />
           </div>
         )}
-        <input
-          id={id}
-          className={`absolute top-0 left-0 w-full h-full cursor-pointer opacity-0 z-10 group-hover/swatch:border-currentColor ${
-            isPickerOpen ? "border-currentColor" : ""
-          }`}
-          type="color"
-          value={color}
-          onChange={handleChange}
-          onFocus={() => setIsPickerOpen(true)}
-          onBlur={() => setIsPickerOpen(false)}
-        />
       </div>
     </fieldset>
   );

--- a/website/src/pages/themes/_components/color-picker.tsx
+++ b/website/src/pages/themes/_components/color-picker.tsx
@@ -44,10 +44,10 @@ const ColorPicker = ({
     setColorOption(value);
     if (value === ColorPickerOptions.NONE) {
       onColorChange(ColorPickerOptions.NONE);
-    } else if (value === DEFAULT_COLOR) {
-      onColorChange(DEFAULT_COLOR);
-    } else {
+    } else if (value === ColorPickerOptions.CUSTOM) {
       onColorChange(PLACEHOLDER_COLOR);
+    } else {
+      onColorChange(DEFAULT_COLOR);
     }
   };
 
@@ -71,11 +71,11 @@ const ColorPicker = ({
               id="color-option"
               value={colorOption}
               options={[
-                { label: "Default", value: DEFAULT_COLOR },
                 { label: "None", value: ColorPickerOptions.NONE },
                 { label: "Custom", value: ColorPickerOptions.CUSTOM },
               ]}
               onChange={handleColorOptionChange}
+              includeDefault
             />
           </div>
         )}

--- a/website/src/pages/themes/_components/color-scale-options.tsx
+++ b/website/src/pages/themes/_components/color-scale-options.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import Select from "./select";
 import ColorPicker from "./color-picker";
 import { ColorScalePropType, VictoryThemeDefinition } from "victory";
-
-export type ColorChangeArgs = {
-  newColor: string;
-  index: number;
-  colorScale: string;
-};
+import { ColorChangeArgs } from "./control";
 
 type ColorScaleOptionsProps = {
   palette?: VictoryThemeDefinition["palette"];

--- a/website/src/pages/themes/_components/config-mapper.tsx
+++ b/website/src/pages/themes/_components/config-mapper.tsx
@@ -1,106 +1,7 @@
 import React from "react";
 import optionsConfig from "../_config";
 import Accordion from "./accordion";
-import Select from "./select";
-import Slider from "./slider";
-import ColorPicker from "./color-picker";
-import ColorScaleOptions from "./color-scale-options";
-import { getConfigValue } from "../_utils";
-
-const ControlComponent = ({
-  type,
-  field,
-  themeConfig,
-  updateThemeConfig,
-  activeColorScale,
-  handleColorScaleChange,
-  className,
-}) => {
-  const handleColorChange = ({ newColor, index, colorScale }) => {
-    const updatedColors = themeConfig?.palette?.[colorScale]?.map((color, i) =>
-      i === index ? newColor : color,
-    );
-    updateThemeConfig(`palette.${colorScale}`, updatedColors);
-  };
-
-  const handleChange = (newValue) => {
-    updateThemeConfig(field.path, newValue);
-  };
-
-  const configValue = getConfigValue(themeConfig, field.path, field.default);
-  switch (type) {
-    case "colorScale":
-      return (
-        <ColorScaleOptions
-          palette={themeConfig?.palette}
-          activeColorScale={activeColorScale}
-          onColorChange={handleColorChange}
-          onColorScaleChange={handleColorScaleChange}
-        />
-      );
-    case "section":
-      return (
-        <section className="mb-6">
-          <h3 className="text-lg text-secondary font-bold mb-4">
-            {field.label}
-          </h3>
-          {field.fields.map((subField, i) => (
-            <ControlComponent
-              key={subField.label + i}
-              type={subField.type}
-              field={subField}
-              themeConfig={themeConfig}
-              updateThemeConfig={updateThemeConfig}
-              activeColorScale={activeColorScale}
-              handleColorScaleChange={handleColorScaleChange}
-              className={className}
-            />
-          ))}
-        </section>
-      );
-    case "slider":
-      return (
-        <Slider
-          id={field.label}
-          key={field.label}
-          label={field.label}
-          value={configValue as number}
-          unit={field.unit}
-          onChange={handleChange}
-          min={field.min}
-          max={field.max}
-          step={field.step}
-          className={className}
-        />
-      );
-    case "select":
-      return (
-        <Select
-          id={field.label}
-          key={field.label}
-          label={field.label}
-          value={configValue as string}
-          onChange={handleChange}
-          options={field.options}
-          className={className}
-        />
-      );
-    case "colorPicker":
-      return (
-        <ColorPicker
-          id={field.label}
-          key={field.label}
-          label={field.label}
-          color={configValue as string}
-          onColorChange={handleChange}
-          className={className}
-          showColorName
-        />
-      );
-    default:
-      return null;
-  }
-};
+import Control from "./control";
 
 const ConfigMapper = ({
   themeConfig,
@@ -119,7 +20,7 @@ const ConfigMapper = ({
         >
           {section.fields.map((field, i) => {
             return (
-              <ControlComponent
+              <Control
                 key={field.label + i}
                 type={field.type}
                 field={field}

--- a/website/src/pages/themes/_components/config-preview.tsx
+++ b/website/src/pages/themes/_components/config-preview.tsx
@@ -28,7 +28,7 @@ const ConfigPreview = ({ config, onClose }: ConfigPreviewProps) => {
   };
 
   return (
-    <div className="fixed top-0 right-0 bottom-0 w-full p-10 z-[100] bg-white flex flex-col">
+    <div className="absolute top-0 right-0 bottom-0 w-full p-10 z-[100] bg-white flex flex-col">
       <button
         onClick={handleClose}
         className="absolute top-3 right-3 bg-transparent border-0 text-xl"

--- a/website/src/pages/themes/_components/config-preview.tsx
+++ b/website/src/pages/themes/_components/config-preview.tsx
@@ -28,10 +28,10 @@ const ConfigPreview = ({ config, onClose }: ConfigPreviewProps) => {
   };
 
   return (
-    <div className="absolute top-0 right-0 bottom-0 w-full p-10 z-[100] bg-white flex flex-col">
+    <div className="fixed top-[60px] right-0 bottom-0 max-h-screen w-full p-10 z-[100] bg-white flex flex-col">
       <button
         onClick={handleClose}
-        className="absolute top-3 right-3 bg-transparent border-0 text-xl"
+        className="absolute top-3 right-3 bg-transparent border-0 text-2xl cursor-pointer"
       >
         &times;
       </button>

--- a/website/src/pages/themes/_components/config-preview.tsx
+++ b/website/src/pages/themes/_components/config-preview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Button from "./button";
 import { VictoryThemeDefinition } from "victory";
-import { Highlight } from "prism-react-renderer";
+import CodeBlock from "./code-block";
 
 type ConfigPreviewProps = {
   config: VictoryThemeDefinition;
@@ -28,40 +28,79 @@ const ConfigPreview = ({ config, onClose }: ConfigPreviewProps) => {
   };
 
   return (
-    <div className="fixed top-[60px] right-0 bottom-0 max-h-screen w-full p-10 z-[100] bg-white flex flex-col">
+    <div className="fixed top-[60px] right-0 w-full py-10 px-20 z-[100] bg-white flex flex-col overflow-y-auto min-h-screen">
       <button
         onClick={handleClose}
         className="absolute top-3 right-3 bg-transparent border-0 text-2xl cursor-pointer"
       >
         &times;
       </button>
-      <h2>Theme Config Preview</h2>
-      <Highlight
-        code={JSON.stringify(config, null, 2)}
-        language="json"
-        className="flex-1 overflow-auto border border-grayscale-300 p-3 bg-grayscale-100"
-      >
-        {({ className, style, tokens, getLineProps, getTokenProps }) => (
-          <pre className={className} style={style}>
-            {tokens.map((line, i) => (
-              <div {...getLineProps({ line, key: i })} key={i}>
-                {line.map((token, key) => (
-                  <span {...getTokenProps({ token, key })} key={key} />
-                ))}
-              </div>
-            ))}
-          </pre>
-        )}
-      </Highlight>
-      <div className="flex items-center justify-end gap-3 mt-5">
-        {copyStatus && (
-          <span className="text-grayscale-400 text-xs italic">
-            {copyStatus}
-          </span>
-        )}
-        <Button onClick={handleCopyThemeConfig} ariaLabel="Copy to Clipboard">
-          Copy to Clipboard
-        </Button>
+      <div className="flex gap-20">
+        <section className="w-1/3">
+          <h1 className="text-2xl">Using Your Exported Victory Theme Config</h1>
+          <ol>
+            <li>
+              <strong>Copy the Config</strong>
+              <ul>
+                <li>
+                  Click the <em>Copy to Clipboard</em> button to copy the JSON
+                  theme configuration.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>Save the Exported Theme as a File</strong>
+              <ul>
+                <li>
+                  Save the copied JSON as a <code>.js</code> or{" "}
+                  <code>.json</code> file in your project, e.g.,{" "}
+                  <code>theme.js</code>.
+                </li>
+                <li>
+                  Import the theme in your app:
+                  <CodeBlock
+                    language="javascript"
+                    code={`import customTheme from './theme.js';`}
+                  />
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>Apply to Victory Components</strong>
+              <ul>
+                <li>
+                  Use the <code>theme</code> prop on any Victory component:
+                  <CodeBlock
+                    language="javascript"
+                    code={`<VictoryChart theme={customTheme}>
+  {/* Your Victory components */}
+</VictoryChart>`}
+                  />
+                </li>
+              </ul>
+            </li>
+          </ol>
+        </section>
+        <section className="flex-1">
+          <CodeBlock
+            language="json"
+            code={JSON.stringify(config, null, 2)}
+            className="min-h-[500px] max-h-[80vh]"
+          />
+          <div className="flex items-center justify-end gap-3 mt-5">
+            {copyStatus && (
+              <span className="text-grayscale-400 text-xs italic">
+                {copyStatus}
+              </span>
+            )}
+            <Button
+              onClick={handleCopyThemeConfig}
+              ariaLabel="Copy to Clipboard"
+            >
+              Copy to Clipboard
+            </Button>
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/website/src/pages/themes/_components/control.tsx
+++ b/website/src/pages/themes/_components/control.tsx
@@ -92,6 +92,7 @@ const Control = ({
           onChange={handleChange}
           options={field.options}
           className={className}
+          includeDefault
         />
       );
     case "colorPicker":

--- a/website/src/pages/themes/_components/control.tsx
+++ b/website/src/pages/themes/_components/control.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import Select from "./select";
+import Slider from "./slider";
+import ColorPicker from "./color-picker";
+import ColorScaleOptions from "./color-scale-options";
+import { getConfigValue } from "../_utils";
+
+export type ColorChangeArgs = {
+  newColor?: string;
+  index: number;
+  colorScale: string;
+};
+
+const Control = ({
+  type,
+  field,
+  themeConfig,
+  updateThemeConfig,
+  activeColorScale,
+  handleColorScaleChange,
+  className,
+}) => {
+  const handleColorChange = ({
+    newColor,
+    index,
+    colorScale,
+  }: ColorChangeArgs) => {
+    const updatedColors = themeConfig?.palette?.[colorScale]?.map((color, i) =>
+      i === index ? newColor : color,
+    );
+    updateThemeConfig(`palette.${colorScale}`, updatedColors);
+  };
+
+  const handleChange = (newValue) => {
+    updateThemeConfig(field.path, newValue);
+  };
+
+  const configValue = getConfigValue(themeConfig, field.path, field.default);
+
+  switch (type) {
+    case "colorScale":
+      return (
+        <ColorScaleOptions
+          palette={themeConfig?.palette}
+          activeColorScale={activeColorScale}
+          onColorChange={handleColorChange}
+          onColorScaleChange={handleColorScaleChange}
+        />
+      );
+    case "section":
+      return (
+        <section className="mb-6">
+          <h3 className="text-lg text-secondary font-bold mb-4">
+            {field.label}
+          </h3>
+          {field.fields.map((subField, i) => (
+            <Control
+              key={subField.label + i}
+              type={subField.type}
+              field={subField}
+              themeConfig={themeConfig}
+              updateThemeConfig={updateThemeConfig}
+              activeColorScale={activeColorScale}
+              handleColorScaleChange={handleColorScaleChange}
+              className={className}
+            />
+          ))}
+        </section>
+      );
+    case "slider":
+      return (
+        <Slider
+          id={field.label}
+          key={field.label}
+          label={field.label}
+          value={configValue as number}
+          unit={field.unit}
+          onChange={handleChange}
+          min={field.min}
+          max={field.max}
+          step={field.step}
+          className={className}
+        />
+      );
+    case "select":
+      return (
+        <Select
+          id={field.label}
+          key={field.label}
+          label={field.label}
+          value={configValue as string}
+          onChange={handleChange}
+          options={field.options}
+          className={className}
+        />
+      );
+    case "colorPicker":
+      return (
+        <ColorPicker
+          id={field.label}
+          key={field.label}
+          label={field.label}
+          color={configValue as string}
+          onColorChange={handleChange}
+          className={className}
+          showColorName
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+export default Control;

--- a/website/src/pages/themes/_components/select.tsx
+++ b/website/src/pages/themes/_components/select.tsx
@@ -12,6 +12,7 @@ type SelectProps = {
   options: SelectOption[];
   value?: string;
   onChange: (value?: string) => void;
+  includeDefault?: boolean;
   className?: string;
 };
 
@@ -21,6 +22,7 @@ const Select = ({
   options,
   value = "",
   onChange,
+  includeDefault,
   className,
 }: SelectProps) => {
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -41,6 +43,7 @@ const Select = ({
         onChange={handleChange}
         className="p-2 w-full text-base border border-grayscale-300 bg-white appearance-none rounded-md bg-select-chevron bg-no-repeat bg-[right_8px_center] bg-[length:16px]"
       >
+        {includeDefault && <option value="">Default</option>}
         {options.map((option, i) => (
           <option key={(option.value || "") + i} value={option.value}>
             {option.label}

--- a/website/src/pages/themes/_components/select.tsx
+++ b/website/src/pages/themes/_components/select.tsx
@@ -11,7 +11,7 @@ type SelectProps = {
   label?: string;
   options: SelectOption[];
   value?: string;
-  onChange: (value: string) => void;
+  onChange: (value?: string) => void;
   className?: string;
 };
 

--- a/website/src/pages/themes/_components/slider.tsx
+++ b/website/src/pages/themes/_components/slider.tsx
@@ -30,14 +30,15 @@ const Slider = ({
     }
   };
 
+  const valueString = value !== undefined ? `${value}${unit ?? ""}` : "default";
+
   return (
     <div className={className}>
       <label
         htmlFor={id}
         className="block mb-1 text-sm font-medium text-grayscale-900 dark:text-white"
       >
-        <span className="text-sm font-bold">{label}</span>: {value}
-        {unit}
+        <span className="text-sm font-bold">{label}</span>: {valueString}
       </label>
       <input
         id={id}

--- a/website/src/pages/themes/_config.tsx
+++ b/website/src/pages/themes/_config.tsx
@@ -31,7 +31,6 @@ type ThemeBuilderFieldConfig =
       max?: number;
       step?: number;
       unit?: string;
-      default: number | string;
       options?: { label: string; value: string }[];
     };
 
@@ -50,8 +49,6 @@ type ThemeBuilderOptionsConfig = {
   content?: (props: any) => React.ReactNode;
   fields: ThemeBuilderFieldConfig[];
 }[];
-
-const defaultFill = undefined;
 
 const getPath = (basePath: string | string[], key: string) => {
   if (Array.isArray(basePath)) {
@@ -74,7 +71,6 @@ const getNestedColorScaleConfig = (
       { label: "Red", value: "red" },
       { label: "Green", value: "green" },
     ],
-    default: "qualitative",
     path: getPath(basePath, "colorScale"),
   },
 ];
@@ -87,7 +83,6 @@ const getBaseStrokeConfig = (
     {
       type: "colorPicker",
       label: StrokeProps.STROKE,
-      default: undefined,
       path: getPath(basePath, "stroke"),
     },
     {
@@ -96,7 +91,6 @@ const getBaseStrokeConfig = (
       min: 0,
       max: 5,
       unit: "px",
-      default: 1,
       path: getPath(basePath, "strokeWidth"),
     },
     {
@@ -104,7 +98,6 @@ const getBaseStrokeConfig = (
       label: StrokeProps.STROKE_DASH_ARRAY,
       min: 0,
       max: 10,
-      default: 0,
       path: getPath(basePath, "strokeDasharray"),
     },
     {
@@ -115,7 +108,6 @@ const getBaseStrokeConfig = (
         { label: "Square", value: "square" },
         { label: "Butt", value: "butt" },
       ],
-      default: "round",
       path: getPath(basePath, "strokeLinecap"),
     },
     {
@@ -126,7 +118,6 @@ const getBaseStrokeConfig = (
         { label: "Bevel", value: "bevel" },
         { label: "Miter", value: "miter" },
       ],
-      default: "round",
       path: getPath(basePath, "strokeLinejoin"),
     },
   ] as ThemeBuilderFieldConfig[];
@@ -147,7 +138,6 @@ const getBaseLabelsConfig = (
     max: 24,
     unit: "px",
     path: getPath(basePath, "fontSize"),
-    default: 12,
   },
   {
     type: "slider",
@@ -156,13 +146,11 @@ const getBaseLabelsConfig = (
     max: 50,
     unit: "px",
     path: getPath(basePath, "padding"),
-    default: 8,
   },
   {
     type: "colorPicker",
     label: "Font Color",
     path: getPath(basePath, "fill"),
-    default: defaultFill,
   },
 ];
 
@@ -187,7 +175,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
         min: 0,
         max: 500,
         unit: "px",
-        default: 350,
         path: [
           "chart.width",
           "axis.width",
@@ -211,7 +198,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
         min: 0,
         max: 500,
         unit: "px",
-        default: 350,
         path: [
           "chart.height",
           "axis.height",
@@ -235,7 +221,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
         min: 0,
         max: 100,
         unit: "px",
-        default: 50,
         path: [
           "chart.padding",
           "axis.padding",
@@ -324,7 +309,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 50,
             unit: "px",
-            default: 5,
             path: "axis.style.ticks.size",
           },
           ...getBaseStrokeConfig("axis.style.ticks", [
@@ -377,7 +361,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 50,
             unit: "px",
-            default: 5,
             path: "polarAxis.style.ticks.size",
           },
           ...getBaseStrokeConfig("polarAxis.style.ticks", [
@@ -422,7 +405,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 50,
             unit: "px",
-            default: 5,
             path: "polarDependentAxis.style.ticks.size",
           },
           ...getBaseStrokeConfig("polarDependentAxis.style.ticks", [
@@ -470,7 +452,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 1,
             step: 0.1,
             path: "area.style.data.fillOpacity",
-            default: 1,
           },
           ...getBaseStrokeConfig("area.style.data", [
             StrokeProps.STROKE,
@@ -480,7 +461,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             type: "colorPicker",
             label: "Fill",
             path: "area.style.data.fill",
-            default: defaultFill,
           },
         ],
       },
@@ -536,7 +516,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             type: "colorPicker",
             label: "Fill",
             path: "bar.style.data.fill",
-            default: defaultFill,
           },
           ...getBaseStrokeConfig("bar.style.data", [
             StrokeProps.STROKE,
@@ -549,7 +528,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 1,
             step: 0.1,
             path: "bar.style.data.fillOpacity",
-            default: 1,
           },
           {
             type: "slider",
@@ -557,7 +535,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             path: "bar.cornerRadius.top",
             max: 2,
             step: 0.5,
-            default: 0,
           },
         ],
       },
@@ -626,7 +603,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
           {
             type: "colorPicker",
             label: "Fill",
-            default: defaultFill,
             path: "boxplot.style.q1.fill",
           },
           {
@@ -635,7 +611,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 10,
             step: 0.5,
-            default: 0,
             path: "boxplot.q1.rx",
           },
           {
@@ -644,7 +619,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 5,
             unit: "px",
-            default: 1,
             path: "boxplot.style.q1.strokeWidth",
           },
           ...getBaseLabelsConfig("boxplot.style.q1Labels"),
@@ -657,7 +631,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
           {
             type: "colorPicker",
             label: "Fill",
-            default: defaultFill,
             path: "boxplot.style.q3.fill",
           },
           {
@@ -666,7 +639,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 10,
             step: 0.5,
-            default: 0,
             path: "boxplot.q3.rx",
           },
           ...getBaseLabelsConfig("boxplot.style.q3Labels"),
@@ -738,7 +710,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             label: "Border Radius",
             max: 2,
             step: 0.5,
-            default: 0,
             path: "candlestick.style.data.rx",
           },
           {
@@ -748,7 +719,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 5,
             unit: "px",
             path: "candlestick.wickStrokeWidth",
-            default: 2,
           },
         ],
       },
@@ -765,13 +735,11 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             type: "colorPicker",
             label: "Positive Color",
             path: "candlestick.candleColors.positive",
-            default: "#ffffff",
           },
           {
             type: "colorPicker",
             label: "Negative Color",
             path: "candlestick.candleColors.negative",
-            default: defaultFill,
           },
         ],
       },
@@ -804,7 +772,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 10,
             unit: "px",
             path: "errorbar.borderWidth",
-            default: 8,
           },
           ...getBaseStrokeConfig("errorbar.style.data", [
             StrokeProps.STROKE,
@@ -852,7 +819,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             type: "colorPicker",
             label: "Fill",
             path: "histogram.style.data.fill",
-            default: defaultFill,
           },
           {
             type: "slider",
@@ -861,7 +827,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 1,
             step: 0.1,
             path: "histogram.style.data.fillOpacity",
-            default: 1,
           },
           {
             type: "slider",
@@ -869,7 +834,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             path: "histogram.cornerRadius.top",
             max: 10,
             step: 0.5,
-            default: 0,
           },
           {
             type: "slider",
@@ -878,7 +842,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 10,
             unit: "px",
             path: "histogram.binSpacing",
-            default: 4,
           },
         ],
       },
@@ -904,7 +867,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 50,
             unit: "px",
-            default: 15,
             path: "group.style.data.width",
           },
         ],
@@ -974,7 +936,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 50,
             unit: "px",
             path: "legend.gutter",
-            default: 20,
           },
           {
             type: "slider",
@@ -983,7 +944,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 50,
             unit: "px",
             path: "legend.borderPadding",
-            default: 10,
           },
           {
             type: "select",
@@ -993,7 +953,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
               { label: "Vertical", value: "vertical" },
             ],
             path: "legend.orientation",
-            default: "horizontal",
           },
           {
             type: "select",
@@ -1005,7 +964,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
               { label: "Right", value: "right" },
             ],
             path: "legend.titleOrientation",
-            default: "top",
           },
           {
             type: "select",
@@ -1017,7 +975,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
               { label: "Star", value: "star" },
             ],
             path: "legend.style.data.type",
-            default: "circle",
           },
         ],
       },
@@ -1107,7 +1064,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             max: 50,
             unit: "px",
             path: "pie.style.data.padding",
-            default: 0,
           },
           ...getBaseStrokeConfig("pie.style.data", [
             StrokeProps.STROKE,
@@ -1145,7 +1101,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
           {
             type: "colorPicker",
             label: "Fill",
-            default: defaultFill,
             path: "scatter.style.data.fill",
           },
           {
@@ -1154,7 +1109,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             min: 0,
             max: 1,
             step: 0.1,
-            default: 1,
             path: "scatter.style.data.opacity",
           },
           ...getBaseStrokeConfig("scatter.style.data", [
@@ -1184,7 +1138,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             label: "Corner Radius",
             min: 0,
             max: 10,
-            default: 0,
             path: "tooltip.cornerRadius",
           },
           {
@@ -1192,7 +1145,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
             label: "Pointer Length",
             min: 0,
             max: 20,
-            default: 10,
             path: "tooltip.pointerLength",
           },
         ],
@@ -1204,7 +1156,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
           {
             type: "colorPicker",
             label: "Fill",
-            default: "#FFFFFF",
             path: "tooltip.flyoutStyle.fill",
           },
           ...getBaseStrokeConfig("tooltip.flyoutStyle", [
@@ -1218,7 +1169,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
               { label: "None", value: "none" },
               { label: "All", value: "all" },
             ],
-            default: "none",
             path: "tooltip.flyoutStyle.pointerEvents",
           },
         ],
@@ -1248,7 +1198,6 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
           {
             type: "colorPicker",
             label: "Fill",
-            default: "#FFFFFF",
             path: "voronoi.style.data.fill",
           },
           ...getBaseStrokeConfig("voronoi.style.data", [

--- a/website/src/pages/themes/_config.tsx
+++ b/website/src/pages/themes/_config.tsx
@@ -7,6 +7,7 @@ import {
   VictoryBoxPlot,
   VictoryCandlestick,
   VictoryErrorBar,
+  VictoryGroup,
   VictoryHistogram,
   VictoryLegend,
   VictoryLine,
@@ -50,7 +51,7 @@ type ThemeBuilderOptionsConfig = {
   fields: ThemeBuilderFieldConfig[];
 }[];
 
-const defaultFill = "#000";
+const defaultFill = undefined;
 
 const getPath = (basePath: string | string[], key: string) => {
   if (Array.isArray(basePath)) {
@@ -58,6 +59,25 @@ const getPath = (basePath: string | string[], key: string) => {
   }
   return `${basePath}.${key}`;
 };
+
+const getNestedColorScaleConfig = (
+  basePath: string | string[],
+): ThemeBuilderFieldConfig[] => [
+  {
+    type: "select",
+    label: "Color Scale",
+    options: [
+      { label: "Qualitative", value: "qualitative" },
+      { label: "Heatmap", value: "heatmap" },
+      { label: "Warm", value: "warm" },
+      { label: "Cool", value: "cool" },
+      { label: "Red", value: "red" },
+      { label: "Green", value: "green" },
+    ],
+    default: "qualitative",
+    path: getPath(basePath, "colorScale"),
+  },
+];
 
 const getBaseStrokeConfig = (
   basePath: string | string[],
@@ -67,7 +87,7 @@ const getBaseStrokeConfig = (
     {
       type: "colorPicker",
       label: StrokeProps.STROKE,
-      default: defaultFill,
+      default: undefined,
       path: getPath(basePath, "stroke"),
     },
     {
@@ -282,33 +302,17 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
       {
         type: "section",
         label: "General",
-        fields: [
-          {
-            type: "colorPicker",
-            label: "Fill",
-            default: defaultFill,
-            path: "axis.style.axis.fill",
-          },
-          ...getBaseStrokeConfig("axis.style.axis", [
-            StrokeProps.STROKE,
-            StrokeProps.STROKE_WIDTH,
-            StrokeProps.STROKE_LINE_CAP,
-            StrokeProps.STROKE_LINE_JOIN,
-          ]),
-        ],
+        fields: getBaseStrokeConfig("axis.style.axis", [
+          StrokeProps.STROKE,
+          StrokeProps.STROKE_WIDTH,
+          StrokeProps.STROKE_LINE_CAP,
+          StrokeProps.STROKE_LINE_JOIN,
+        ]),
       },
       {
         type: "section",
         label: "Grid",
-        fields: [
-          {
-            type: "colorPicker",
-            label: "Fill",
-            default: defaultFill,
-            path: "axis.style.grid.fill",
-          },
-          ...getBaseStrokeConfig("axis.style.grid"),
-        ],
+        fields: getBaseStrokeConfig("axis.style.grid"),
       },
       {
         type: "section",
@@ -493,17 +497,35 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
     content: (props) => [
       <VictoryAxis key="x-axis" label="X Axis" />,
       <VictoryAxis key="y-axis" dependentAxis label="Y Axis" />,
-      <VictoryBar
-        key="bar-chart"
-        {...props}
-        data={[
-          { x: 1, y: 2, label: "A" },
-          { x: 2, y: 3, label: "B" },
-          { x: 3, y: 5, label: "C" },
-          { x: 4, y: 4, label: "D" },
-          { x: 5, y: 7, label: "E" },
-        ]}
-      />,
+      <VictoryGroup key="victory-group" domainPadding={{ x: 20 }} offset={20}>
+        <VictoryBar
+          {...props}
+          data={[
+            { x: "2023 Q1", y: 1 },
+            { x: "2023 Q2", y: 2 },
+            { x: "2023 Q3", y: 3 },
+            { x: "2023 Q4", y: 2 },
+          ]}
+        />
+        <VictoryBar
+          {...props}
+          data={[
+            { x: "2023 Q1", y: 2 },
+            { x: "2023 Q2", y: 3 },
+            { x: "2023 Q3", y: 4 },
+            { x: "2023 Q4", y: 5 },
+          ]}
+        />
+        <VictoryBar
+          {...props}
+          data={[
+            { x: "2023 Q1", y: 1 },
+            { x: "2023 Q2", y: 2 },
+            { x: "2023 Q3", y: 3 },
+            { x: "2023 Q4", y: 4 },
+          ]}
+        />
+      </VictoryGroup>,
     ],
     fields: [
       {
@@ -869,6 +891,28 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
   },
   {
     type: "section",
+    title: "Group",
+    fields: [
+      {
+        type: "section",
+        label: "Data",
+        fields: [
+          ...getNestedColorScaleConfig("group"),
+          {
+            type: "slider",
+            label: "Width",
+            min: 0,
+            max: 50,
+            unit: "px",
+            default: 15,
+            path: "group.style.data.width",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "section",
     title: "Legend",
     content: (props) => [
       <VictoryLegend
@@ -1055,6 +1099,7 @@ const optionsConfig: ThemeBuilderOptionsConfig = [
         type: "section",
         label: "Data",
         fields: [
+          ...getNestedColorScaleConfig("pie"),
           {
             type: "slider",
             label: "Padding",

--- a/website/src/pages/themes/_utils.ts
+++ b/website/src/pages/themes/_utils.ts
@@ -32,6 +32,6 @@ export const getConfigValue = (
   if (!pathString) return undefined;
   const pathArray = pathString.split(".");
   return pathArray.reduce((acc, key) => {
-    return acc && acc[key] ? acc[key] : defaultValue || undefined;
+    return acc && acc[key] !== undefined ? acc[key] : defaultValue;
   }, config);
 };

--- a/website/src/pages/themes/index.tsx
+++ b/website/src/pages/themes/index.tsx
@@ -118,6 +118,7 @@ const ThemeBuilder = () => {
   };
 
   const handleThemeConfigPreviewOpen = () => {
+    window.scrollTo({ top: 0 });
     setShowThemeConfigPreview(true);
   };
 

--- a/website/src/pages/themes/index.tsx
+++ b/website/src/pages/themes/index.tsx
@@ -89,7 +89,7 @@ const ThemeBuilder = () => {
     React.useState(false);
   const [showTooltips, setShowTooltips] = React.useState(false);
 
-  const handleThemeSelect = (themeName: string) => {
+  const handleThemeSelect = (themeName?: string) => {
     const theme = themes.find((t) => t.name === themeName);
     if (!theme) {
       setBaseTheme(undefined);
@@ -127,8 +127,8 @@ const ThemeBuilder = () => {
 
   return (
     <Layout>
-      <div className="flex flex-row flex-wrap items-start justify-start w-full h-lvh theme-builder">
-        <aside className="relative flex flex-col h-full w-[380px] border-r border-grayscale-300">
+      <div className="relative flex flex-row flex-wrap items-start justify-start w-full theme-builder">
+        <aside className="sticky top-0 h-screen flex flex-col w-[380px] border-r border-grayscale-300">
           <div className="grow overflow-y-auto p-4 pb-[100px]">
             <h2 className="mb-0 text-lg font-bold">Customize Your Theme</h2>
             <p className="text-sm mb-4 text-grayscale-400">
@@ -167,22 +167,27 @@ const ThemeBuilder = () => {
         </aside>
         <main className="flex-1 flex flex-col items-center overflow-y-auto h-full">
           {customThemeConfig && (
-            <div className="max-w-screen-xl w-full py-4 px-10">
-              <h2 className="text-xl font-bold mb-4">Example Charts</h2>
-              <fieldset>
-                <div className="flex items-center gap-4 mb-4">
-                  <input
-                    type="checkbox"
-                    id="show-tooltips"
-                    className="form-checkbox h-5 w-5 text-primary"
-                    checked={showTooltips}
-                    onChange={() => setShowTooltips(!showTooltips)}
-                  />
-                  <label htmlFor="show-tooltips">
-                    Show tooltips instead of labels
-                  </label>
-                </div>
-              </fieldset>
+            <div className="max-w-screen-xl w-full p-10 pb-20">
+              <div className="flex justify-between items-center mb-4">
+                <h1 className="text-4xl font-bold">Example Charts</h1>
+                <fieldset className="p-0 m-0">
+                  <div className="flex items-center gap-2 mb-4 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      id="show-tooltips"
+                      className="form-checkbox h-4 w-4 text-primary"
+                      checked={showTooltips}
+                      onChange={() => setShowTooltips(!showTooltips)}
+                    />
+                    <label
+                      htmlFor="show-tooltips"
+                      className="text-xs cursor-pointer"
+                    >
+                      Show tooltips instead of labels
+                    </label>
+                  </div>
+                </fieldset>
+              </div>
               <div className="grid grid-cols-2 gap-10">
                 <div>
                   <h3 className="text-base font-bold mb-3">
@@ -200,11 +205,7 @@ const ThemeBuilder = () => {
                       aria-label="Victory Stack Demo"
                     >
                       {[...Array(NUM_STACKS)].map((_, i) => (
-                        <VictoryArea
-                          data={sampleStackData}
-                          key={i}
-                          labels={() => undefined}
-                        />
+                        <VictoryArea data={sampleStackData} key={i} />
                       ))}
                     </VictoryStack>
                   </VictoryChart>


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds the ability to override color scales on a chart by chart basis and also adds some final polish for theme builder MVP ✨ 

![2024-11-27 14 54 13](https://github.com/user-attachments/assets/320e1f65-247a-4845-af55-3d7838bb8d50)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
