### PR TITLE
Feat: theme builder refactor axis panel

### DIFF
--- a/website/src/pages/themes/_components/base-theme-panel.tsx
+++ b/website/src/pages/themes/_components/base-theme-panel.tsx
@@ -4,13 +4,10 @@ import { themes, useTheme } from "../_providers/themeProvider";
 import { usePreviewOptions } from "../_providers/previewOptionsProvider";
 import PanelHeader from "./panel-header";
 
-const themeOptions = [
-  { label: "Select a theme", value: "" },
-  ...themes.map((theme) => ({
-    label: theme.name,
-    value: theme.name,
-  })),
-];
+const themeOptions = themes.map((theme) => ({
+  label: theme.name,
+  value: theme.name,
+}));
 
 const BaseThemePanel = () => {
   const { baseTheme, onBaseThemeSelect } = useTheme();

--- a/website/src/pages/themes/_components/chart-panel.tsx
+++ b/website/src/pages/themes/_components/chart-panel.tsx
@@ -1,43 +1,54 @@
-import React from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import Control from "./control";
 import Select from "./select";
 import { usePreviewOptions } from "../_providers/previewOptionsProvider";
-import { chartOptionsConfig } from "../_config";
+import { ChartPanelConfig } from "../_config";
 import PanelHeader from "./panel-header";
 
-const ChartPanel = () => {
-  const [chartType, setChartType] = React.useState("");
+type ChartPanelProps = {
+  config: ChartPanelConfig;
+};
+
+const ChartPanel = ({
+  config: { title, description, selectLabel, types },
+}: ChartPanelProps) => {
+  const [chartType, setChartType] = React.useState(Object.keys(types)[0]);
   const { setExampleConfigs } = usePreviewOptions();
-  const selectOptions = Object.keys(chartOptionsConfig).map((key) => ({
-    label: chartOptionsConfig[key].label,
+  const selectOptions = Object.keys(types).map((key) => ({
+    label: types[key].label,
     value: key,
   }));
-  const options = [
-    { label: "Select a chart type", value: "" },
-    ...selectOptions,
-  ];
-  const controls = chartOptionsConfig[chartType]?.controls || [];
+  const options = useMemo(
+    () => [
+      { label: `Select ${selectLabel.toLowerCase()}`, value: "" },
+      ...selectOptions,
+    ],
+    [selectOptions, selectLabel],
+  );
+  const controls = types[chartType]?.controls || [];
 
-  const onChartTypeChange = (newValue: string) => {
-    setChartType(newValue);
-    const examples = chartOptionsConfig[newValue]
-      ? [chartOptionsConfig[newValue]]
-      : [];
-    setExampleConfigs(examples);
-  };
+  const onChartTypeChange = useCallback(
+    (newValue: string) => {
+      setChartType(newValue);
+      const examples = types[newValue] ? [types[newValue]] : [];
+      setExampleConfigs(examples);
+    },
+    [setExampleConfigs, types],
+  );
+
+  useEffect(() => {
+    onChartTypeChange(Object.keys(types)[0]);
+  }, [types, onChartTypeChange]);
 
   return (
     <>
-      <PanelHeader
-        title="Chart Options"
-        description="Select a chart type to begin customizing."
-      />
+      <PanelHeader title={title} description={description} />
       <Select
         id="chart-type-select"
         value={chartType}
         onChange={onChartTypeChange}
         options={options}
-        label="Chart Type"
+        label={selectLabel}
         className="mt-4 mb-8"
       />
       {controls.map((control, i) => {

--- a/website/src/pages/themes/_components/options-panel.tsx
+++ b/website/src/pages/themes/_components/options-panel.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import Control from "./control";
 import PanelHeader from "./panel-header";
+import { OptionsPanelConfig } from "../_config";
 
 type GlobalPanelProps = {
-  title?: string;
-  description?: string;
-  controls: any[];
+  config: OptionsPanelConfig;
 };
 
-const OptionsPanel = ({ title, description, controls }: GlobalPanelProps) => {
+const OptionsPanel = ({
+  config: { title, description, controls },
+}: GlobalPanelProps) => {
   return (
     <>
       <PanelHeader title={title} description={description} />

--- a/website/src/pages/themes/_components/sidenav.tsx
+++ b/website/src/pages/themes/_components/sidenav.tsx
@@ -7,7 +7,8 @@ import {
 import clsx from "clsx";
 import React from "react";
 import {
-  ControlConfig,
+  chartOptionsConfig,
+  ChartPanelConfig,
   globalOptionsConfig,
   OptionsPanelConfig,
   paletteOptionsConfig,
@@ -26,12 +27,15 @@ type NavItem = {
   icon: React.ElementType;
 } & (
   | {
-      panelType: "theme" | "chart" | "export";
+      panelType: "theme" | "export";
     }
   | {
       panelType: "default";
       config: OptionsPanelConfig;
-      examples?: ControlConfig[];
+    }
+  | {
+      panelType: "chart";
+      config: ChartPanelConfig;
     }
 );
 
@@ -61,13 +65,13 @@ export const NAV_ITEMS: NavItem[] = [
   {
     title: "Axis Options",
     icon: AdjustmentsVerticalIcon,
-    panelType: "default",
     config: axisOptionsConfig,
-    examples: axisOptionsConfig.controls,
+    panelType: "chart",
   },
   {
     title: "Chart Options",
     icon: AdjustmentsVerticalIcon,
+    config: chartOptionsConfig,
     panelType: "chart",
   },
 ];
@@ -86,11 +90,7 @@ const SideNav = ({ activeItem, onItemSelect }: SideNavProps) => {
   const handleItemSelect = (item: NavItem) => {
     onItemSelect(item);
     updateColorScale(defaultColorScale);
-    if (item.panelType === "default" && !!item.examples) {
-      setExampleConfigs(item.examples);
-    } else {
-      setExampleConfigs(defaultExampleConfigs);
-    }
+    setExampleConfigs(defaultExampleConfigs);
   };
 
   const isExportItemActive = activeItem.title === exportItem.title;

--- a/website/src/pages/themes/_config/axis.tsx
+++ b/website/src/pages/themes/_config/axis.tsx
@@ -2,8 +2,8 @@
 import React from "react";
 import { getBaseLabelsConfig, getBaseStrokeConfig } from "../_utils";
 import { VictoryAxis, VictoryPolarAxis } from "victory";
-import { ControlConfig, OptionsPanelConfig } from ".";
 import { StrokeProps } from "../_const";
+import { ControlConfig } from ".";
 
 const generalAxisOptionsConfig: ControlConfig = {
   type: "accordion",
@@ -54,19 +54,12 @@ const generalAxisOptionsConfig: ControlConfig = {
   ],
 };
 
-const polarAxisOptionsConfig = {
+const polarAxisOptionsConfig: ControlConfig = {
   type: "accordion",
   label: "Polar Axis",
-  content: (props) => [
-    <VictoryPolarAxis {...props} key="polar-axis" standalone={false} />,
-    <VictoryPolarAxis
-      {...props}
-      key="polar-axis-dependent"
-      dependentAxis
-      domain={[0, 10]}
-      standalone={false}
-    />,
-  ],
+  content: (props) => (
+    <VictoryPolarAxis {...props} key="polar-axis" standalone={false} />
+  ),
   controls: [
     {
       type: "section",
@@ -112,6 +105,15 @@ const polarAxisOptionsConfig = {
 const polarDependentAxisOptionsConfig: ControlConfig = {
   type: "accordion",
   label: "Polar Dependent Axis",
+  content: (props) => (
+    <VictoryPolarAxis
+      {...props}
+      key="polar-axis-dependent"
+      dependentAxis
+      domain={[0, 10]}
+      standalone={false}
+    />
+  ),
   controls: [
     {
       type: "section",
@@ -154,14 +156,15 @@ const polarDependentAxisOptionsConfig: ControlConfig = {
   ],
 };
 
-const axisOptionsConfig: OptionsPanelConfig = {
+const axisOptionsConfig = {
   title: "Axis Options",
-  description: "Customize the appearance of axes in your charts.",
-  controls: [
-    generalAxisOptionsConfig,
-    polarAxisOptionsConfig,
-    polarDependentAxisOptionsConfig,
-  ],
+  description: "Customize the appearance of axes.",
+  selectLabel: "Axis Type",
+  types: {
+    base: generalAxisOptionsConfig,
+    polarAxis: polarAxisOptionsConfig,
+    polarDependentAxis: polarDependentAxisOptionsConfig,
+  },
 };
 
 export default axisOptionsConfig;

--- a/website/src/pages/themes/_config/chart.tsx
+++ b/website/src/pages/themes/_config/chart.tsx
@@ -24,7 +24,7 @@ import {
 import { ControlConfig } from ".";
 import { NUM_STACKS, sampleStackData, StrokeProps } from "../_const";
 
-const chartOptionsConfig: {
+const chartConfigs: {
   [key: string]: ControlConfig;
 } = {
   area: {
@@ -881,6 +881,13 @@ const chartOptionsConfig: {
       },
     ],
   },
+};
+
+const chartOptionsConfig = {
+  title: "Chart Options",
+  description: "Customize the appearance of individual charts.",
+  selectLabel: "Chart Type",
+  types: chartConfigs,
 };
 
 export default chartOptionsConfig;

--- a/website/src/pages/themes/_config/index.tsx
+++ b/website/src/pages/themes/_config/index.tsx
@@ -37,6 +37,13 @@ export type OptionsPanelConfig = {
   controls: ControlConfig[];
 };
 
+export type ChartPanelConfig = {
+  title: string;
+  description?: string;
+  selectLabel: string;
+  types: Record<string, ControlConfig>;
+};
+
 export { default as paletteOptionsConfig } from "./palette";
 export { default as globalOptionsConfig } from "./global";
 export { default as axisOptionsConfig } from "./axis";

--- a/website/src/pages/themes/_providers/themeProvider.tsx
+++ b/website/src/pages/themes/_providers/themeProvider.tsx
@@ -4,7 +4,7 @@ import { setNestedConfigValue } from "../_utils";
 
 export type ThemeOption = {
   name: string;
-  config?: VictoryThemeDefinition;
+  config: VictoryThemeDefinition;
 };
 
 type ThemeContextType = {
@@ -20,21 +20,20 @@ export const themes: ThemeOption[] = [
   { name: "Grayscale", config: VictoryTheme.grayscale },
 ];
 
+const defaultTheme = themes[0];
+
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider = ({ children }) => {
-  const [baseTheme, setBaseTheme] = React.useState<ThemeOption | undefined>(
-    undefined,
-  );
-  const [customThemeConfig, setCustomThemeConfig] = React.useState<
-    VictoryThemeDefinition | undefined
-  >(undefined);
+  const [baseTheme, setBaseTheme] = React.useState<ThemeOption>(defaultTheme);
+  const [customThemeConfig, setCustomThemeConfig] =
+    React.useState<VictoryThemeDefinition>(defaultTheme.config);
 
   const onBaseThemeSelect = (themeName?: string) => {
     const theme = themes.find((t) => t.name === themeName);
     if (!theme) {
-      setBaseTheme(undefined);
-      setCustomThemeConfig(undefined);
+      setBaseTheme(defaultTheme);
+      setCustomThemeConfig(defaultTheme.config);
     } else {
       setBaseTheme(theme);
       setCustomThemeConfig({ ...theme?.config });

--- a/website/src/pages/themes/index.tsx
+++ b/website/src/pages/themes/index.tsx
@@ -12,20 +12,14 @@ import ThemePreview from "./_components/theme-preview";
 import { PreviewOptionsProvider } from "./_providers/previewOptionsProvider";
 import ExportPanel from "./_components/export-panel";
 
-const getPanel = (activeSidebarItem) => {
-  switch (activeSidebarItem.panelType) {
+const getPanel = ({ panelType, config }) => {
+  switch (panelType) {
     case "theme":
       return <BaseThemePanel />;
     case "chart":
-      return <ChartPanel />;
+      return <ChartPanel config={config} />;
     default:
-      return (
-        <OptionsPanel
-          title={activeSidebarItem.config.title}
-          description={activeSidebarItem.config.description}
-          controls={activeSidebarItem.config.controls}
-        />
-      );
+      return <OptionsPanel config={config} />;
   }
 };
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

This PR refactors `ChartPanel` to be more generic, which allows it to be used for the axis panel as well. I also updated theme builder to have the `clean` theme auto-selected as the base theme when the app loads.

![2024-12-13 16 38 21](https://github.com/user-attachments/assets/b05dec18-ce99-482b-8743-0edbbe69aecd)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update