### PR TITLE
feat(theme-builder): keep config in local storage

### DIFF
--- a/website/src/hooks/useLocalStorage.tsx
+++ b/website/src/hooks/useLocalStorage.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export const useLocalStorage = (key: string, initialValue: any) => {
+  const [storedValue, setStoredValue] = useState(() => {
+    if (typeof window === "undefined") return initialValue;
+
+    try {
+      const item = localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        localStorage.setItem(key, JSON.stringify(storedValue));
+      } catch (error) {
+        console.error("Error saving to localStorage", error);
+      }
+    }
+  }, [storedValue, key]);
+
+  return [storedValue, setStoredValue];
+};

--- a/website/src/pages/themes/_providers/themeProvider.tsx
+++ b/website/src/pages/themes/_providers/themeProvider.tsx
@@ -28,12 +28,13 @@ export const themes: ThemeOption[] = [
 const defaultTheme = themes[0];
 
 const localStorageCustomConfigKey = "customThemeConfig";
+const localStorageBaseThemeKey = "baseTheme";
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider = ({ children }) => {
   const [baseTheme, setBaseTheme] = React.useState<ThemeOption>(() => {
-    const storedTheme = localStorage.getItem("baseTheme");
+    const storedTheme = localStorage.getItem(localStorageBaseThemeKey);
     const baseThemeFromStorage = storedTheme
       ? JSON.parse(storedTheme)
       : defaultTheme;
@@ -58,7 +59,7 @@ export const ThemeProvider = ({ children }) => {
   }, [customThemeConfig]);
 
   useEffect(() => {
-    localStorage.setItem("baseTheme", JSON.stringify(baseTheme));
+    localStorage.setItem(localStorageBaseThemeKey, JSON.stringify(baseTheme));
   }, [baseTheme]);
 
   const onBaseThemeSelect = (themeName?: string) => {

--- a/website/src/pages/themes/_providers/themeProvider.tsx
+++ b/website/src/pages/themes/_providers/themeProvider.tsx
@@ -34,6 +34,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider = ({ children }) => {
   const [baseTheme, setBaseTheme] = React.useState<ThemeOption>(() => {
+    if (typeof window === "undefined") return defaultTheme;
     const storedTheme = localStorage.getItem(localStorageBaseThemeKey);
     const baseThemeFromStorage = storedTheme
       ? JSON.parse(storedTheme)
@@ -45,12 +46,13 @@ export const ThemeProvider = ({ children }) => {
   });
   const [customThemeConfig, setCustomThemeConfig] =
     React.useState<VictoryThemeDefinition>(() => {
+      if (typeof window === "undefined") return defaultTheme.config;
       const storedConfig = localStorage.getItem(localStorageCustomConfigKey);
       return storedConfig ? JSON.parse(storedConfig) : defaultTheme.config;
     });
 
   useEffect(() => {
-    if (customThemeConfig) {
+    if (customThemeConfig && typeof window !== "undefined") {
       localStorage.setItem(
         localStorageCustomConfigKey,
         JSON.stringify(customThemeConfig),
@@ -59,7 +61,8 @@ export const ThemeProvider = ({ children }) => {
   }, [customThemeConfig]);
 
   useEffect(() => {
-    localStorage.setItem(localStorageBaseThemeKey, JSON.stringify(baseTheme));
+    if (typeof window !== "undefined")
+      localStorage.setItem(localStorageBaseThemeKey, JSON.stringify(baseTheme));
   }, [baseTheme]);
 
   const onBaseThemeSelect = (themeName?: string) => {

--- a/website/src/pages/themes/_providers/themeProvider.tsx
+++ b/website/src/pages/themes/_providers/themeProvider.tsx
@@ -1,11 +1,7 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-} from "react";
+import React, { createContext, useCallback, useContext } from "react";
 import { VictoryTheme, VictoryThemeDefinition } from "victory";
 import { setNestedConfigValue } from "../_utils";
+import { useLocalStorage } from "@site/src/hooks/useLocalStorage";
 
 export type ThemeOption = {
   name: string;
@@ -33,37 +29,14 @@ const localStorageBaseThemeKey = "baseTheme";
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider = ({ children }) => {
-  const [baseTheme, setBaseTheme] = React.useState<ThemeOption>(() => {
-    if (typeof window === "undefined") return defaultTheme;
-    const storedTheme = localStorage.getItem(localStorageBaseThemeKey);
-    const baseThemeFromStorage = storedTheme
-      ? JSON.parse(storedTheme)
-      : defaultTheme;
-    const validTheme = themes.find(
-      (t) => t.name === baseThemeFromStorage?.name,
-    );
-    return validTheme ?? defaultTheme;
-  });
-  const [customThemeConfig, setCustomThemeConfig] =
-    React.useState<VictoryThemeDefinition>(() => {
-      if (typeof window === "undefined") return defaultTheme.config;
-      const storedConfig = localStorage.getItem(localStorageCustomConfigKey);
-      return storedConfig ? JSON.parse(storedConfig) : defaultTheme.config;
-    });
-
-  useEffect(() => {
-    if (customThemeConfig && typeof window !== "undefined") {
-      localStorage.setItem(
-        localStorageCustomConfigKey,
-        JSON.stringify(customThemeConfig),
-      );
-    }
-  }, [customThemeConfig]);
-
-  useEffect(() => {
-    if (typeof window !== "undefined")
-      localStorage.setItem(localStorageBaseThemeKey, JSON.stringify(baseTheme));
-  }, [baseTheme]);
+  const [baseTheme, setBaseTheme] = useLocalStorage(
+    localStorageBaseThemeKey,
+    defaultTheme,
+  );
+  const [customThemeConfig, setCustomThemeConfig] = useLocalStorage(
+    localStorageCustomConfigKey,
+    defaultTheme.config,
+  );
 
   const onBaseThemeSelect = (themeName?: string) => {
     const theme = themes.find((t) => t.name === themeName);
@@ -88,7 +61,7 @@ export const ThemeProvider = ({ children }) => {
       );
       setCustomThemeConfig(updatedConfig);
     },
-    [customThemeConfig],
+    [customThemeConfig, setCustomThemeConfig],
   );
 
   return (


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description
This PR stores the selected base theme and custom theme config in local storage. That way, if users navigate away, their work is saved.

Relates to https://www.notion.so/nearform/Display-prompt-when-navigating-away-mid-edit-1759aa50dea280358b9ef7f65bb45dcb?pvs=4

![2025-01-10 14 10 52](https://github.com/user-attachments/assets/49bb44f0-eaca-45f9-9120-72f91a06c681)

