### PR TITLE
feat(theme-builder): simplify color picker

### DIFF
--- a/website/src/pages/themes/_components/color-palette-selector.tsx
+++ b/website/src/pages/themes/_components/color-palette-selector.tsx
@@ -1,26 +1,23 @@
 import React from "react";
-import ColorPicker from "./color-picker";
-import { ColorScalePropType, VictoryThemeDefinition } from "victory";
-import { ColorChangeArgs } from "./control";
+import { VictoryThemeDefinition } from "victory";
 import clsx from "clsx";
 import { usePreviewOptions } from "../_providers/previewOptionsProvider";
+import ColorPickerList from "./color-picker-list";
 
 type ColorPaletteSelectorProps = {
   label: string;
   value: string;
   palette?: VictoryThemeDefinition["palette"];
-  colorScaleType?: ColorScalePropType;
-  onColorChange: (args: ColorChangeArgs) => void;
   className?: string;
+  onColorsChange: (newColors: string[]) => void;
 };
 
 const ColorPaletteSelector = ({
   label,
   value,
-  colorScaleType,
   palette,
-  onColorChange,
   className,
+  onColorsChange,
 }: ColorPaletteSelectorProps) => {
   const { colorScale, updateColorScale } = usePreviewOptions();
 
@@ -28,15 +25,9 @@ const ColorPaletteSelector = ({
     updateColorScale(value);
   };
 
-  const handleColorChange = (newColor, i, cScale) => {
-    onColorChange({
-      newColor,
-      index: i,
-      colorScale: cScale,
-    });
-    if (colorScale !== cScale) {
-      updateColorScale(cScale);
-    }
+  const handleColorsChange = (newColors) => {
+    onColorsChange(newColors);
+    updateColorScale(value);
   };
 
   const isSelected = colorScale === value;
@@ -56,22 +47,11 @@ const ColorPaletteSelector = ({
         checked={isSelected}
         onChange={handleRadioChange}
       />
-      <div className="p-0 m-0">
-        <span className="block mb-3 text-sm font-bold">{label}</span>
-        {!!colorScaleType && (
-          <div className="flex flex-wrap gap-3">
-            {palette?.[colorScaleType as string]?.map((color, i) => (
-              <ColorPicker
-                key={i}
-                color={color}
-                onColorChange={(newColor) =>
-                  handleColorChange(newColor, i, colorScaleType)
-                }
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <ColorPickerList
+        label={label}
+        colors={palette?.[value as string]}
+        onColorsChange={handleColorsChange}
+      />
     </label>
   );
 };

--- a/website/src/pages/themes/_components/color-picker-list.tsx
+++ b/website/src/pages/themes/_components/color-picker-list.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import ColorPicker, { PLACEHOLDER_COLOR } from "./color-picker";
+import clsx from "clsx";
+import { TiPlus } from "react-icons/ti";
+
+type ColorPickerListProps = {
+  label?: string;
+  colors?: string[];
+  onColorsChange: (newColors: string[]) => void;
+  className?: string;
+};
+
+const ColorPickerList = ({
+  label,
+  colors = [],
+  onColorsChange,
+  className,
+}: ColorPickerListProps) => {
+  const handleColorChange = (newColor, i) => {
+    const updatedColors = [...colors];
+    updatedColors[i] = newColor;
+    onColorsChange(updatedColors);
+  };
+
+  const handleRemoveColor = (i) => {
+    const updatedColors = [...colors];
+    updatedColors.splice(i, 1);
+    onColorsChange(updatedColors);
+  };
+
+  const handleAddColor = () => {
+    const updatedColors = [...colors, PLACEHOLDER_COLOR];
+    onColorsChange(updatedColors);
+  };
+
+  return (
+    <div className={clsx("p-0 m-0", className)}>
+      {label && <span className="block mb-3 text-sm font-bold">{label}</span>}
+      <div className="flex flex-wrap gap-3">
+        {colors.map((color, i) => (
+          <ColorPicker
+            key={i}
+            color={color}
+            onColorChange={(newColor) => handleColorChange(newColor, i)}
+            onColorRemove={() => handleRemoveColor(i)}
+          />
+        ))}
+        <button
+          onClick={handleAddColor}
+          className="flex w-[35px] h-[35px] p-0.5 rounded-full cursor-pointer justify-center items-center border-2 border-grayscale-300"
+        >
+          <TiPlus />
+        </button>
+      </div>
+    </div>
+  );
+};
+export default ColorPickerList;

--- a/website/src/pages/themes/_components/color-picker.tsx
+++ b/website/src/pages/themes/_components/color-picker.tsx
@@ -1,5 +1,5 @@
 import React, { useId } from "react";
-import { TiPencil } from "react-icons/ti";
+import { IoMdClose } from "react-icons/io";
 import clsx from "clsx";
 import Select from "./select";
 
@@ -7,11 +7,12 @@ type ColorPickerProps = {
   label?: string;
   color: string;
   onColorChange: (color?: string) => void;
+  onColorRemove?: () => void;
   showSelectOptions?: boolean;
   className?: string;
 };
 
-const PLACEHOLDER_COLOR = "#000000";
+export const PLACEHOLDER_COLOR = "#000000";
 const DEFAULT_COLOR = undefined;
 enum ColorPickerOptions {
   NONE = "none",
@@ -22,6 +23,7 @@ const ColorPicker = ({
   label,
   color,
   onColorChange,
+  onColorRemove,
   showSelectOptions = false,
   className,
 }: ColorPickerProps) => {
@@ -53,6 +55,10 @@ const ColorPicker = ({
     if (onColorChange) {
       onColorChange(event.target.value);
     }
+  };
+
+  const handleRemoveColor = () => {
+    if (onColorRemove) onColorRemove();
   };
 
   const id = useId();
@@ -88,7 +94,7 @@ const ColorPicker = ({
               <div className="relative">
                 <div
                   className={clsx(
-                    "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor outline-2 border-2 border-white outline outline-grayscale-300 group-hover/swatch:outline-currentColor",
+                    "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor outline-2 border-2 border-white outline outline-grayscale-300 group-hover/swatch:outline-grayscale-800",
                     isPickerOpen
                       ? "outline-currentColor"
                       : "outline-grayscale-300",
@@ -97,9 +103,14 @@ const ColorPicker = ({
                     color,
                   }}
                 />
-                <div className="absolute top-0 left-0 w-full h-full text-white flex justify-center items-center text-xl rounded-full">
-                  <TiPencil />
-                </div>
+                {onColorRemove && (
+                  <button
+                    onClick={handleRemoveColor}
+                    className="absolute -top-1 -right-1 w-4 h-4 text-white bg-red-500 flex justify-center items-center text-2xl font-bold rounded-full opacity-0 p-0.5 group-hover/swatch:opacity-100 z-20 cursor-pointer"
+                  >
+                    <IoMdClose />
+                  </button>
+                )}
               </div>
             </div>
             <input

--- a/website/src/pages/themes/_components/color-picker.tsx
+++ b/website/src/pages/themes/_components/color-picker.tsx
@@ -7,7 +7,7 @@ type ColorPickerProps = {
   label?: string;
   color: string;
   onColorChange: (color?: string) => void;
-  showColorName?: boolean;
+  showSelectOptions?: boolean;
   className?: string;
 };
 
@@ -22,7 +22,7 @@ const ColorPicker = ({
   label,
   color,
   onColorChange,
-  showColorName = false,
+  showSelectOptions = false,
   className,
 }: ColorPickerProps) => {
   const [isPickerOpen, setIsPickerOpen] = React.useState(false);
@@ -64,8 +64,8 @@ const ColorPicker = ({
           {label}
         </span>
       )}
-      <div className="flex items-center gap-2">
-        {showColorName && (
+      <div className="flex items-center justify-between gap-2">
+        {showSelectOptions && (
           <div className="flex items-center my-2 flex-1">
             <Select
               id={id}
@@ -82,56 +82,26 @@ const ColorPicker = ({
         )}
         {colorOption === ColorPickerOptions.CUSTOM && (
           <div
-            className={clsx(
-              "relative inline-flex rounded-full group/swatch flex-1",
-              {
-                "border-2 border-grayscale-300 p-0.5 cursor-pointer justify-between bg-grayscale-100":
-                  showColorName,
-              },
-            )}
+            className={clsx("relative inline-flex rounded-full group/swatch")}
           >
             <div className="flex items-center">
               <div className="relative">
                 <div
                   className={clsx(
-                    "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor",
-                    {
-                      "outline-2 border-2 border-white outline outline-grayscale-300":
-                        !showColorName,
-                    },
-                    { "w-[30px] h-[30px] p-0.5": showColorName },
+                    "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor outline-2 border-2 border-white outline outline-grayscale-300 group-hover/swatch:outline-currentColor",
+                    isPickerOpen
+                      ? "outline-currentColor"
+                      : "outline-grayscale-300",
                   )}
                   style={{
                     color,
                   }}
                 />
-                {!showColorName && (
-                  <div
-                    className={`absolute top-0 left-0 w-full h-full text-white flex justify-center items-center text-xl rounded-full opacity-0 group-hover/swatch:opacity-100 ${
-                      isPickerOpen ? "opacity-100" : ""
-                    }`}
-                  >
-                    <TiPencil />
-                  </div>
-                )}
+                <div className="absolute top-0 left-0 w-full h-full text-white flex justify-center items-center text-xl rounded-full">
+                  <TiPencil />
+                </div>
               </div>
-              {showColorName && (
-                <span
-                  className={
-                    "text-sm font-medium text-grayscale-900 uppercase ml-2 cursor-pointer"
-                  }
-                >
-                  {color}
-                </span>
-              )}
             </div>
-            {showColorName && (
-              <div
-                className={`text-grayscale-400 flex justify-center items-center text-xl rounded-full place-items-end ml-6 mr-1`}
-              >
-                <TiPencil />
-              </div>
-            )}
             <input
               id={id}
               className={`absolute top-0 left-0 w-full h-full cursor-pointer opacity-0 z-10 group-hover/swatch:border-currentColor ${

--- a/website/src/pages/themes/_components/color-picker.tsx
+++ b/website/src/pages/themes/_components/color-picker.tsx
@@ -87,14 +87,22 @@ const ColorPicker = ({
           </div>
         )}
         {colorOption === ColorPickerOptions.CUSTOM && (
-          <div
-            className={clsx("relative inline-flex rounded-full group/swatch")}
-          >
+          <div className="relative inline-flex rounded-full group/swatch">
             <div className="flex items-center">
               <div className="relative">
+                {onColorRemove && (
+                  <div className="absolute -top-1 -right-1 z-20 group/remove">
+                    <button
+                      onClick={handleRemoveColor}
+                      className="w-4 h-4 text-white bg-red-500 flex justify-center items-center text-2xl font-bold rounded-full p-0.5 cursor-pointer opacity-0 group-hover/swatch:opacity-100 group-hover/remove:bg-red-800"
+                    >
+                      <IoMdClose />
+                    </button>
+                  </div>
+                )}
                 <div
                   className={clsx(
-                    "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor outline-2 border-2 border-white outline outline-grayscale-300 group-hover/swatch:outline-grayscale-800",
+                    "block w-[35px] h-[35px] rounded-full cursor-pointer transition-all justify-center items-center after:content-[''] after:block after:w-full after:h-full after:rounded-[inherit] after:bg-currentColor outline-2 border-2 border-white outline outline-grayscale-300",
                     isPickerOpen
                       ? "outline-currentColor"
                       : "outline-grayscale-300",
@@ -103,14 +111,6 @@ const ColorPicker = ({
                     color,
                   }}
                 />
-                {onColorRemove && (
-                  <button
-                    onClick={handleRemoveColor}
-                    className="absolute -top-1 -right-1 w-4 h-4 text-white bg-red-500 flex justify-center items-center text-2xl font-bold rounded-full opacity-0 p-0.5 group-hover/swatch:opacity-100 z-20 cursor-pointer"
-                  >
-                    <IoMdClose />
-                  </button>
-                )}
               </div>
             </div>
             <input

--- a/website/src/pages/themes/_components/color-scale-override-selector.tsx
+++ b/website/src/pages/themes/_components/color-scale-override-selector.tsx
@@ -1,17 +1,17 @@
-import React, { useCallback } from "react";
-import ColorPicker from "./color-picker";
+import React, { useCallback, useEffect } from "react";
 import clsx from "clsx";
 import Toggle from "./toggle";
 import {
   defaultColorScale,
   usePreviewOptions,
 } from "../_providers/previewOptionsProvider";
+import ColorPickerList from "./color-picker-list";
 
 type ColorScaleOverrideSelectorProps = {
   id: string;
   label?: string;
-  value?: string | string[];
-  onChange: (value: string[] | undefined) => void;
+  colors?: string | string[];
+  onColorsChange: (colors: string[] | undefined) => void;
   hideDefaultToggle?: boolean;
   className?: string;
 };
@@ -19,15 +19,14 @@ type ColorScaleOverrideSelectorProps = {
 const ColorScaleOverrideSelector = ({
   id,
   label = "Color Scale",
-  value,
-  onChange,
+  colors,
+  onColorsChange,
   hideDefaultToggle = false,
   className,
 }: ColorScaleOverrideSelectorProps) => {
   const { colorScale, updateColorScale } = usePreviewOptions();
-  const hasCustomValue = Array.isArray(value);
-  const [initialCustomValue] = React.useState(
-    hasCustomValue ? value : undefined,
+  const [showCustomColors, setShowCustomColors] = React.useState(
+    () => !!colors && Array.isArray(colors),
   );
 
   const setColorScaleToDefault = useCallback(() => {
@@ -37,18 +36,15 @@ const ColorScaleOverrideSelector = ({
   }, [colorScale, updateColorScale]);
 
   const onCheckboxChange = (isChecked) => {
-    if (isChecked) {
-      onChange(initialCustomValue);
-    } else {
-      onChange(undefined);
+    setShowCustomColors(isChecked);
+    if (!isChecked) {
+      onColorsChange(undefined);
     }
     setColorScaleToDefault();
   };
 
-  const handleColorChange = (newColor, index) => {
-    const newValue = [...(value as string[])];
-    newValue[index] = newColor;
-    onChange(newValue);
+  const handleColorsChange = (newColors) => {
+    onColorsChange(newColors);
     setColorScaleToDefault();
   };
 
@@ -59,22 +55,14 @@ const ColorScaleOverrideSelector = ({
         <Toggle
           id={id}
           label="Use custom color scale"
-          checked={hasCustomValue}
+          checked={showCustomColors}
           onChange={onCheckboxChange}
           className="mb-3"
           size="sm"
         />
       )}
-      {hasCustomValue && (
-        <div className="flex flex-wrap gap-2 mt-3">
-          {value.map((color, i) => (
-            <ColorPicker
-              key={i}
-              color={color}
-              onColorChange={(newColor) => handleColorChange(newColor, i)}
-            />
-          ))}
-        </div>
+      {showCustomColors && typeof colors !== "string" && (
+        <ColorPickerList colors={colors} onColorsChange={handleColorsChange} />
       )}
     </label>
   );

--- a/website/src/pages/themes/_components/control.tsx
+++ b/website/src/pages/themes/_components/control.tsx
@@ -23,16 +23,6 @@ type ControlProps = {
 
 const Control = ({ type, control, className }: ControlProps) => {
   const { baseTheme, customThemeConfig, updateCustomThemeConfig } = useTheme();
-  const handleColorChange = ({
-    newColor,
-    index,
-    colorScale,
-  }: ColorChangeArgs) => {
-    const updatedColors = customThemeConfig?.palette?.[colorScale]?.map(
-      (color, i) => (i === index ? newColor : color),
-    );
-    updateCustomThemeConfig(`palette.${colorScale}`, updatedColors);
-  };
 
   const handleChange = (newValue) => {
     updateCustomThemeConfig(control.path, newValue);
@@ -78,8 +68,7 @@ const Control = ({ type, control, className }: ControlProps) => {
           label={control.label}
           value={control.value}
           palette={customThemeConfig?.palette}
-          colorScaleType={control.colorScaleType}
-          onColorChange={handleColorChange}
+          onColorsChange={handleChange}
           className="my-4"
         />
       );
@@ -140,8 +129,8 @@ const Control = ({ type, control, className }: ControlProps) => {
         <ColorScaleOverrideSelector
           id={id}
           label={control.label}
-          value={configValue as string}
-          onChange={handleChange}
+          colors={configValue as string}
+          onColorsChange={handleChange}
           className={className}
           hideDefaultToggle={control.hideDefaultToggle}
         />

--- a/website/src/pages/themes/_components/control.tsx
+++ b/website/src/pages/themes/_components/control.tsx
@@ -162,7 +162,7 @@ const Control = ({ type, control, className }: ControlProps) => {
           color={configValue as string}
           onColorChange={handleChange}
           className={className}
-          showColorName
+          showSelectOptions
         />
       );
     default:

--- a/website/src/pages/themes/_config/index.tsx
+++ b/website/src/pages/themes/_config/index.tsx
@@ -14,8 +14,8 @@ export type ControlConfig = {
     }
   | {
       type: "colorPalette";
-      colorScaleType: string;
       value: string;
+      path: string | string[];
     }
   | {
       type: "colorScale";

--- a/website/src/pages/themes/_config/palette.tsx
+++ b/website/src/pages/themes/_config/palette.tsx
@@ -36,8 +36,8 @@ const paletteOptionsConfig: OptionsPanelConfig = {
       controls: colorScaleOptions.map((option) => ({
         type: "colorPalette",
         label: option.label,
-        colorScaleType: option.value,
         value: option.value,
+        path: `palette.${option.value}`,
       })),
     },
   ],


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

This PR simplifies the color picker UI and also adds the ability to add and remove colors from a palette.
https://www.notion.so/nearform/Simplify-color-picker-1759aa50dea2800eb152e80015f77385?pvs=4

| Color Scale | Individual Color Picker |
| --- | --- |
| ![2025-01-09 13 53 41](https://github.com/user-attachments/assets/8ccf47b5-7636-450f-a9b1-0f85faf4a8cc) | ![2025-01-09 13 55 36](https://github.com/user-attachments/assets/cc72d752-1c26-4eed-b7c0-93c5360ff12e) |

