### PR TITLE
fix(native): fix container prop forwarding

### DIFF
--- a/.changeset/cute-foxes-shop.md
+++ b/.changeset/cute-foxes-shop.md
@@ -2,4 +2,4 @@
 "victory-native": patch
 ---
 
-fix native voronoi container prop forwarding
+fix native container prop forwarding

--- a/.changeset/cute-foxes-shop.md
+++ b/.changeset/cute-foxes-shop.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+fix native voronoi container prop forwarding

--- a/packages/victory-native/src/components/victory-brush-container.tsx
+++ b/packages/victory-native/src/components/victory-brush-container.tsx
@@ -29,12 +29,12 @@ const RectWithStyle = ({
 export const VictoryBrushContainer = (
   initialProps: VictoryBrushContainerNativeProps,
 ) => {
-  const props = useVictoryBrushContainer({
+  const { props, children } = useVictoryBrushContainer({
     ...initialProps,
     brushComponent: initialProps.brushComponent ?? <RectWithStyle />,
     handleComponent: initialProps.handleComponent ?? <RectWithStyle />,
   });
-  return <VictoryContainer {...props} />;
+  return <VictoryContainer {...props}>{children}</VictoryContainer>;
 };
 
 VictoryBrushContainer.role = "container";

--- a/packages/victory-native/src/components/victory-cursor-container.tsx
+++ b/packages/victory-native/src/components/victory-cursor-container.tsx
@@ -20,12 +20,12 @@ export interface VictoryCursorContainerNativeProps
 export const VictoryCursorContainer = (
   initialProps: VictoryCursorContainerNativeProps,
 ) => {
-  const props = useVictoryCursorContainer({
+  const { props, children } = useVictoryCursorContainer({
     ...initialProps,
     cursorLabelComponent: initialProps.cursorLabelComponent ?? <VictoryLabel />,
     cursorComponent: initialProps.cursorComponent ?? <LineSegment />,
   });
-  return <VictoryContainer {...props} />;
+  return <VictoryContainer {...props}>{children}</VictoryContainer>;
 };
 
 VictoryCursorContainer.role = "container";

--- a/packages/victory-native/src/components/victory-selection-container.tsx
+++ b/packages/victory-native/src/components/victory-selection-container.tsx
@@ -29,7 +29,7 @@ const DefaultSelectionComponent = ({
 export const VictorySelectionContainer = (
   initialProps: VictorySelectionContainerNativeProps,
 ) => {
-  const props = useVictorySelectionContainer({
+  const { props, children } = useVictorySelectionContainer({
     ...initialProps,
     // @ts-expect-error TODO: standalone is not a valid prop for VictoryContainer, figure out why this is here
     standalone: initialProps.standalone ?? true,
@@ -37,7 +37,7 @@ export const VictorySelectionContainer = (
       <DefaultSelectionComponent />
     ),
   });
-  return <VictoryContainer {...props} />;
+  return <VictoryContainer {...props}>{children}</VictoryContainer>;
 };
 
 VictorySelectionContainer.role = "container";

--- a/packages/victory-native/src/components/victory-voronoi-container.tsx
+++ b/packages/victory-native/src/components/victory-voronoi-container.tsx
@@ -21,14 +21,14 @@ const DEFAULT_VORONOI_PADDING = 5;
 export const VictoryVoronoiContainer = (
   initialProps: VictoryVoronoiContainerNativeProps,
 ) => {
-  const props = useVictoryVoronoiContainer({
+  const {children, props} = useVictoryVoronoiContainer({
     ...initialProps,
     activateData: initialProps.activateData ?? true,
     activateLabels: initialProps.activateLabels ?? true,
     labelComponent: initialProps.labelComponent ?? <VictoryTooltip />,
     voronoiPadding: initialProps.voronoiPadding ?? DEFAULT_VORONOI_PADDING,
   });
-  return <VictoryContainer {...props} />;
+  return <VictoryContainer {...props}>{children}</VictoryContainer>;
 };
 
 VictoryVoronoiContainer.role = "container";

--- a/packages/victory-native/src/components/victory-voronoi-container.tsx
+++ b/packages/victory-native/src/components/victory-voronoi-container.tsx
@@ -21,7 +21,7 @@ const DEFAULT_VORONOI_PADDING = 5;
 export const VictoryVoronoiContainer = (
   initialProps: VictoryVoronoiContainerNativeProps,
 ) => {
-  const {children, props} = useVictoryVoronoiContainer({
+  const { props, children } = useVictoryVoronoiContainer({
     ...initialProps,
     activateData: initialProps.activateData ?? true,
     activateLabels: initialProps.activateLabels ?? true,


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

Victory Native's containers are not forwarding props from their respective hooks to the `VictoryContainer` component.

This causes the svg to get clipped because the `viewBox` is being set to `0 0 undefined undefined`.

[The native implementation spreads the object returned from the hook as-is](https://github.com/FormidableLabs/victory/blob/v37.3.6/packages/victory-native/src/components/victory-voronoi-container.tsx#L31), but [the hook returns `props` and `children` as separate properties on the object](https://github.com/FormidableLabs/victory/blob/v37.3.6/packages/victory-voronoi-container/src/victory-voronoi-container.tsx#L197), so they should be de-structured first [like they are for the web implementation](https://github.com/FormidableLabs/victory/blob/v37.3.6/packages/victory-voronoi-container/src/victory-voronoi-container.tsx#L210).

Fixes https://github.com/FormidableLabs/victory/issues/2895
Fixes https://github.com/FormidableLabs/victory/issues/3063

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

I investigated the issue using the lead from [this comment](https://github.com/FormidableLabs/victory/issues/2895#issuecomment-3164715142) and [this Expo Snack](https://snack.expo.dev/@adamhari-kashoo/victory-native-viewbox-issue).

I did not test the native implementation using a fixture in this repo.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
