### PR TITLE
docs(theme-builder): update docs and launch-blocking bug fixes

### DIFF
--- a/website/docs/api/victory-area.mdx
+++ b/website/docs/api/victory-area.mdx
@@ -129,7 +129,7 @@ See the [Events Guide](/docs/guides/events) for more information on defining eve
 `VictoryArea` uses the standard `groupComponent` prop. [Read about it in detail](/docs/api/victory-common-theme-props#groupcomponent)
 
 :::note
-`VictoryArea` uses [`VictoryClipContainer`](/docs/api/victory-clip-container) as its default `groupComponent` `VictoryClipContainer` renders a `<g>` tag with a `clipPath` `def`. This allows continuous data components to transition smoothly when new data points enter and exit. 
+`VictoryArea` uses [`VictoryClipContainer`](/docs/api/victory-clip-container) as its default `groupComponent` `VictoryClipContainer` renders a `<g>` tag with a `clipPath` `def`. This allows continuous data components to transition smoothly when new data points enter and exit.
 :::
 
 :::warning
@@ -241,7 +241,7 @@ To enable tooltips on `VictoryArea`, it is necessary to use [`VictoryVoronoiCont
 Defines the style of the component using [VictoryStyleInterface](/docs/api/victory-style-interface).
 
 :::note
-Since `VictoryArea` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of an individual `datum`. Instead, try using [gradient fills](/docs/guides/themes#gradient-fills) for styling continuous data.
+Since `VictoryArea` renders a single element to represent an entire dataset, it is not possible to use functional styles to change the style of the line as a function of an individual `datum`. Instead, try using [gradient fills](/docs/guides/themes#using-gradient-fills) for styling continuous data.
 :::
 
 ```jsx live

--- a/website/docs/api/victory-theme.mdx
+++ b/website/docs/api/victory-theme.mdx
@@ -43,6 +43,23 @@ interface VictoryThemeDefinition {
 }
 ```
 
+### `palette`
+
+The `palette` property defines a collection of colors that can be used across all chart elements. Each palette contains predefined color arrays that you can use directly or customize as needed.
+
+#### Properties
+
+| Property      | Type       | Description                                                                                   |
+| ------------- | ---------- | --------------------------------------------------------------------------------------------- |
+| `grayscale`   | `string[]` | Shades of gray, ideal for minimalist or monochrome chart designs                              |
+| `qualitative` | `string[]` | Used for categorical data, containing distinct colors that are easy to differentiate visually |
+| `heatmap`     | `string[]` | A gradient-based color scheme often used for heatmaps or data density visualizations          |
+| `warm`        | `string[]` | Warm colors like reds, oranges, and yellows                                                   |
+| `cool`        | `string[]` | Cool colors such as blues, purples, and greens                                                |
+| `red`         | `string[]` | Various shades of red                                                                         |
+| `blue`        | `string[]` | Various shades of blue                                                                        |
+| `green`       | `string[]` | Various shades of green                                                                       |
+
 ## Example
 
 ```jsx live

--- a/website/docs/guides/themes.mdx
+++ b/website/docs/guides/themes.mdx
@@ -14,7 +14,7 @@ Victory themes are essentially JavaScript objects that define styling properties
 
 Theme configuration variables include:
 
-- [`.palette`](/docs/victory-theme#palette)
+- [`.palette`](/docs/api/victory-theme#palette)
   - Defines color schemes used across the theme.
 - [`.chart`](/docs/api/victory-chart)
   - Global styles like background and padding.
@@ -36,7 +36,7 @@ Theme configuration variables include:
 - [`.tooltip`](/docs/api/victory-tooltip)
 - [`.voronoi`](/docs/api/victory-voronoi)
 
-Each configuration variable takes props specific to its chart element, allowing customization of styles like colors, padding, labels, and more. For detailed information about each variable, refer to the [VictoryTheme API page](/docs/victory-theme).
+Each configuration variable takes props specific to its chart element, allowing customization of styles like colors, padding, labels, and more. For detailed information about each variable, refer to the [VictoryTheme API page](/docs/api/victory-theme).
 
 When a theme is passed to a chart via the `theme` prop, the styles from the theme object are applied to the corresponding child components unless they are explicitly overridden by inline props.
 

--- a/website/docs/guides/themes.mdx
+++ b/website/docs/guides/themes.mdx
@@ -4,7 +4,61 @@ title: Themes & Styling
 
 ## Themes
 
-Try out the Victory themes and make your own. Check out the [VictoryTheme API documentation](/docs/api/victory-theme) more details on themes.
+Victory themes are reusable style configurations that enable you to standardize the appearance of charts across your application. Themes simplify chart development by reducing repetitive styling logic and ensuring visual consistency.
+
+Themes are applied at the chart level and automatically cascade to all child components, such as axes, bars, lines, and legends. Victory provides built-in themes like `clean`, `material` and `grayscale`, but you can also create custom themes to match your branding.
+
+### How Themes Work in Victory
+
+Victory themes are essentially JavaScript objects that define styling properties for various chart elements. These theme configurations enable consistent and reusable styling across charts. Each theme configuration variable corresponds to a specific chart element and takes props that define its styles.
+
+Theme configuration variables include:
+
+- [`.palette`](/docs/victory-theme#palette)
+  - Defines color schemes used across the theme.
+- [`.chart`](/docs/api/victory-chart)
+  - Global styles like background and padding.
+- [`.area`](/docs/api/victory-area)
+- [`.axis`](/docs/api/victory-axis)
+- [`.polarAxis`](/docs/api/victory-polar-axis)
+- [`.polarDependentAxis`](/docs/api/victory-polar-axis)
+- [`.bar`](/docs/api/victory-bar)
+- [`.boxplot`](/docs/api/victory-boxplot)
+- [`.candlestick`](/docs/api/victory-candlestick)
+- [`.errorbar`](/docs/api/victory-error-bar)
+- [`.group`](/docs/api/victory-group)
+- [`.histogram`](/docs/api/victory-histogram)
+- [`.legend`](/docs/api/victory-legend)
+- [`.line`](/docs/api/victory-line)
+- [`.pie`](/docs/api/victory-pie)
+- [`.scatter`](/docs/api/victory-scatter)
+- [`.stack`](/docs/api/victory-stack)
+- [`.tooltip`](/docs/api/victory-tooltip)
+- [`.voronoi`](/docs/api/victory-voronoi)
+
+Each configuration variable takes props specific to its chart element, allowing customization of styles like colors, padding, labels, and more. For detailed information about each variable, refer to the [VictoryTheme API page](/docs/victory-theme).
+
+When a theme is passed to a chart via the `theme` prop, the styles from the theme object are applied to the corresponding child components unless they are explicitly overridden by inline props.
+
+```jsx live
+<VictoryChart
+  theme={VictoryTheme.material}
+>
+  <VictoryBar />
+</VictoryChart>
+```
+
+### Predefined Themes
+
+Victory includes several built-in themes to help you quickly style your charts:
+
+| Theme                    | Description                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `VictoryTheme.clean`     | A minimalist theme with no gridlines or extra styling, perfect for clean and modern visualizations. |
+| `VictoryTheme.material`  | Inspired by Google's Material Design, this theme includes bold colors and a structured grid.        |
+| `VictoryTheme.grayscale` | A neutral theme featuring grayscale tones, ideal for muted and professional-looking charts.         |
+
+Each of these themes can be applied to your Victory components by passing it into the `theme` prop.
 
 ```jsx live noInline
 const result = [...Array(10).keys()];
@@ -39,34 +93,34 @@ const DemoComponent = () => {
   ];
   return (
     <div>
-      <div className="mb-8 p-4 mx-auto">
+      <div className="mb-8 p-4 mx-auto flex justify-between w-full">
         <button
-          className="bg-gray-600 border border-gray-800 text-white uppercase py-6 px-12"
+          className="bg-blue-600 border-none rounded-md text-white uppercase py-3 px-6 hover:bg-blue-700 cursor-pointer"
           onClick={() =>
-            setTheme(
-              VictoryTheme.grayscale,
-            )
+            setTheme(VictoryTheme.clean)
           }
         >
-          use grayscale
+          clean
         </button>
         <button
-          className="bg-orange-600 border border-blue-800 text-white uppercase py-6 px-12 ml-2"
+          className="bg-orange-600 border-none rounded-md text-white uppercase py-3 px-6 hover:bg-orange-700 cursor-pointer"
           onClick={() =>
             setTheme(
               VictoryTheme.material,
             )
           }
         >
-          use material
+          material
         </button>
         <button
-          className="bg-blue-600 border border-blue-800 text-white uppercase py-6 px-12 ml-2"
+          className="bg-gray-600 border-none rounded-md text-white uppercase py-3 px-6 hover:bg-gray-700 cursor-pointer"
           onClick={() =>
-            setTheme(VictoryTheme.clean)
+            setTheme(
+              VictoryTheme.grayscale,
+            )
           }
         >
-          use clean
+          grayscale
         </button>
       </div>
       <svg
@@ -231,11 +285,83 @@ const DemoComponent = () => {
 render(<DemoComponent />);
 ```
 
-## Styles
+You can also customize these themes or use them as a base to create your own. To build upon a predefined theme, you can extend it using the spread operator:
 
-### How can I change the colors of lines and other elements in Victory?
+```jsx
+const extendedTheme = {
+  ...VictoryTheme.material,
+  axis: {
+    ...VictoryTheme.material.axis,
+    style: {
+      ...VictoryTheme.material.axis
+        .style,
+      tickLabels: {
+        fill: "#444",
+        fontSize: 10,
+        fontStyle: "italic",
+      },
+    },
+  },
+};
+```
 
-Most components in Victory use a standard `style` prop with style namespaces for "data" and "labels". Any styles added to the "data" namespace will be applied to all the svg elements rendered for a given dataset.
+### Creating a Custom Theme
+
+To create a completely custom theme, define a JavaScript object that includes styles for the components you want to theme. You can omit components that use default styling.
+
+```jsx live noInline
+const customTheme = {
+  axis: {
+    style: {
+      grid: { stroke: "none" },
+      axis: {
+        stroke: "#333",
+        strokeWidth: 2,
+      },
+      ticks: {
+        stroke: "#555",
+        size: 5,
+      },
+      tickLabels: {
+        fill: "#222",
+        fontSize: 12,
+        padding: 5,
+      },
+    },
+  },
+  bar: {
+    style: {
+      data: {
+        fill: "#0074d9",
+        width: 15,
+      },
+    },
+  },
+};
+
+render(
+  <VictoryChart
+    theme={customTheme}
+    domainPadding={{ x: 40 }}
+  >
+    <VictoryBar
+      data={[
+        { x: 1, y: 2 },
+        { x: 2, y: 4 },
+        { x: 3, y: 6 },
+      ]}
+    />
+  </VictoryChart>,
+);
+```
+
+To enhance the "Styles" section of the Victory Themes guide, consider incorporating the following detailed explanations and examples:
+
+## Styling Individual Components
+
+To customize the appearance of Victory components, you can use the `style` prop, which accepts an object containing styles for various component elements like `data`, `labels`, and `parent`. For a detailed breakdown of the style options available, refer to the [Victory Style Interface](/docs/api/victory-style-interface).
+
+**Example: Customizing Bar and Line Colors**
 
 ```jsx live
 <VictoryChart
@@ -262,9 +388,11 @@ Most components in Victory use a standard `style` prop with style namespaces for
 </VictoryChart>
 ```
 
-### How can I change the color of an individual point or bar?
+### Styling Data
 
-Individual elements in Victory can be styled by adding style attributes directly to your data object and using functional styles and props as in the example below. Functions are called with all the props that correspond to the element they render.
+To style individual elements within a dataset, you can include style attributes directly in your data objects and utilize functional styles.
+
+**Note:** Continuous data components like `VictoryLine` and `VictoryArea` render a single SVG element for the entire dataset, so individual styling of data points within these components is not applicable.
 
 ```jsx live
 <VictoryChart>
@@ -284,7 +412,7 @@ Individual elements in Victory can be styled by adding style attributes directly
     style={{
       data: {
         fill: ({ index }) =>
-          +index % 2 === 0
+          index % 2 === 0
             ? "blue"
             : "grey",
         stroke: ({ datum }) =>
@@ -307,11 +435,9 @@ Individual elements in Victory can be styled by adding style attributes directly
 </VictoryChart>
 ```
 
-Note that continuous data types such as `VictoryLine` and `VictoryArea` cannot be styled in this way, as they only render a single element for a given dataset.
+### Using Gradient Fills
 
-### Gradient Fills
-
-Create a gradient def as usual and then reference it by id in your style object. Gradients can be used to give continuous charts (_i.e._ line or area charts) the appearance of discrete data elements and hover states. 
+To apply gradient fills to your charts, define a gradient in the SVG `defs` section and reference it by id in your component's style. Gradients can be used to give continuous charts (i.e. line or area charts) the appearance of discrete data elements and hover states.
 
 ```jsx live
 <div>

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -175,6 +175,10 @@ const config: Config = {
       darkTheme: prismThemes.dracula,
       additionalLanguages: ["diff", "diff-ts"],
     },
+    colorMode: {
+      defaultMode: "light",
+      disableSwitch: true,
+    },
   },
   headTags: [
     {

--- a/website/src/pages/themes/_components/color-scale-override-selector.tsx
+++ b/website/src/pages/themes/_components/color-scale-override-selector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import clsx from "clsx";
 import Toggle from "./toggle";
 import {
@@ -28,6 +28,9 @@ const ColorScaleOverrideSelector = ({
   const [showCustomColors, setShowCustomColors] = React.useState(
     () => !!colors && Array.isArray(colors),
   );
+  const [prevColors, setPrevColors] = React.useState<string[]>(
+    Array.isArray(colors) ? colors : [],
+  );
 
   const setColorScaleToDefault = useCallback(() => {
     if (colorScale !== defaultColorScale) {
@@ -37,14 +40,13 @@ const ColorScaleOverrideSelector = ({
 
   const onCheckboxChange = (isChecked) => {
     setShowCustomColors(isChecked);
-    if (!isChecked) {
-      onColorsChange(undefined);
-    }
+    onColorsChange(!isChecked ? undefined : prevColors);
     setColorScaleToDefault();
   };
 
   const handleColorsChange = (newColors) => {
     onColorsChange(newColors);
+    setPrevColors(newColors);
     setColorScaleToDefault();
   };
 

--- a/website/src/pages/themes/_components/control.tsx
+++ b/website/src/pages/themes/_components/control.tsx
@@ -22,25 +22,13 @@ type ControlProps = {
 };
 
 const Control = ({ type, control, className }: ControlProps) => {
-  const { baseTheme, customThemeConfig, updateCustomThemeConfig } = useTheme();
+  const { customThemeConfig, updateCustomThemeConfig } = useTheme();
 
   const handleChange = (newValue) => {
     updateCustomThemeConfig(control.path, newValue);
   };
 
-  const handleSliderToggle = (isChecked: boolean) => {
-    const defaultValue =
-      getConfigValue(baseTheme?.config, control.path, control.min) || 0;
-    const newValue = isChecked ? undefined : defaultValue;
-    handleChange(newValue);
-  };
-
-  const configValue = getConfigValue(
-    customThemeConfig,
-    control.path,
-    control.default,
-  );
-
+  const configValue = getConfigValue(customThemeConfig, control.path);
   const id = useId();
 
   switch (type) {
@@ -103,13 +91,13 @@ const Control = ({ type, control, className }: ControlProps) => {
           key={control.label}
           label={control.label}
           value={configValue as number}
+          defaultValue={control.default}
           unit={control.unit}
           onChange={handleChange}
           min={control.min}
           max={control.max}
           step={control.step}
           className={className}
-          onDefaultToggle={handleSliderToggle}
         />
       );
     case "select":

--- a/website/src/pages/themes/_components/slider.tsx
+++ b/website/src/pages/themes/_components/slider.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import clsx from "clsx";
 import Toggle from "./toggle";
 
@@ -6,34 +6,39 @@ type SliderProps = {
   label: string;
   id: string;
   value?: number;
+  defaultValue?: number;
   unit?: string;
   onChange?: (value?: number) => void;
-  onDefaultToggle?: (isChecked: boolean) => void;
   min?: number;
   max?: number;
   step?: number;
   className?: string;
 };
 
-const DEFAULT_MIN = 0;
+const DEFAULT_MIN = 1;
 const DEFAULT_MAX = 100;
 
 const Slider = ({
   label,
   id,
   value,
+  defaultValue,
   unit,
   onChange,
-  onDefaultToggle,
   min = DEFAULT_MIN,
   max = DEFAULT_MAX,
   step = 1,
   className,
 }: SliderProps) => {
+  const [prevValue, setPrevValue] = useState(() => {
+    return value ?? defaultValue ?? min;
+  });
+
   const handleSliderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.valueAsNumber;
     if (onChange) {
       onChange(newValue);
+      setPrevValue(newValue);
     }
   };
 
@@ -45,8 +50,9 @@ const Slider = ({
   };
 
   const handleToggle = (isChecked: boolean) => {
-    if (!onDefaultToggle) return;
-    onDefaultToggle(isChecked);
+    if (!onChange) return;
+    const newValue = isChecked ? undefined : prevValue;
+    onChange(newValue);
   };
 
   const isUsingDefault = value === undefined;

--- a/website/src/pages/themes/_config/global.tsx
+++ b/website/src/pages/themes/_config/global.tsx
@@ -12,7 +12,7 @@ const globalOptionsConfig: OptionsPanelConfig = {
         {
           type: "slider",
           label: "Width",
-          min: 0,
+          min: 150,
           max: 500,
           unit: "px",
           path: [
@@ -35,7 +35,7 @@ const globalOptionsConfig: OptionsPanelConfig = {
         {
           type: "slider",
           label: "Height",
-          min: 0,
+          min: 150,
           max: 500,
           unit: "px",
           path: [

--- a/website/src/pages/themes/_config/index.tsx
+++ b/website/src/pages/themes/_config/index.tsx
@@ -23,13 +23,22 @@ export type ControlConfig = {
       showDefaultToggle?: boolean;
     }
   | {
-      type: "slider" | "select" | "colorPicker";
+      type: "slider";
       path: string | string[];
       min?: number;
       max?: number;
       step?: number;
       unit?: string;
+      default?: number;
+    }
+  | {
+      type: "select" | "colorPicker";
+      path: string | string[];
       options?: { label: string; value: string }[];
+    }
+  | {
+      type: "colorPicker";
+      path: string | string[];
     }
 );
 

--- a/website/src/pages/themes/_utils.ts
+++ b/website/src/pages/themes/_utils.ts
@@ -28,13 +28,12 @@ export const setNestedConfigValue = (
 export const getConfigValue = (
   config: VictoryThemeDefinition,
   path: string | string[],
-  defaultValue?: unknown,
 ) => {
   const pathString = Array.isArray(path) ? path[0] : path;
   if (!pathString) return undefined;
   const pathArray = pathString.split(".");
   return pathArray.reduce((acc, key) => {
-    return acc && acc[key] !== undefined ? acc[key] : defaultValue;
+    return acc?.[key];
   }, config);
 };
 
@@ -73,13 +72,18 @@ export const getBaseStrokeConfig = (
       max: 5,
       unit: "px",
       path: getPath(basePath, "strokeWidth"),
+      default: 1,
     },
     {
-      type: "slider",
+      type: "select",
       label: StrokeProps.STROKE_DASH_ARRAY,
-      min: 0,
-      max: 10,
       path: getPath(basePath, "strokeDasharray"),
+      options: [
+        { label: "Solid", value: "0" },
+        { label: "Dashed", value: "4, 4" },
+        { label: "Dotted", value: "1, 1" },
+        { label: "Long Dash", value: "10, 5" },
+      ],
     },
     {
       type: "select",


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description
This PR updates docs and fixes the last of the soft launch blocking bugs.

Tasks:
- [Update theme and styling docs](https://www.notion.so/nearform/Update-theme-and-styling-docs-1899aa50dea28001bc84f9ef3cdbacc3?pvs=4)
- [Disable dark mode](https://www.notion.so/nearform/Disable-dark-mode-1889aa50dea28066bffdf0f86b57de3c?pvs=4)
- [Update global options min + max values to prevent crashes](https://www.notion.so/nearform/Update-global-options-min-max-values-to-prevent-crashes-1889aa50dea28059b915cd0ef7a4575b?pvs=4)
- [Prevent colors from disappearing from default color scales when enabling/disabling custom colors](https://www.notion.so/nearform/Prevent-colors-from-disappearing-from-default-color-scales-when-enabling-disabling-custom-colors-1889aa50dea2807a8c14f065b9c893fb?pvs=4)
- [Add ability to go back to previous color scale after toggling custom](https://www.notion.so/nearform/Add-ability-to-go-back-to-previous-color-scale-after-toggling-custom-1889aa50dea2806e96d4dc54fa4d27c4?pvs=4)
