### PR TITLE
feat(theme-builder): update options components styles

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -112,5 +112,14 @@ body {
   .theme-builder * {
     border-width: 0;
     border-style: solid;
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-family: Inter, Helvetica, Arial, sans-serif;
+    }
   }
 }

--- a/website/src/pages/themes/_components/accordion.tsx
+++ b/website/src/pages/themes/_components/accordion.tsx
@@ -7,6 +7,7 @@ type AccordionProps = {
   title: string;
   children: React.ReactNode;
   defaultOpen?: boolean;
+  className?: string;
 };
 
 const Accordion = ({
@@ -14,6 +15,7 @@ const Accordion = ({
   title,
   children,
   defaultOpen = false,
+  className,
 }: AccordionProps) => {
   const [isOpen, setIsOpen] = React.useState(defaultOpen);
 
@@ -22,7 +24,7 @@ const Accordion = ({
   };
 
   return (
-    <div id={id} className="group">
+    <div id={id} className={clsx("group", className)}>
       <h2 id={`${id}-heading`} className="mb-0">
         <button
           type="button"

--- a/website/src/pages/themes/_components/chart-panel.tsx
+++ b/website/src/pages/themes/_components/chart-panel.tsx
@@ -61,7 +61,6 @@ const ChartPanel = ({
             key={control.label + i}
             type={control.type}
             control={control}
-            className="my-4"
           />
         );
       })}

--- a/website/src/pages/themes/_components/code-panel.tsx
+++ b/website/src/pages/themes/_components/code-panel.tsx
@@ -76,7 +76,9 @@ const CodePanel = () => {
           </code>{" "}
           are required for proper theme functionality.
         </p>
-        <Button onClick={applyCustomTheme}>Apply Changes</Button>
+        <Button onClick={applyCustomTheme} className="flex-shrink-0">
+          Apply Changes
+        </Button>
       </div>
       <div className="w-full flex-1 border rounded">
         <Editor

--- a/website/src/pages/themes/_components/color-picker-list.tsx
+++ b/website/src/pages/themes/_components/color-picker-list.tsx
@@ -35,7 +35,11 @@ const ColorPickerList = ({
 
   return (
     <div className={clsx("p-0 m-0", className)}>
-      {label && <span className="block mb-3 text-sm font-bold">{label}</span>}
+      {label && (
+        <span className="block mb-3 text-sm font-semibold text-gray-800">
+          {label}
+        </span>
+      )}
       <div className="flex flex-wrap gap-3">
         {colors.map((color, i) => (
           <ColorPicker

--- a/website/src/pages/themes/_components/color-picker.tsx
+++ b/website/src/pages/themes/_components/color-picker.tsx
@@ -64,15 +64,18 @@ const ColorPicker = ({
   const id = useId();
 
   return (
-    <label className={clsx("p-0 m-0", className)}>
+    <div className={clsx("p-0 m-0", className)}>
       {label && (
-        <span className="block mb-1 text-sm text-grayscale-900 dark:text-white font-bold">
+        <label
+          htmlFor={id}
+          className="block mb-1 text-sm font-semibold text-gray-800 dark:text-white"
+        >
           {label}
-        </span>
+        </label>
       )}
       <div className="flex items-center justify-between gap-2">
         {showSelectOptions && (
-          <div className="flex items-center my-2 flex-1">
+          <div className="flex items-center flex-1">
             <Select
               id={id}
               value={colorOption}
@@ -127,7 +130,7 @@ const ColorPicker = ({
           </div>
         )}
       </div>
-    </label>
+    </div>
   );
 };
 

--- a/website/src/pages/themes/_components/color-scale-override-selector.tsx
+++ b/website/src/pages/themes/_components/color-scale-override-selector.tsx
@@ -49,8 +49,10 @@ const ColorScaleOverrideSelector = ({
   };
 
   return (
-    <label className={clsx("p-0 m-0", className)}>
-      <span className="block mb-3 text-sm font-bold">{label}</span>
+    <div className={clsx("p-0 m-0", className)}>
+      <label htmlFor={id} className="block mb-3 text-sm font-bold">
+        {label}
+      </label>
       {!hideDefaultToggle && (
         <Toggle
           id={id}
@@ -64,7 +66,7 @@ const ColorScaleOverrideSelector = ({
       {showCustomColors && typeof colors !== "string" && (
         <ColorPickerList colors={colors} onColorsChange={handleColorsChange} />
       )}
-    </label>
+    </div>
   );
 };
 export default ColorScaleOverrideSelector;

--- a/website/src/pages/themes/_components/control.tsx
+++ b/website/src/pages/themes/_components/control.tsx
@@ -51,6 +51,7 @@ const Control = ({ type, control, className }: ControlProps) => {
           title={control.label}
           id={id}
           defaultOpen={control.defaultOpen}
+          className="!my-0"
         >
           {control.controls?.map((nestedControl, i) => (
             <Control
@@ -74,9 +75,9 @@ const Control = ({ type, control, className }: ControlProps) => {
       );
     case "section":
       return (
-        <section className="mb-8">
+        <section className="mb-6 bg-white p-4 rounded-md space-y-4">
           <div className="mb-4">
-            <h3 className="text-lg font-semibold text-secondary mb-0">
+            <h3 className="text-lg font-bold text-secondary mb-0 text-gray-800">
               {control.label}
             </h3>
             {control.description && (

--- a/website/src/pages/themes/_components/main.tsx
+++ b/website/src/pages/themes/_components/main.tsx
@@ -18,7 +18,7 @@ const Main = () => {
 
   return (
     <>
-      <aside className="sticky top-[60px] h-theme-builder p-6 border-r border-grayscale-300 overflow-y-scroll w-[380px] bg-gray-100">
+      <aside className="sticky top-[60px] h-theme-builder p-6 border-r border-grayscale-300 overflow-y-scroll w-[390px] bg-gray-100">
         {activeSideNavItem.panelType === "theme" && <BaseThemePanel />}
         {activeSideNavItem.panelType === "chart" && (
           <ChartPanel config={activeSideNavItem.config} />

--- a/website/src/pages/themes/_components/panel-header.tsx
+++ b/website/src/pages/themes/_components/panel-header.tsx
@@ -8,7 +8,9 @@ type PanelHeaderProps = {
 const PanelHeader = ({ title, description }: PanelHeaderProps) => {
   return (
     <div className="mb-4">
-      {!!title && <h2 className="mb-0 text-xl font-bold">{title}</h2>}
+      {!!title && (
+        <h2 className="mb-0 text-xl font-bold text-gray-800">{title}</h2>
+      )}
       {!!description && (
         <p className="text-sm mt-1 text-grayscale-400">{description}</p>
       )}

--- a/website/src/pages/themes/_components/select.tsx
+++ b/website/src/pages/themes/_components/select.tsx
@@ -33,7 +33,7 @@ const Select = ({
     }
   };
 
-  const labelSizeClasses = size === "sm" ? "font-medium" : "font-bold";
+  const labelSizeClasses = size === "sm" ? "font-medium" : "font-semibold";
   const selectSizeClasses =
     size === "sm" ? "text-sm px-2 py-1.5" : "text-base p-2";
 
@@ -42,7 +42,10 @@ const Select = ({
       {label && (
         <label
           htmlFor={id}
-          className={clsx("block flex-1 my-1 text-sm", labelSizeClasses)}
+          className={clsx(
+            "block flex-1 mb-1 text-sm text-gray-800",
+            labelSizeClasses,
+          )}
         >
           {label}
         </label>
@@ -52,7 +55,7 @@ const Select = ({
         value={value}
         onChange={handleChange}
         className={clsx(
-          "w-full border border-grayscale-300 bg-white appearance-none rounded-md bg-select-chevron bg-no-repeat bg-[right_8px_center] bg-[length:16px] flex-1",
+          "w-full border border-grayscale-300 bg-white appearance-none rounded-md bg-select-chevron bg-no-repeat bg-[right_8px_center] bg-[length:16px] flex-1 font-sans text-sm p-2.5",
           selectSizeClasses,
         )}
       >

--- a/website/src/pages/themes/_components/sideNavButton.tsx
+++ b/website/src/pages/themes/_components/sideNavButton.tsx
@@ -24,7 +24,7 @@ const SideNavButton = ({
       onClick={onClick}
       disabled={isDisabled}
       className={clsx(
-        "group flex w-full flex-col items-center rounded-md p-3 text-xs font-bold cursor-pointer",
+        "group flex w-full flex-col items-center rounded-md p-3 text-xs font-semibold cursor-pointer",
         isActive
           ? "text-white bg-gray-800"
           : "text-grayscale-300 hover:text-white disabled:text-grayscale-800 disabled:cursor-not-allowed bg-transparent hover:bg-gray-900",

--- a/website/src/pages/themes/_components/slider.tsx
+++ b/website/src/pages/themes/_components/slider.tsx
@@ -49,48 +49,58 @@ const Slider = ({
     onDefaultToggle(isChecked);
   };
 
+  const isUsingDefault = value === undefined;
+
   return (
-    <fieldset className={clsx("relative py-2 px-0 m-0", className)}>
+    <fieldset className={clsx("relative p-0 m-0", className)}>
       <label
         htmlFor={id}
-        className="flex justify-between items-center mb-2 text-sm font-bold text-grayscale-900"
+        className="flex justify-between items-center mb-2 text-sm font-semibold text-gray-800"
       >
         <span>{label}</span>
       </label>
       <Toggle
         id={`${id}-toggle`}
-        label="Use default value"
+        label="Use default"
         checked={value === undefined}
         onChange={handleToggle}
         size="xs"
-        className="mb-2"
       />
-      {value !== undefined && (
-        <div className="flex items-center gap-4">
+      <div
+        className={clsx(
+          "flex items-center gap-4 mt-2",
+          isUsingDefault && "opacity-30",
+        )}
+      >
+        <input
+          id={id}
+          type="range"
+          value={isUsingDefault ? "" : value}
+          onChange={handleSliderChange}
+          className={clsx(
+            "w-full h-2 bg-grayscale-300 rounded-lg appearance-none accent-blue-500 m-0",
+            !isUsingDefault && "cursor-pointer",
+          )}
+          min={min}
+          max={max}
+          step={step}
+          disabled={isUsingDefault}
+        />
+        <div className="flex items-center">
           <input
-            id={id}
-            type="range"
-            value={value}
-            onChange={handleSliderChange}
-            className="w-full h-2 bg-grayscale-300 rounded-lg appearance-none cursor-pointer accent-blue-800 m-0"
+            id={`${id}-number-input`}
+            type="number"
+            value={isUsingDefault ? "" : value}
+            onChange={handleNumberChange}
+            className="px-2 py-1 text-sm border border-grayscale-300 rounded-lg"
             min={min}
             max={max}
             step={step}
+            disabled={isUsingDefault}
           />
-          <div className="flex items-center">
-            <input
-              type="number"
-              value={value}
-              onChange={handleNumberChange}
-              className="px-2 py-1 text-sm border border-grayscale-300 rounded-lg"
-              min={min}
-              max={max}
-              step={step}
-            />
-            {unit && <span className="text-sm ml-1">{unit}</span>}
-          </div>
+          {unit && <span className="text-sm ml-1">{unit}</span>}
         </div>
-      )}
+      </div>
     </fieldset>
   );
 };

--- a/website/src/pages/themes/_components/theme-preview/options.tsx
+++ b/website/src/pages/themes/_components/theme-preview/options.tsx
@@ -17,7 +17,9 @@ export const Options = forwardRef<HTMLDivElement, Props>(({ isOpen }, ref) => {
           className="absolute w-[400px] right-0 mt-1 border border-grayscale-300 bg-white rounded-md z-50 p-4 shadow-md"
           ref={ref}
         >
-          <h1 className="text-base font-bold mb-4">Preview Settings</h1>
+          <h1 className="text-base font-bold mb-4 text-gray-800">
+            Preview Settings
+          </h1>
           <PreviewColorScaleSelect size="sm" />
           <Toggle
             id="show-tooltips"
@@ -25,7 +27,7 @@ export const Options = forwardRef<HTMLDivElement, Props>(({ isOpen }, ref) => {
             checked={showTooltips}
             onChange={setShowTooltips}
             className="mt-4"
-            size="sm"
+            size="xs"
           />
         </div>
       )}

--- a/website/src/pages/themes/_components/toggle.tsx
+++ b/website/src/pages/themes/_components/toggle.tsx
@@ -22,11 +22,8 @@ const Toggle = ({
     onChange(!checked);
   };
 
-  const labelSizeClasses = size === "md" ? "font-bold" : "font-medium";
-
   return (
-    <div className={clsx("flex justify-between items-center", className)}>
-      <label className={clsx("text-sm", labelSizeClasses)}>{label}</label>
+    <div className={clsx("flex justify-start items-center gap-2", className)}>
       <button
         type="button"
         id={id}
@@ -34,7 +31,7 @@ const Toggle = ({
         aria-checked={checked}
         onClick={handleToggle}
         className={clsx(
-          "group flex p-0.5 rounded-full bg-grayscale-300 transition-colors duration-200 ease-in-out overflow-hidden aria-checked:bg-blue-800 cursor-pointer",
+          "group flex p-0.5 rounded-full bg-gray-300 transition-colors duration-200 ease-in-out overflow-hidden aria-checked:bg-blue-500 cursor-pointer",
           size === "xs" && "w-7 h-4",
           size === "sm" && "w-9 h-5",
           size === "md" && "w-11 h-6",
@@ -49,6 +46,9 @@ const Toggle = ({
           )}
         ></span>
       </button>
+      <label htmlFor={id} className="text-sm font-medium">
+        {label}
+      </label>
     </div>
   );
 };

--- a/website/src/pages/themes/index.tsx
+++ b/website/src/pages/themes/index.tsx
@@ -17,7 +17,7 @@ const ThemeBuilder = () => {
         <PreviewOptionsProvider>
           <AlertProvider>
             <SideNavProvider>
-              <div className="relative flex flex-row items-start justify-start w-full theme-builder">
+              <div className="relative flex flex-row items-start justify-start w-full theme-builder font-sans text-gray-700">
                 <SideNav />
                 <Main />
               </div>

--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -16,13 +16,6 @@ const NearFormColors = {
   DeepNavy: "hsla(225, 100%, 11%, 1)",
 };
 
-const blue = {
-  100: "#E8F0FF",
-  300: "#B9D3FF",
-  500: "#8AB6FF",
-  800: "#4589FF",
-};
-
 const orange = {
   100: "#ff684f",
   200: "#ff4b2e",
@@ -52,7 +45,6 @@ module.exports = {
           800: "#888888",
         },
         orange,
-        blue,
         "theme-1": NearFormColors.Green,
         "theme-2": NearFormColors.DeepNavy,
         "theme-3": NearFormColors.DeepNavy,


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

This PR updates styles for components used in the options panel to match the new design files. ([Notion](https://www.notion.so/nearform/Toggle-label-styling-revision-1759aa50dea280809e79c2ec4ff0196f?pvs=4),  [Figma](https://www.figma.com/design/TmM8v8Xvr77HYVqYzyE3Mb/Victory-Theme-Builder?node-id=354-923&t=SYzG2CmgwpLe4fTj-0))

![Screenshot 2025-01-15 at 4 32 27 PM](https://github.com/user-attachments/assets/cec44279-0cba-444d-adf2-e2935c1ab973)


