### PR TITLE
Fix running storybook:dev locally

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,9 +5,12 @@ const path = require("path");
 const ROOT = path.resolve(__dirname, "..");
 const STORIES = path.resolve(ROOT, "stories");
 
+const getAbsolutePath = (packageName: string): any =>
+  path.dirname(require.resolve(path.join(packageName, 'package.json')));
+
 const config: StorybookConfig = {
   addons: [
-    "@storybook/addon-essentials",
+    getAbsolutePath("@storybook/addon-essentials"),
     {
       name: "@storybook/addon-storysource",
       options: {
@@ -20,12 +23,12 @@ const config: StorybookConfig = {
         },
       },
     },
-    "@storybook/addon-webpack5-compiler-swc",
-    "@chromatic-com/storybook",
+    getAbsolutePath("@storybook/addon-webpack5-compiler-swc"),
+    getAbsolutePath("@chromatic-com/storybook"),
   ],
 
   framework: {
-    name: "@storybook/react-webpack5",
+    name: getAbsolutePath("@storybook/react-webpack5"),
     options: {
       builder: {},
     },


### PR DESCRIPTION
Fixes the following error when running pnpm storybook:dev locally:

```
SB_CORE-SERVER_0002 (CriticalPresetLoadError): Storybook failed to load the following preset: @storybook/react-webpack5/preset.
```

Reference: https://storybook.js.org/docs/faq#how-do-i-fix-module-resolution-in-special-environments

<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

Fixes error by resolving storybook addons using absolute paths as [recommended by the docs](https://storybook.js.org/docs/faq#how-do-i-fix-module-resolution-in-special-environments)

Fixes #2993 

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Run `pnpm storybook:dev` locally  and verify storybook opens successfully.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
