### PR TITLE
fix: handle empty labelStyle values

### DIFF
--- a/.changeset/silver-crabs-deliver.md
+++ b/.changeset/silver-crabs-deliver.md
@@ -1,0 +1,5 @@
+---
+"victory-candlestick": minor
+---
+
+Handle undefined labelStyle properties in VictoryCandlestick. Fixes #3039

--- a/packages/victory-candlestick/src/helper-methods.ts
+++ b/packages/victory-candlestick/src/helper-methods.ts
@@ -268,13 +268,13 @@ const calculatePlotValues = (props) => {
 
     const dy =
       orientation === "top" || orientation === "bottom"
-        ? signY * (candleWidth / 2) + signY * (labelStyle.padding || 0)
+        ? signY * (candleWidth / 2) + signY * (labelStyle?.padding || 0)
         : 0;
 
     const dx =
       orientation === "top" || orientation === "bottom"
         ? 0
-        : signX * (labelStyle.padding || 1);
+        : signX * (labelStyle?.padding || 1);
 
     return { yValue, xValue, dx, dy };
   }
@@ -283,13 +283,13 @@ const calculatePlotValues = (props) => {
 
   const dy =
     orientation === "top" || orientation === "bottom"
-      ? signY * (labelStyle.padding || 1)
+      ? signY * (labelStyle?.padding || 1)
       : 0;
 
   const dx =
     orientation === "top" || orientation === "bottom"
       ? 0
-      : signX * (candleWidth / 2) + signX * (labelStyle.padding || 0);
+      : signX * (candleWidth / 2) + signX * (labelStyle?.padding || 0);
 
   return { yValue, xValue, dx, dy };
 };
@@ -358,10 +358,10 @@ const getLabelProps = (props, text, style, type?: string) => {
     datum,
     data,
     orientation,
-    textAnchor: labelStyle.textAnchor || defaultTextAnchors[orientation],
+    textAnchor: labelStyle?.textAnchor || defaultTextAnchors[orientation],
     verticalAnchor:
-      labelStyle.verticalAnchor || defaultVerticalAnchors[orientation],
-    angle: labelStyle.angle,
+      labelStyle?.verticalAnchor || defaultVerticalAnchors[orientation],
+    angle: labelStyle?.angle,
     horizontal,
   };
 


### PR DESCRIPTION
### Description

fix: Handle undefined labelStyle properties in VictoryCandlestick

- Add null coalescing for `labelStyle?.` in calculatePlotValues
- Prevents TypeError when accessing labelStyle properties

Fixes #3039 

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I added the code that produces the bug to Storybook and tested it in Storybook. Without this change the code produces the bug as described, with this change the bug is no longer present.

### Checklist:

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have run all builds, tests, and linting and all checks pass
