### PR TITLE
Fix regression in cursor rendering caused by #2999

### DIFF
--- a/.changeset/orange-rockets-rest.md
+++ b/.changeset/orange-rockets-rest.md
@@ -1,0 +1,5 @@
+---
+"victory-cursor-container": patch
+---
+
+Fix regression in cursor rendering caused by #2999

--- a/packages/victory-cursor-container/src/victory-cursor-container.tsx
+++ b/packages/victory-cursor-container/src/victory-cursor-container.tsx
@@ -95,7 +95,7 @@ export const useVictoryCursorContainer = (
             return isObject(c.props) && c.props.padding !== undefined;
           })
         : props.children;
-      return Helpers.getPadding(child?.props);
+      return Helpers.getPadding(child?.props?.padding);
     }
     return Helpers.getPadding(props.padding);
   };


### PR DESCRIPTION
Correct the rendering regression caused by the change in #2999 and captured by Chromatic in https://www.chromatic.com/test?appId=5b4acf7c54c0490024d5980b&id=675360427f60e8728902e703 that caused the cursor to render outside the boundaries of the chart

## Bug Render

![image](https://github.com/user-attachments/assets/44bd11d2-5b32-468f-bbec-f8a27feec092)

## Corrected Render

![image](https://github.com/user-attachments/assets/4c773a60-f589-49d7-9d5d-5694bc38559d)
