### PR TITLE
feat(theme-builder): allow users to choose which options to include in theme export

### DIFF
--- a/website/src/pages/themes/_components/button.tsx
+++ b/website/src/pages/themes/_components/button.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import React from "react";
 
 type ButtonProps = {
@@ -6,6 +7,7 @@ type ButtonProps = {
   className?: string;
   ariaLabel?: string;
   disabled?: boolean;
+  size?: "sm" | "md";
 };
 
 const Button = ({
@@ -14,17 +16,20 @@ const Button = ({
   className = "",
   ariaLabel = "",
   disabled = false,
+  size = "md",
   ...props
 }: ButtonProps) => {
-  const baseClasses =
-    "py-2 px-5 border-none font-bold rounded-md cursor-pointer text-sm bg-button-bg text-button-fg hover:underline disabled:bg-grayscale-300 disabled:text-grayscale-400 disabled:cursor-not-allowed disabled:hover:no-underline";
-
   return (
     <button
       onClick={onClick}
       disabled={disabled}
       aria-label={ariaLabel || undefined}
-      className={`${baseClasses} ${className}`}
+      className={clsx(
+        "border-none rounded-md cursor-pointer text-sm bg-button-bg text-button-fg hover:underline disabled:bg-grayscale-300 disabled:text-grayscale-400 disabled:cursor-not-allowed disabled:hover:no-underline",
+        size === "md" && "py-2 px-5 font-bold",
+        size === "sm" && "py-1.5 px-3 font-semibold",
+        className,
+      )}
       {...props}
     >
       {children}

--- a/website/src/pages/themes/_components/checkbox.tsx
+++ b/website/src/pages/themes/_components/checkbox.tsx
@@ -23,7 +23,8 @@ const Checkbox = ({
   const id = useId();
 
   return (
-    <fieldset
+    <label
+      htmlFor={id}
       className={clsx("p-0 m-0 flex items-center justify-start", className)}
     >
       <input
@@ -34,10 +35,8 @@ const Checkbox = ({
         onChange={handleChange}
         className="mr-2"
       />
-      <label htmlFor={id} className="text-sm">
-        {label}
-      </label>
-    </fieldset>
+      <span className="text-sm">{label}</span>
+    </label>
   );
 };
 export default Checkbox;

--- a/website/src/pages/themes/_components/color-picker.tsx
+++ b/website/src/pages/themes/_components/color-picker.tsx
@@ -58,11 +58,11 @@ const ColorPicker = ({
   const id = useId();
 
   return (
-    <fieldset className={clsx("p-0 m-0", className)}>
+    <label className={clsx("p-0 m-0", className)}>
       {label && (
-        <label className="block mb-1 text-sm text-grayscale-900 dark:text-white font-bold">
+        <span className="block mb-1 text-sm text-grayscale-900 dark:text-white font-bold">
           {label}
-        </label>
+        </span>
       )}
       <div className="flex items-center gap-2">
         {showColorName && (
@@ -146,7 +146,7 @@ const ColorPicker = ({
           </div>
         )}
       </div>
-    </fieldset>
+    </label>
   );
 };
 

--- a/website/src/pages/themes/_components/color-scale-override-selector.tsx
+++ b/website/src/pages/themes/_components/color-scale-override-selector.tsx
@@ -36,8 +36,8 @@ const ColorScaleOverrideSelector = ({
   };
 
   return (
-    <fieldset className={clsx("p-0 m-0", className)}>
-      <label className="block mb-3 text-sm font-bold">{label}</label>
+    <label className={clsx("p-0 m-0", className)}>
+      <span className="block mb-3 text-sm font-bold">{label}</span>
       <Toggle
         id="color-scale-override-toggle"
         label="Use custom color scale"
@@ -57,7 +57,7 @@ const ColorScaleOverrideSelector = ({
           ))}
         </div>
       )}
-    </fieldset>
+    </label>
   );
 };
 export default ColorScaleOverrideSelector;

--- a/website/src/pages/themes/_components/export-panel.tsx
+++ b/website/src/pages/themes/_components/export-panel.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from "react";
 import CodeBlock from "./code-block";
 import { useTheme } from "../_providers/themeProvider";
+import { VictoryTheme } from "victory";
+import Button from "./button";
 
 const generateThemeCode = (config, format: "js" | "ts") => {
   const jsonConfig = JSON.stringify(config, null, 2).replace(
@@ -14,24 +16,61 @@ const generateThemeCode = (config, format: "js" | "ts") => {
   return `import { VictoryThemeDefinition } from 'victory';\n\nconst customTheme: VictoryThemeDefinition = ${jsonConfig};\n\nexport default customTheme;`;
 };
 
+const availableOptions = Object.keys(VictoryTheme.clean).map((key) => {
+  return {
+    label: key,
+    value: key,
+  };
+});
+
 const ExportPanel = () => {
   const { customThemeConfig: config } = useTheme();
+  const [selectedOptions, setSelectedOptions] = React.useState<string[]>(() =>
+    availableOptions.map((option) => option.value),
+  );
+
+  const filteredConfig = useMemo(() => {
+    if (!config) return {};
+    return Object.keys(config).reduce((acc, key) => {
+      if (selectedOptions.includes(key)) {
+        acc[key] = config[key];
+      }
+      return acc;
+    }, {});
+  }, [config, selectedOptions]);
 
   const blocks = useMemo(
     () => [
       {
         title: "theme.js",
-        code: generateThemeCode(config, "js"),
+        code: generateThemeCode(filteredConfig, "js"),
         language: "jsx",
       },
       {
         title: "theme.ts",
-        code: generateThemeCode(config, "ts"),
+        code: generateThemeCode(filteredConfig, "ts"),
         language: "tsx",
       },
     ],
-    [config],
+    [filteredConfig],
   );
+
+  const handleSelectButtonClick = () => {
+    const newOptions =
+      selectedOptions.length === availableOptions.length
+        ? []
+        : availableOptions.map((option) => option.value);
+    setSelectedOptions(newOptions);
+  };
+
+  const handleCheckboxChange = (value: string) => {
+    setSelectedOptions((prev) => {
+      if (prev.includes(value)) {
+        return prev.filter((option) => option !== value);
+      }
+      return [...prev, value];
+    });
+  };
 
   return (
     <div className="max-w-screen-lg mx-auto p-10 w-export-panel">
@@ -40,14 +79,45 @@ const ExportPanel = () => {
       </h1>
       <ol className="pl-4 space-y-2">
         <li>
-          <div>
-            <strong>Save the Exported Theme File</strong>
-            <p className="mb-2">
-              Save your custom generate theme to a file in your project. Use{" "}
-              <code>theme.js</code> or <code>theme.ts</code> depending on
-              whether your project uses JavaScript or TypeScript.
-            </p>
+          <strong>Choose Theme Options to Export</strong>
+          <p className="mb-2">
+            Select the theme options to include in your custom theme export.
+          </p>
+          <div className="mb-6">
+            <ul className="space-y-2 p-0 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 w-full">
+              {availableOptions.map(({ label, value }) => (
+                <li key={value} className="flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    id={value}
+                    checked={selectedOptions.includes(value)}
+                    onChange={() => handleCheckboxChange(value)}
+                    className="mr-2"
+                  />
+                  <label htmlFor={value} className="cursor-pointer">
+                    {label}
+                  </label>
+                </li>
+              ))}
+            </ul>
+            <Button
+              onClick={handleSelectButtonClick}
+              size="sm"
+              className="mt-4"
+            >
+              {selectedOptions.length === availableOptions.length
+                ? "Deselect All"
+                : "Select All"}
+            </Button>
           </div>
+        </li>
+        <li>
+          <strong>Save the Exported Theme File</strong>
+          <p className="mb-2">
+            Save your custom generate theme to a file in your project. Use{" "}
+            <code>theme.js</code> or <code>theme.ts</code> depending on whether
+            your project uses JavaScript or TypeScript.
+          </p>
           <CodeBlock blocks={blocks} className="h-[500px]" />
         </li>
         <li>


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

This PR adds functionality that allows the user to choose which theme options to include in their export in theme builder.

![2024-12-18 11 42 57](https://github.com/user-attachments/assets/f7e4702e-9feb-4e50-aead-038c61749ba8)


#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
