### PR TITLE
feat(theme-builder): add warning message when leaving theme builder

### DIFF
--- a/website/src/pages/themes/index.tsx
+++ b/website/src/pages/themes/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import "../../css/custom.css";
 
@@ -11,6 +11,7 @@ import { ThemeProvider } from "./_providers/themeProvider";
 import { ThemePreview } from "./_components/theme-preview";
 import { PreviewOptionsProvider } from "./_providers/previewOptionsProvider";
 import ExportPanel from "./_components/export-panel";
+import { useHistory } from "@docusaurus/router";
 
 const getPanel = ({ panelType, config }) => {
   switch (panelType) {
@@ -23,10 +24,38 @@ const getPanel = ({ panelType, config }) => {
   }
 };
 
+const UNSAVED_CHANGES_MESSAGE =
+  "If you leave this page, your changes will be lost. Are you sure you want to continue?";
+
 const ThemeBuilder = () => {
   const [activeSidebarItem, setActiveSidebarItem] = React.useState(
     NAV_ITEMS[0],
   );
+  const history = useHistory();
+
+  useEffect(() => {
+    const unblock = history.block((location) => {
+      if (window.confirm(UNSAVED_CHANGES_MESSAGE)) {
+        unblock();
+        history.push(location.pathname);
+      }
+      return false;
+    });
+
+    const blockBeforeRefresh = (event) => {
+      const message = UNSAVED_CHANGES_MESSAGE;
+      event.preventDefault();
+      event.returnValue = message;
+      return message;
+    };
+
+    window.addEventListener("beforeunload", blockBeforeRefresh);
+
+    return () => {
+      window.removeEventListener("beforeunload", blockBeforeRefresh);
+      unblock();
+    };
+  }, [history]);
 
   const isExportPanel = activeSidebarItem.panelType === "export";
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

This PR adds a warning alert when users try to navigate away from theme builder.
https://www.notion.so/nearform/Display-prompt-when-navigating-away-mid-edit-1759aa50dea280358b9ef7f65bb45dcb?pvs=4

![2025-01-10 10 48 53](https://github.com/user-attachments/assets/95fae27d-e938-4927-b5a8-45175fee6fd0)

