### PR TITLE
"props.groupComponent is undefined" error

### DIFF
--- a/.changeset/large-comics-repeat.md
+++ b/.changeset/large-comics-repeat.md
@@ -1,0 +1,5 @@
+---
+"victory-bar": patch
+---
+
+Fix "props.groupComponent is undefined" error

--- a/packages/victory-bar/src/helper-methods.ts
+++ b/packages/victory-bar/src/helper-methods.ts
@@ -64,7 +64,7 @@ const getCalculatedValues = (props) => {
 
   // when inside a zoom container, reset the _x and _y properties of each datum to the original
   // x and y property values so they will not be clipped. See https://github.com/FormidableLabs/victory/pull/2970
-  if (props.groupComponent.type === VictoryClipContainer) {
+  if (props.groupComponent?.type === VictoryClipContainer) {
     data = data.map((datum) => ({ ...datum, _x: datum.x, _y: datum.y }));
   }
 

--- a/packages/victory-bar/src/victory-bar.tsx
+++ b/packages/victory-bar/src/victory-bar.tsx
@@ -148,7 +148,7 @@ class VictoryBarBase extends React.Component<VictoryBarProps> {
     // when inside a zoom container (the only place VictoryClipContainer is used), all data
     // should be renderable so bars won't dissappear before they've fully exited the container's bounds
     // see https://github.com/FormidableLabs/victory/pull/2970
-    if (props.groupComponent.type === VictoryClipContainer) {
+    if (props.groupComponent?.type === VictoryClipContainer) {
       children = this.renderData(props, VictoryBarBase.shouldRenderDatum);
     } else {
       children = this.renderData(props);


### PR DESCRIPTION
### Description

This fixes a VictoryBar issue related to #2970. That change causes a "props.groupComponent is undefined" error in our VictoryBar wrapper.

Fixes #3013

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested changes locally with our Victory-bar wrapper to ensure error is no longer generated.



