### PR TITLE
feat(theme-builder): default chart + axis type

### DIFF
--- a/website/src/pages/themes/_components/chart-panel.tsx
+++ b/website/src/pages/themes/_components/chart-panel.tsx
@@ -14,24 +14,35 @@ const ChartPanel = ({
 }: ChartPanelProps) => {
   const [chartType, setChartType] = React.useState(Object.keys(types)[0]);
   const { setExampleContent } = usePreviewOptions();
-  const options = Object.keys(types).map((key) => ({
-    label: types[key].label,
-    value: key,
-  }));
-  const controls = types[chartType]?.controls || [];
+
+  useEffect(() => {
+    const newChartType = Object.keys(types)[0];
+    setChartType((prevChartType) =>
+      prevChartType !== newChartType ? newChartType : prevChartType,
+    );
+  }, [types]);
+
+  useEffect(() => {
+    const examples = types[chartType]?.content ?? [];
+    setExampleContent(examples);
+  }, [types, chartType, setExampleContent]);
+
+  const options = useMemo(
+    () =>
+      Object.keys(types).map((key) => ({
+        label: types[key].label,
+        value: key,
+      })),
+    [types],
+  );
+  const controls = useMemo(
+    () => types[chartType]?.controls || [],
+    [types, chartType],
+  );
 
   const onChartTypeChange = (newValue: string) => {
     setChartType(newValue);
   };
-
-  useEffect(() => {
-    const newChartType = Object.keys(types)[0];
-    if (chartType !== newChartType) {
-      const examples = types[newChartType]?.content || [];
-      setChartType(newChartType);
-      setExampleContent(examples);
-    }
-  }, [types, chartType, setExampleContent]);
 
   return (
     <>

--- a/website/src/pages/themes/_components/chart-panel.tsx
+++ b/website/src/pages/themes/_components/chart-panel.tsx
@@ -14,17 +14,10 @@ const ChartPanel = ({
 }: ChartPanelProps) => {
   const [chartType, setChartType] = React.useState(Object.keys(types)[0]);
   const { setExampleContent } = usePreviewOptions();
-  const selectOptions = Object.keys(types).map((key) => ({
+  const options = Object.keys(types).map((key) => ({
     label: types[key].label,
     value: key,
   }));
-  const options = useMemo(
-    () => [
-      { label: `Select ${selectLabel.toLowerCase()}`, value: "" },
-      ...selectOptions,
-    ],
-    [selectOptions, selectLabel],
-  );
   const controls = types[chartType]?.controls || [];
 
   const onChartTypeChange = (newValue: string) => {
@@ -32,9 +25,13 @@ const ChartPanel = ({
   };
 
   useEffect(() => {
-    const examples = types[chartType]?.content || [];
-    setExampleContent(examples);
-  }, [chartType, setExampleContent, types]);
+    const newChartType = Object.keys(types)[0];
+    if (chartType !== newChartType) {
+      const examples = types[newChartType]?.content || [];
+      setChartType(newChartType);
+      setExampleContent(examples);
+    }
+  }, [types, chartType, setExampleContent]);
 
   return (
     <>


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

This PR sets a default chart and axis type for when users first navigate to those options panels to avoid having an empty state in the preview area.
https://www.notion.so/nearform/Add-simple-empty-state-1759aa50dea280008e82e4ecc9b35e03?pvs=4

![2025-01-13 10 10 25](https://github.com/user-attachments/assets/892b53a2-10f6-4bf5-b10b-89206583203a)