### PR TITLE
Fix Urql url

### DIFF
--- a/website/src/pages/_components/landing-featured-projects.tsx
+++ b/website/src/pages/_components/landing-featured-projects.tsx
@@ -48,7 +48,7 @@ const projects: Projects[] = [
   {
     name: "urql",
     Component: UrqlBadge,
-    link: "https://commerce.nearform.com/open-source/victory/",
+    link: "https://commerce.nearform.com/open-source/urql/",
     description:
       "The highly customizable and versatile GraphQL client with which you add on features like normalized caching as you grow.",
   },


### PR DESCRIPTION
### Description

Just passing through. Noticed that the anchor tag for Urql in the "More Open Source from Nearform Commerce" section linked to `https://commerce.nearform.com/open-source/victory/` rather than `https://commerce.nearform.com/open-source/urql/`. 

#### Type of Change

Hyperlink fix

### How Has This Been Tested?

I have not built and tested this change against the result, but I can confirm the URL I changed the link to point to is a real URL (and I believe the intended one).
