### PR TITLE
Feat: theme builder default slider

### DIFF
--- a/website/src/pages/themes/_components/control.tsx
+++ b/website/src/pages/themes/_components/control.tsx
@@ -14,8 +14,14 @@ export type ColorChangeArgs = {
   colorScale: string;
 };
 
-const Control = ({ type, control, className }) => {
-  const { customThemeConfig, updateCustomThemeConfig } = useTheme();
+type ControlProps = {
+  type: string;
+  control: any;
+  className?: string;
+};
+
+const Control = ({ type, control, className }: ControlProps) => {
+  const { baseTheme, customThemeConfig, updateCustomThemeConfig } = useTheme();
   const handleColorChange = ({
     newColor,
     index,
@@ -29,6 +35,13 @@ const Control = ({ type, control, className }) => {
 
   const handleChange = (newValue) => {
     updateCustomThemeConfig(control.path, newValue);
+  };
+
+  const handleSliderToggle = (isChecked: boolean) => {
+    const defaultValue =
+      getConfigValue(baseTheme?.config, control.path, control.min) || 0;
+    const newValue = isChecked ? undefined : defaultValue;
+    handleChange(newValue);
   };
 
   const configValue = getConfigValue(
@@ -98,6 +111,7 @@ const Control = ({ type, control, className }) => {
           max={control.max}
           step={control.step}
           className={className}
+          onDefaultToggle={handleSliderToggle}
         />
       );
     case "select":

--- a/website/src/pages/themes/_components/slider.tsx
+++ b/website/src/pages/themes/_components/slider.tsx
@@ -1,16 +1,22 @@
-import React from "react";
+import React, { useState } from "react";
+import clsx from "clsx";
+import Toggle from "./toggle";
 
 type SliderProps = {
   label: string;
   id: string;
   value?: number;
   unit?: string;
-  onChange?: (value: number) => void;
+  onChange?: (value?: number) => void;
+  onDefaultToggle?: (isChecked: boolean) => void;
   min?: number;
   max?: number;
   step?: number;
   className?: string;
 };
+
+const DEFAULT_MIN = 0;
+const DEFAULT_MAX = 100;
 
 const Slider = ({
   label,
@@ -18,40 +24,75 @@ const Slider = ({
   value,
   unit,
   onChange,
-  min,
-  max,
+  onDefaultToggle,
+  min = DEFAULT_MIN,
+  max = DEFAULT_MAX,
   step = 1,
   className,
 }: SliderProps) => {
-  const handleChange = (event) => {
+  const handleSliderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.valueAsNumber;
     if (onChange) {
       onChange(newValue);
     }
   };
 
-  const valueString = value !== undefined ? `${value}${unit ?? ""}` : "default";
+  const handleNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = parseFloat(event.target.value) || min;
+    if (onChange) {
+      onChange(newValue);
+    }
+  };
+
+  const handleToggle = (isChecked: boolean) => {
+    if (!onDefaultToggle) return;
+    onDefaultToggle(isChecked);
+  };
 
   return (
-    <div className={className}>
+    <fieldset className={clsx("relative py-2 px-0 m-0", className)}>
       <label
         htmlFor={id}
-        className="flex flex-row mb-1 text-sm text-grayscale-900 dark:text-white"
+        className="flex justify-between items-center mb-2 text-sm font-bold text-grayscale-900"
       >
-        <span className="flex-1 text-sm font-bold ">{label}</span>
-        <span className="">{valueString}</span>
+        <span>{label}</span>
       </label>
-      <input
-        id={id}
-        type="range"
-        value={value}
-        onChange={handleChange}
-        className="w-full h-2 bg-grayscale-300 rounded-lg appearance-none cursor-pointer accent-blue-800 dark:bg-grayscale-700"
-        min={min}
-        max={max}
-        step={step}
+      <Toggle
+        id={`${id}-toggle`}
+        label="Use default value"
+        checked={value === undefined}
+        onChange={handleToggle}
+        size="xs"
+        className="mb-2"
       />
-    </div>
+      {value !== undefined && (
+        <div className="flex items-center gap-4">
+          <input
+            id={id}
+            type="range"
+            value={value}
+            onChange={handleSliderChange}
+            className="w-full h-2 bg-grayscale-300 rounded-lg appearance-none cursor-pointer accent-blue-800 m-0"
+            min={min}
+            max={max}
+            step={step}
+          />
+          <div className="flex items-center">
+            <input
+              type="number"
+              value={value}
+              onChange={handleNumberChange}
+              className="px-2 py-1 text-sm border border-grayscale-300 rounded-lg"
+              min={min}
+              max={max}
+              step={step}
+            />
+            {unit && <span className="text-sm ml-1">{unit}</span>}
+          </div>
+        </div>
+      )}
+    </fieldset>
   );
 };
+
 export default Slider;

--- a/website/src/pages/themes/_components/toggle.tsx
+++ b/website/src/pages/themes/_components/toggle.tsx
@@ -7,7 +7,7 @@ type ToggleProps = {
   checked: boolean;
   onChange: (checked: boolean) => void;
   className?: string;
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
 };
 
 const Toggle = ({
@@ -22,11 +22,7 @@ const Toggle = ({
     onChange(!checked);
   };
 
-  const labelSizeClasses = size === "sm" ? "font-medium" : "font-bold";
-  const toggleSize =
-    size === "sm"
-      ? "w-9 h-5 after:h-4 after:w-4"
-      : "w-11 h-6 after:h-5 after:w-5 ";
+  const labelSizeClasses = size === "md" ? "font-bold" : "font-medium";
 
   return (
     <label
@@ -47,7 +43,9 @@ const Toggle = ({
       <div
         className={clsx(
           "relative bg-grayscale-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-grayscale-300 after:border after:rounded-full after:transition-all peer-checked:bg-blue-800",
-          toggleSize,
+          size === "xs" && "w-7 h-4 after:h-3 after:w-3",
+          size === "sm" && "w-9 h-5 after:h-4 after:w-4",
+          size === "md" && "w-11 h-6 after:h-5 after:w-5",
         )}
       ></div>
     </label>


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

This PR fixes the issue where sliders were going between controlled/uncontrolled states when the config value for the slider is `undefined`.

![2024-12-19 17 02 50](https://github.com/user-attachments/assets/a733d56d-5aac-4bdc-8754-3f6962441a5e)


#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
